### PR TITLE
Implement setVideoInput

### DIFF
--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -323,6 +323,14 @@ class CallSession extends Disposable {
     );
   }
 
+  Future<void> _applyCurrentVideoInputDevice() async {
+    final state = stateManager.callStateStream.valueOrNull;
+    final videoInputDevice = state?.videoInputDevice;
+    if (videoInputDevice != null) {
+      await setVideoInputDevice(videoInputDevice);
+    }
+  }
+
   Future<void> _onLocalTrackPublished(RtcLocalTrack track) async {
     _logger.d(() => '[onPublisherTrackPublished] track: $track');
 
@@ -332,6 +340,10 @@ class CallSession extends Disposable {
     // If the track is an audioTrack, apply the current audio output device.
     if (track.isAudioTrack) {
       await _applyCurrentAudioOutputDevice();
+    }
+
+    if(track.isVideoTrack) {
+      await _applyCurrentVideoInputDevice();
     }
 
     // Send a mute state update to the server.


### PR DESCRIPTION
### 🎯 Goal
This PR implements `setVideoInputDevice` when a new track is published. 

This solves the long wait time between tracks being published and sometimes not being rendered immediately. 

### 🛠 Implementation details

- Create a new function `_applyCurrentVideoInputDevice` for setting the track and device
- Call `_applyCurrentVideoInputDevice` if the track is video. 



### 🧪 Testing
Tested manually until a testing framework is added. 


### ☑️Contributor Checklist

#### General
- [X] Assigned a person / code owner group (required)
- [X] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [X] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [X] Sample runs & works
- [X] UI Changes correct (before & after images)
- [X] Bugs validated (bugfixes)
- [X] New feature tested and works
- [X] All code we touched has new or updated Documentation
