### PR TITLE
Migrate LobbyView to `TrackOptions.enabled`

### DIFF
--- a/packages/stream_video_flutter/example/android/app/build.gradle
+++ b/packages/stream_video_flutter/example/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.example.stream_video_flutter_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion Math.max(flutter.minSdkVersion, 33)
+        minSdkVersion Math.max(flutter.minSdkVersion, 32)
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
@@ -61,8 +61,12 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
   StreamSubscription<Object>? _fetchSubscription;
   StreamSubscription<Object>? _eventSubscription;
 
+  bool get hasCameraEnabled => _cameraTrack != null;
+
+  bool get hasMicrophoneEnabled => _microphoneTrack != null;
+
   Future<void> toggleCamera() async {
-    if (_cameraTrack != null) {
+    if (hasCameraEnabled) {
       await _cameraTrack?.stop();
       return setState(() => _cameraTrack = null);
     }
@@ -76,7 +80,7 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
   }
 
   Future<void> toggleMicrophone() async {
-    if (_microphoneTrack != null) {
+    if (hasMicrophoneEnabled) {
       await _microphoneTrack?.stop();
       return setState(() => _microphoneTrack = null);
     }
@@ -91,20 +95,17 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
 
   void onJoinCallPressed() {
     _isJoiningCall = true;
-
     var options = const CallConnectOptions();
 
-    final cameraTrack = _cameraTrack;
-    if (cameraTrack != null) {
+    if (hasCameraEnabled) {
       options = options.copyWith(
-        camera: TrackOption.provided(cameraTrack),
+        camera: TrackOption.enabled(),
       );
     }
 
-    final microphoneTrack = _microphoneTrack;
-    if (microphoneTrack != null) {
+    if (hasMicrophoneEnabled) {
       options = options.copyWith(
-        microphone: TrackOption.provided(microphoneTrack),
+        microphone: TrackOption.enabled(),
       );
     }
 


### PR DESCRIPTION
### 🎯 Goal
This PR addresses the issues outlined in the ticket https://github.com/GetStream/stream-video-flutter/issues/617.


### 🛠 Implementation details
Migrates the `StreamLobbyView` view implementation to `TrackOptions.enabled` instead of `TrackOptions.provided`. The Camera and Microphone on/off state are checked and synced to a new instance of `CallConnectOptions` before being passed to the active `Call` object. 

Tested on:
- Android: Pixel 3a API version 32 
- iOS: iPhone 15 Pro Max, iOS 17.4 
- React: Stream's current production [demo app](https://getstream.io/video/demos/) 


### 🧪 Testing
- To be added in a separate PR (testing infra needs to be configured)

### ☑️Contributor Checklist

#### General
- [x] Assigned a person/code owner group (required)
- [X] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [X] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [X] All code we touched has new or updated Documentation
