### PR TITLE
fix: fix hot reload

### DIFF
--- a/packages/stream_video_flutter/lib/theme/stream_color_theme.dart
+++ b/packages/stream_video_flutter/lib/theme/stream_color_theme.dart
@@ -327,7 +327,7 @@ class Effect {
       sigmaX: sigmaX ?? this.sigmaX,
       sigmaY: sigmaY ?? this.sigmaY,
       color: color ?? this.color,
-      opacity: this.opacity ?? color?.opacity,
+      opacity: opacity ?? this.opacity,
       blur: blur ?? this.blur,
     );
   }
@@ -337,8 +337,7 @@ class Effect {
       sigmaX: lerpDouble(sigmaX, other.sigmaX, t),
       sigmaY: lerpDouble(sigmaY, other.sigmaY, t),
       color: Color.lerp(color, other.color, t),
-      opacity: lerpDouble(
-          opacity ?? color?.opacity, other.opacity ?? other.color?.opacity, t),
+      opacity: lerpDouble(opacity, other.opacity, t),
       blur: lerpDouble(blur, other.blur, t),
     );
   }


### PR DESCRIPTION
### 🎯 Goal

Closes https://github.com/GetStream/stream-video-flutter/issues/82

Fix the issue with hot reload:

```
type 'Color' is not a subtype of type 'double?' in type cast

When the exception was thrown, this was the stack: 
#0      Effect.lerp (package:stream_video_flutter/theme/stream_color_theme.dart:341:17)
#1      StreamColorTheme.lerp (package:stream_video_flutter/theme/stream_color_theme.dart:284:28)
#2      StreamVideoTheme.lerp (package:stream_video_flutter/theme/stream_video_theme.dart:141:30)
#3      ThemeData._lerpThemeExtensions.<anonymous closure> (package:flutter/src/material/theme_data.dart:1938:73)
#4      MapMixin.map (dart:collection/maps.dart:170:28)
#5      MapView.map (dart:collection/maps.dart:360:12)
#6      ThemeData._lerpThemeExtensions (package:flutter/src/material/theme_data.dart:1936:77)
#7      ThemeData.lerp (package:flutter/src/material/theme_data.dart:1975:19)
```

Also, renamed alpha to opacity as in Flutter alpha is a value from 0 to 255:

```
withAlpha() Returns a new color that matches this color with the alpha channel replaced with a (which ranges from 0 to 255).

withOpacity() Returns a new color that matches this color with the alpha channel replaced with the given opacity (which ranges from 0.0 to 1.0).
```

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
