### PR TITLE
feat: dispose tracks when closing lobby screen

### DIFF
--- a/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
@@ -47,6 +47,7 @@ class StreamLobbyView extends StatefulWidget {
 class _StreamLobbyViewState extends State<StreamLobbyView> {
   RtcLocalAudioTrack? _microphoneTrack;
   RtcLocalCameraTrack? _cameraTrack;
+  bool _isJoiningCall = false;
 
   Future<void> toggleCamera() async {
     if (_cameraTrack != null) {
@@ -69,6 +70,8 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
   }
 
   void onJoinCallPressed() {
+    _isJoiningCall = true;
+
     var options = const CallConnectOptions();
 
     final cameraTrack = _cameraTrack;
@@ -104,6 +107,12 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
 
   @override
   void dispose() {
+    // Dispose tracks if we closed lobby screen without joining the call.
+    if (!_isJoiningCall) {
+      _cameraTrack?.stop();
+      _microphoneTrack?.stop();
+    }
+
     _cameraTrack = null;
     _microphoneTrack = null;
     super.dispose();


### PR DESCRIPTION
### 🎯 Goal

Closes https://github.com/GetStream/stream-video-flutter/issues/260

We need to dispose tracks if we are leaving the lobby screen without pressing the "Join Call" button.

### 🧪 Testing

1. Run the sample app on web
2. Open lobby screen and enable camera 
4. Observe that the green indicator on your laptop is on
5. Close the screen by pressing close button
6. Observe that led indicator disappears

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
