### PR TITLE
[Docs] Use shared page for call types

### DIFF
--- a/docusaurus/docs/Flutter/03-core-concepts/05-call-types.mdx
+++ b/docusaurus/docs/Flutter/03-core-concepts/05-call-types.mdx
@@ -4,24 +4,6 @@ slug: /call-types
 description: How Call Types control features and permissions
 ---
 
-When you start a call, you also need to provide the call type. Call types come with some predefined settings and permissions, depending on the video calling use-case they represent.
+import CallTypesPage from '../../../shared/video/_call-types.md';
 
-#### Development
-
-The `development` call type has all the permissions enabled, and can be used during development. It's not recommended to use this call type in production, since all the participants in the calls would be able to do everything (blocking, muting everyone, etc).
-
-For these call types, backstage is not enabled, therefore you don't have to explicitly call `goLive` in order for the call to be started.
-
-#### Default
-
-The `default` call type can be used for different video-calling apps, such as 1-1 calls, group calls or meetings with multiple people. Both video and audio are enabled, and backstage is disabled. It has permissions settings in place, where admins and hosts have elevated permissions over other types of users.
-
-#### Audio Room
-
-The `audio_room` call type is suitable for apps like Clubhouse or Twitter Spaces. It has pre-configured workflow around requesting permissions to speak for regular listeners. Backstage is enabled, and new calls are going to the backstage mode when created. You will need to explicitly call the `goLive` method to make the call active for all participants.
-
-You can find a guide on how to handle this [here](../../tutorials/audio-room).
-
-#### Livestream
-
-The `livestream` call type is configured to be used for livestreaming apps. Access to calls is granted to all authenticated users, and backstage is enabled by default.
+<CallTypesPage />


### PR DESCRIPTION
### 🎯 Goal

Use the shared Call types page.

### 🛠 Implementation details

It takes the shared page that we have and loads it into the Flutter docs. The content is not fully there, but once it is and the shared page has the content, it will automatically be distributed across SDKs.

Want to run it locally? Check [this page](https://www.notion.so/stream-wiki/Documentation-knowledge-d37b53d3ce6e42bcaaa0cabf3bc125c5) for details.

### 🎨 UI Changes

![Call Types | Stream Video - Flutter SDK Docs](https://github.com/GetStream/stream-video-flutter/assets/12433593/2f06d998-472d-4030-bed3-3d50c255698c)

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)

### ☑️Reviewer Checklist
- [x] Sample runs & works
- [x] All code we touched has new or updated Documentation
