### PR TITLE
StreamVideoTheme missing callContentTheme parameter

### DIFF
--- a/packages/stream_video_flutter/lib/src/theme/stream_video_theme.dart
+++ b/packages/stream_video_flutter/lib/src/theme/stream_video_theme.dart
@@ -14,8 +14,8 @@ class StreamVideoTheme extends ThemeExtension<StreamVideoTheme> {
   factory StreamVideoTheme({
     required Brightness brightness,
     StreamTextTheme? textTheme,
-    StreamCallContentThemeData? callContentTheme,
     StreamColorTheme? colorTheme,
+    StreamCallContentThemeData? callContentTheme,
     StreamCallControlsThemeData? callControlsTheme,
     StreamUserAvatarThemeData? userAvatarTheme,
     StreamLobbyViewThemeData? lobbyViewTheme,

--- a/packages/stream_video_flutter/lib/src/theme/stream_video_theme.dart
+++ b/packages/stream_video_flutter/lib/src/theme/stream_video_theme.dart
@@ -14,6 +14,7 @@ class StreamVideoTheme extends ThemeExtension<StreamVideoTheme> {
   factory StreamVideoTheme({
     required Brightness brightness,
     StreamTextTheme? textTheme,
+    StreamCallContentThemeData? callContentTheme,
     StreamColorTheme? colorTheme,
     StreamCallControlsThemeData? callControlsTheme,
     StreamUserAvatarThemeData? userAvatarTheme,
@@ -37,6 +38,7 @@ class StreamVideoTheme extends ThemeExtension<StreamVideoTheme> {
     );
 
     final customizedTheme = defaultTheme.copyWith(
+      callContentTheme: callContentTheme,
       textTheme: textTheme,
       colorTheme: colorTheme,
       callControlsTheme: callControlsTheme,

--- a/packages/stream_video_flutter/lib/src/theme/stream_video_theme.dart
+++ b/packages/stream_video_flutter/lib/src/theme/stream_video_theme.dart
@@ -38,9 +38,9 @@ class StreamVideoTheme extends ThemeExtension<StreamVideoTheme> {
     );
 
     final customizedTheme = defaultTheme.copyWith(
-      callContentTheme: callContentTheme,
       textTheme: textTheme,
       colorTheme: colorTheme,
+      callContentTheme: callContentTheme,
       callControlsTheme: callControlsTheme,
       userAvatarTheme: userAvatarTheme,
       lobbyViewTheme: lobbyViewTheme,


### PR DESCRIPTION
Fixes #546

### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

_Describe the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="" controls="controls" muted="muted" />
</td>
<td>
<video src="" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Provide the patch code here
```

</details>


### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
