### PR TITLE
chore: fix vale linter

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -14,3 +14,4 @@ mdx = md
 [*.md]
 BasedOnStyles = Vale, Google
 BlockIgnores = (^import .*;), (import .*;), (<table>\n(.*\n)+</table>), (\| .* \|)
+TokenIgnores = (^import .*;),(import .*;)

--- a/docusaurus/docs/Flutter/02-guides/02-chat-with-video.mdx
+++ b/docusaurus/docs/Flutter/02-guides/02-chat-with-video.mdx
@@ -524,7 +524,7 @@ This snippet is larger than the previous integration steps, but it packs a few t
 3. To build the `Attachment`, you use its constructor, which lets you define the type of the `Attachment`, its author and any `extraData` you might need to render the UI. In this case, you pass in the `call.callCid` used to show the UI in the list.
 4. Finally, when the attachment is ready, you can build a new `Message` and pass in your `customAttachment`. By calling `channel.sendMessage()`, you create a new message in the channel, with the details required to join the Call.
 
-You could've approached this logic differently and shown special dialogs to the user for the call creation, give them more options for customization, like who to invite and similar. But for this basic use case of Chat + Video, you'll just create a simple call that's public in the Channel.
+You could've approached this logic differently and shown a special dialog to the user for the call creation, give them more options for customization, like who to invite and similar. But for this basic use case of Chat + Video, you'll just create a simple call that's public in the Channel.
 
 Now, you're fully ready to start and enjoy the Chat + Video experience. Build and run the app, log in and join any call attachment, or create a new call and join like that.
 


### PR DESCRIPTION
### 🎯 Goal

Fix Vale linter that was not ignoring imports in our code blocks. For example:

```
import 'package:flutter/material.dart';
```

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
