### PR TITLE
[Fix] Docusaurus deployment action using Node 16

### DIFF
--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docusaurus/**'
 
 jobs:
   push_docusaurus:
@@ -11,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+      - name: Setup Node 16
+        uses: actions/setup-node@v3.1.0
+        with:
+          node-version: 16
       - name: push
         uses: GetStream/push-stream-chat-docusaurus-action@main
         with:


### PR DESCRIPTION
🎯 Goal

This PR fixes the currently failing docusaurus staging deployment action.
Due to the GitHub Action not specifying node 16 as the runtime for stream-chat-docusaurus it currently fails when trying to execute the build.

This PR fixes it and adds a trigger to only execute when files inside of the docusaurus folder are changed. This limits the action to only run when there are actual changes to the documentation.

🛠 Implementation details

Add paths trigger and specify node setup to use node 16.

🎨 UI Changes

None

🧪 Testing

Possible to test locally with [act](https://github.com/nektos/act) but otherwise only possible to see it when running on GitHub.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
