### PR TITLE
`StreamOutgoingCallContent` mic and camera buttons don't response

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -264,8 +264,7 @@ class Call {
 
   set connectOptions(CallConnectOptions connectOptions) {
     final status = _status.value;
-    if (status == _ConnectionStatus.connecting ||
-        status == _ConnectionStatus.connected) {
+    if (status == _ConnectionStatus.connected) {
       _logger.w(
         () => '[setConnectOptions] rejected (connectOptions must be'
             ' set before invoking `connect`)',


### PR DESCRIPTION
Fixes #571

While in `StreamOutgoingCallContent` the status `_ConnectionStatus.value` is `_ConnectionStatus.connecting` and the update falls becase of it