### PR TITLE
Hide debug stats in production

### DIFF
--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../../stream_video_flutter.dart';
@@ -152,8 +153,10 @@ class _StreamCallContentState extends State<StreamCallContent> {
   }
 
   void _toggleStatsVisibility() {
-    setState(() {
-      _isStatsVisible = !_isStatsVisible;
-    });
+    if(kDebugMode){
+      setState(() {
+        _isStatsVisible = !_isStatsVisible;
+      });
+    }
   }
 }


### PR DESCRIPTION
This PR tweaks the debug stats visibility to ensure stats are only shown when the app is in debug mode. 

