### PR TITLE
fix: added missing params to `getOrCreate()` 

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -902,6 +902,9 @@ class Call {
   Future<Result<CallReceivedOrCreatedData>> getOrCreate({
     List<String> memberIds = const [],
     bool ringing = false,
+    String? team,
+    bool? notify,
+    Map<String, Object> custom = const {},
   }) async {
     _logger.d(
       () => '[getOrCreate] cid: $callCid, ringing: $ringing, '
@@ -923,6 +926,9 @@ class Call {
           role: 'admin',
         );
       }).toList(),
+      team: team,
+      notify: notify,
+      custom: custom,
     );
 
     return response.fold(

--- a/packages/stream_video/lib/src/coordinator/coordinator_client.dart
+++ b/packages/stream_video/lib/src/coordinator/coordinator_client.dart
@@ -60,6 +60,9 @@ abstract class CoordinatorClient {
     required StreamCallCid callCid,
     bool? ringing,
     List<open.MemberRequest>? members,
+    String? team,
+    bool? notify,
+    Map<String, Object> custom = const {},
   });
 
   Future<Result<models.CoordinatorJoined>> joinCall({

--- a/packages/stream_video/lib/src/coordinator/open_api/coordinator_client_open_api.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/coordinator_client_open_api.dart
@@ -387,6 +387,9 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
     required StreamCallCid callCid,
     bool? ringing,
     List<open.MemberRequest>? members,
+    String? team,
+    bool? notify,
+    Map<String, Object> custom = const {},
   }) async {
     try {
       _logger.d(
@@ -404,8 +407,11 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
         open.GetOrCreateCallRequest(
           data: open.CallRequest(
             members: members ?? [],
+            team: team,
+            custom: custom,
           ),
           ring: ringing,
+          notify: notify,
         ),
       );
       _logger.v(() => '[getOrCreateCall] completed: $result');

--- a/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
+++ b/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
@@ -141,12 +141,18 @@ class CoordinatorClientRetry extends CoordinatorClient {
     required StreamCallCid callCid,
     bool? ringing,
     List<open.MemberRequest>? members,
+    String? team,
+    bool? notify,
+    Map<String, Object> custom = const {},
   }) {
     return _retryManager.execute(
       () => _delegate.getOrCreateCall(
         callCid: callCid,
         ringing: ringing,
         members: members,
+        team: team,
+        notify: notify,
+        custom: custom,
       ),
       (error, nextAttemptDelay) async {
         _logRetry('getOrCreateCall', error, nextAttemptDelay);


### PR DESCRIPTION
Fixes #519 