### PR TITLE
fix: fix the dogfooding app

### DIFF
--- a/packages/stream_video/lib/src/coordinator/open_api/coordinator_ws_open_api.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/coordinator_ws_open_api.dart
@@ -71,6 +71,7 @@ class CoordinatorWebSocketOpenApi extends CoordinatorWebSocket
     _logger.i(() => '[authenticateUser] url: $url');
 
     final token = await tokenManager.loadToken();
+    final image = userInfo.image;
 
     final authMessage = {
       'token': token.rawValue,
@@ -81,7 +82,7 @@ class CoordinatorWebSocketOpenApi extends CoordinatorWebSocket
         // 'image': userInfo.image,
         'custom': <String, dynamic>{
           'name': userInfo.name,
-          'image': userInfo.image,
+          if (image != null) ...{'image': image},
           ...?userInfo.extraData,
         },
       },


### PR DESCRIPTION
### 🎯 Goal

Currently there's an error while joining a call in the dogfooding app. The reason is that we send `null` as the user image, then we get the currently logged-in user as a response of the `getOrCreateCall` method. The user fails to deserialize as we get their image in custom data and `Map<String, Object> custom;` values are not nullable.

The response that we get if we connected with a user with `null` image:
```
{"id":"gggg","name":"gggg","role":"user","custom":{"image":null},"created_at":"2023-03-15T11:48:21.536031Z","updated_at":"2023-03-15T11:48:21.537934Z"}
```

The response that we get if we connected with a user with empty image:
```
{"id":"gggg","name":"gggg","role":"user","image":"","custom":{},"created_at":"2023-03-15T11:51:47.18087Z","updated_at":"2023-03-15T11:51:47.196567Z"}
```

**user_response.dart**
```
///
/// Please note: This property should have been non-nullable! Since the specification file
/// does not include a default value (using the "default:" property), however, the generated
/// source code must fall back to having a nullable type.
/// Consider adding a "default:" property in the specification file to hide this note.
///
String? image;

///
/// Please note: This property should have been non-nullable! Since the specification file
/// does not include a default value (using the "default:" property), however, the generated
/// source code must fall back to having a nullable type.
/// Consider adding a "default:" property in the specification file to hide this note.
///
String? name;

Map<String, Object> custom;
```