### PR TITLE
fix: change core to llc dependency in UI

### DIFF
--- a/packages/stream_video_flutter/pubspec.yaml
+++ b/packages/stream_video_flutter/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   google_fonts: ^3.0.1
   flutter:
     sdk: flutter
-  stream_video_flutter_core:
-    path: ../stream_video_flutter_core
- 
+  stream_video:
+    path: ../stream_video
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Switch the removed `stream_video_core` dependency to `stream_video` in `stream_video_flutter.pubspec`