### PR TITLE
fix: `connectUser` / auto connect bug 

### DIFF
--- a/docusaurus/docs/Flutter/03-core-concepts/01-authentication.mdx
+++ b/docusaurus/docs/Flutter/03-core-concepts/01-authentication.mdx
@@ -25,6 +25,7 @@ factory StreamVideo(
     muteVideoWhenInBackground: false,
     muteAudioWhenInBackground: false,
     autoConnect: true,
+    includeUserDetailsForAutoConnect: true,
   ),
   required User user,
   String? userToken,
@@ -33,6 +34,25 @@ factory StreamVideo(
   bool failIfSingletonExists = true,
   PNManagerProvider? pushNotificationManagerProvider,
 });
+```
+
+The SDK tries to connect automatically by default. You can set `autoConnect` to false in `StreamVideoOptions`
+to change this behaviour.
+
+To connect later, you can use the `connect()` method:
+
+```dart
+    StreamVideo.instance.connect();
+```
+
+The connection passes the user info by default to the backend.
+To change this, you can set the `includeUserDetailsForAutoConnect` parameter in `StreamVideoOptions` when auto-connecting
+or use the `includeUserDetails` parameter when using the `connect()` method:
+
+```dart
+    StreamVideo.instance.connect(
+        includeUserDetails: false,
+    );
 ```
 
 ### Working with Tokens

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+✅ Added
+
+* Added a `includeUserDetails` field to determine if user details should be passed to backend when connecting user.
+
 ## 0.2.0
 
 ✅ Added

--- a/packages/stream_video/lib/src/coordinator/coordinator_client.dart
+++ b/packages/stream_video/lib/src/coordinator/coordinator_client.dart
@@ -21,7 +21,10 @@ import 'models/coordinator_models.dart' as models;
 abstract class CoordinatorClient {
   SharedEmitter<CoordinatorEvent> get events;
 
-  Future<Result<None>> connectUser(UserInfo user);
+  Future<Result<None>> connectUser(
+    UserInfo user, {
+    bool includeUserDetails = false,
+  });
 
   Future<Result<None>> openConnection();
 

--- a/packages/stream_video/lib/src/coordinator/open_api/coordinator_client_open_api.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/coordinator_client_open_api.dart
@@ -97,7 +97,10 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
   StreamSubscription<CoordinatorEvent>? _wsSubscription;
 
   @override
-  Future<Result<None>> connectUser(UserInfo user) async {
+  Future<Result<None>> connectUser(
+    UserInfo user, {
+    bool includeUserDetails = false,
+  }) async {
     _logger.d(() => '[connectUser] user.id: ${user.id}');
     final state = _connectionState.value;
     if (state.isConnected) {
@@ -112,7 +115,10 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
       userId: user.id,
     );
     _user = user;
-    _ws = _createWebSocket(user).also((ws) {
+    _ws = _createWebSocket(
+      user,
+      includeUserDetails: includeUserDetails,
+    ).also((ws) {
       _wsSubscription = ws.events.listen((event) {
         if (event is CoordinatorConnectedEvent) {
           _logger.i(() => '[connectUser] WS connected');
@@ -223,13 +229,17 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
     );
   }
 
-  CoordinatorWebSocketOpenApi _createWebSocket(UserInfo user) {
+  CoordinatorWebSocketOpenApi _createWebSocket(
+    UserInfo user, {
+    bool includeUserDetails = false,
+  }) {
     return CoordinatorWebSocketOpenApi(
       _wsUrl,
       apiKey: _apiKey,
       userInfo: user,
       tokenManager: _tokenManager,
       retryPolicy: _retryPolicy,
+      includeUserDetails: includeUserDetails,
     );
   }
 

--- a/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
+++ b/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
@@ -289,8 +289,14 @@ class CoordinatorClientRetry extends CoordinatorClient {
   }
 
   @override
-  Future<Result<None>> connectUser(UserInfo user) {
-    return _delegate.connectUser(user);
+  Future<Result<None>> connectUser(
+    UserInfo user, {
+    bool includeUserDetails = false,
+  }) {
+    return _delegate.connectUser(
+      user,
+      includeUserDetails: includeUserDetails,
+    );
   }
 
   @override


### PR DESCRIPTION
Adds a `includeUserDetails` field to determine if user should be passed to backend.

By default, both `connectUser` and auto-connecting default to passing fields to backend.