### PR TITLE
feat: pass API key param to create-token endpoint

### DIFF
--- a/dogfooding/lib/src/login_screen.dart
+++ b/dogfooding/lib/src/login_screen.dart
@@ -7,13 +7,14 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
 import 'package:stream_video/stream_video.dart';
 
+import '../env/env.dart';
 import 'model/user_credentials.dart';
 import 'routes/routes.dart';
 import 'user_repository.dart';
 import 'utils/assets.dart';
 
 class LoginScreen extends StatefulWidget {
-  const LoginScreen({Key? key}) : super(key: key);
+  const LoginScreen({super.key});
 
   @override
   State<LoginScreen> createState() => _LoginScreenState();
@@ -52,7 +53,7 @@ class _LoginScreenState extends State<LoginScreen> {
   Future<void> _onLoginSuccess(UserInfo user) async {
     final userId = user.id;
     final response = await http.get(Uri.parse(
-      'https://stream-calls-dogfood.vercel.app/api/auth/create-token?user_id=$userId',
+      'https://stream-calls-dogfood.vercel.app/api/auth/create-token?user_id=$userId&api_key=${Env.apiKey}',
     ));
 
     final token = json.decode(response.body)['token'];


### PR DESCRIPTION
### 🎯 Goal

Closes https://github.com/GetStream/stream-video-flutter/issues/256

Pass `api_key` param to the `https://stream-calls-dogfood.vercel.app/api/auth/create-token` endpoint.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
