### PR TITLE
Fix navigation when call ends

### DIFF
--- a/packages/stream_video_flutter/lib/src/call_controls/controls/leave_call_option.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/controls/leave_call_option.dart
@@ -33,8 +33,6 @@ class LeaveCallOption extends StatelessWidget {
     } else {
       await call.apply(const CancelCall());
       await call.disconnect();
-
-      await Navigator.maybePop(context);
     }
   }
 }

--- a/packages/stream_video_flutter/lib/src/call_screen/incoming_call/incoming_call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/incoming_call/incoming_call_content.dart
@@ -133,8 +133,6 @@ class _StreamIncomingCallContentState extends State<StreamIncomingCallContent> {
     } else {
       await widget.call.apply(const RejectCall());
       await widget.call.disconnect();
-
-      await Navigator.maybePop(context);
     }
   }
 

--- a/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
@@ -151,7 +151,7 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
               if (widget.onCloseTap != null) {
                 widget.onCloseTap!();
               } else {
-                await Navigator.of(context).maybePop();
+                await Navigator.maybePop(context);
               }
             },
           ),

--- a/packages/stream_video_flutter/lib/src/call_screen/outgoing_call/outgoing_call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/outgoing_call/outgoing_call_content.dart
@@ -129,8 +129,6 @@ class _StreamOutgoingCallContentState extends State<StreamOutgoingCallContent> {
     } else {
       await widget.call.apply(const CancelCall());
       await widget.call.disconnect();
-
-      await Navigator.maybePop(context);
     }
   }
 


### PR DESCRIPTION
### 🎯 Goal

Handle navigation only in call container when the call is dropped to ensure that the stack is not popped twice.

### 🎨 UI Changes


<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/223952277-e8bb521f-b382-4022-8234-444360c5c11d.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/223953362-7dbb7ca7-1b6e-4ee6-9e2b-084a8348acc1.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
