### PR TITLE
fix: OpenAPI Spec fix

### DIFF
--- a/packages/stream_video/lib/src/coordinator/open_api/open_api_mapper_extensions.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/open_api_mapper_extensions.dart
@@ -406,4 +406,3 @@ extension on TranscriptionSettingsMode {
     }
   }
 }
-


### PR DESCRIPTION
Fixes spec implementation for latest spec (handles ring event through `CallCreatedEvent` for now)