### PR TITLE
[62] Google SignIn does not work on Web

### DIFF
--- a/dogfooding/web/index.html
+++ b/dogfooding/web/index.html
@@ -26,6 +26,10 @@
   <meta name="apple-mobile-web-app-title" content="dogfooding">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
+  <!-- Google Sign In -->
+  <script src="https://apis.google.com/js/platform.js" async defer></script>
+  <meta name="google-signin-client_id" content="248009810755-8k5328q32caj1l3ihjc5l5v4l5dfdinj.apps.googleusercontent.com">
+
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 


### PR DESCRIPTION
### 🎯 Goal

Closes #62 

### 🧪 Testing

- install [flutter_cors](https://pub.dev/packages/flutter_cors) to be able to omit CORS errors
- run `fluttercors --disable -p <path_to_flutter_sdk>` to disable CORS checks
- run `flutter run -d chrome --web-port=5000` to launch `dogfooding` on specified port
- click on `Login with Google`
- provide your credentials if required
- wait when you get navigated to Home Screen (may take a few seconds)

There are just 3 localhost ports from which `Google Sign In` is currently allowed (we can change this if required):
- 80
- 5000
- 8080
<img width="482" alt="Screenshot 2022-12-15 at 1 54 40 PM" src="https://user-images.githubusercontent.com/1286516/207975363-cd0ace62-948b-46c6-aa6c-aa70bebea446.png">



### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
