### PR TITLE
fix(llc): fixing call participants creation when receving call details

### DIFF
--- a/dogfooding/lib/screens/lobby_screen.dart
+++ b/dogfooding/lib/screens/lobby_screen.dart
@@ -28,8 +28,11 @@ class _LobbyScreenState extends State<LobbyScreen> {
   RtcLocalCameraTrack? _cameraTrack;
 
   final _userAuthController = locator.get<UserAuthController>();
+  bool _isJoiningCall = false;
 
   void joinCallPressed() {
+    _isJoiningCall = true;
+
     var options = const CallConnectOptions();
 
     final cameraTrack = _cameraTrack;
@@ -47,6 +50,19 @@ class _LobbyScreenState extends State<LobbyScreen> {
     }
 
     widget.onJoinCallPressed(options);
+  }
+
+  @override
+  void dispose() {
+    // Dispose tracks if we closed lobby screen without joining the call.
+    if (!_isJoiningCall) {
+      _cameraTrack?.stop();
+      _microphoneTrack?.stop();
+    }
+
+    _cameraTrack = null;
+    _microphoneTrack = null;
+    super.dispose();
   }
 
   @override

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -233,7 +233,7 @@ class Call {
 
   StreamCallCid get callCid => state.value.callCid;
 
-  String get type => state.value.callType;
+  StreamCallType get type => state.value.callType;
 
   String get id => state.value.callId;
 
@@ -534,14 +534,17 @@ class Call {
 
     _logger.v(() => '[join] starting sfu session');
     final sessionResult = await _startSession(joinedResult.data);
+
     if (sessionResult is! Success<None>) {
       _logger.w(() => '[join] sfu session start failed: $sessionResult');
       final error = (sessionResult as Failure).error;
       _stateManager.lifecycleCallConnectFailed(ConnectFailed(error));
       return sessionResult;
     }
+
     _logger.v(() => '[join] started session');
     _stateManager.lifecycleCallConnected(const CallConnected());
+
     await _applyConnectOptions();
 
     _logger.v(() => '[join] completed');

--- a/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:state_notifier/state_notifier.dart';
 
 import '../../../../stream_video.dart';
@@ -290,24 +291,39 @@ mixin StateLifecycleMixin on StateNotifier<CallState> {
 extension on CallMetadata {
   List<CallParticipantState> toCallParticipants(CallState state) {
     final result = <CallParticipantState>[];
-    for (final userId in members.keys) {
+
+    for (final participant in session.participants.values) {
+      final userId = participant.userId;
       final member = members[userId];
       final user = users[userId];
+      final currentState =
+          state.callParticipants.firstWhereOrNull((it) => it.userId == userId);
       final isLocal = state.currentUserId == userId;
+
       result.add(
-        CallParticipantState(
-          userId: userId,
-          role: member?.role ?? user?.role ?? '',
-          name: user?.name ?? '',
-          custom: user?.custom ?? {},
-          image: user?.image ?? '',
-          sessionId: '',
-          trackIdPrefix: '',
-          isLocal: isLocal,
-          isOnline: !isLocal,
-        ),
+        currentState?.copyWith(
+              role: member?.role ?? user?.role ?? '',
+              name: user?.name ?? '',
+              custom: user?.custom ?? {},
+              image: user?.image ?? '',
+              sessionId: participant.userSessionId,
+              isLocal: isLocal,
+              isOnline: !isLocal,
+            ) ??
+            CallParticipantState(
+              userId: userId,
+              role: member?.role ?? user?.role ?? '',
+              name: user?.name ?? '',
+              custom: user?.custom ?? {},
+              image: user?.image ?? '',
+              sessionId: participant.userSessionId,
+              trackIdPrefix: '',
+              isLocal: isLocal,
+              isOnline: !isLocal,
+            ),
       );
     }
+
     return result;
   }
 }

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -140,7 +140,7 @@ class CallState extends Equatable {
 
   String get callId => callCid.id;
 
-  String get callType => callCid.id;
+  StreamCallType get callType => callCid.type;
 
   CallParticipantState? get localParticipant {
     return callParticipants.firstWhereOrNull((element) => element.isLocal);


### PR DESCRIPTION
Previously wherever we get a call details we updated the CallState with participants created from member list. First problem was that it was losing the state of CallParticipant which contains publishedTracks. Second is that it should iterate session participats and not members collection.