### PR TITLE
fix(video_renderer): disable mirroring for rendering local back camera stream

### DIFF
--- a/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
+++ b/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
@@ -80,11 +80,20 @@ class StreamVideoRenderer extends StatelessWidget {
       return placeholderBuilder.call(context);
     }
 
+    var mirror = participant.isLocal;
+
+    // If the track is local and it's a back camera, don't mirror the video.
+    if (participant.isLocal && videoTrack is RtcLocalTrack<CameraConstraints>) {
+      final isBackCamera =
+          videoTrack.mediaConstraints.facingMode == FacingMode.environment;
+      mirror = participant.isLocal && !isBackCamera;
+    }
+
     return VideoTrackRenderer(
       key: ValueKey(videoTrack.trackId),
       videoFit: videoFit,
       videoTrack: videoTrack,
-      mirror: participant.isLocal,
+      mirror: mirror,
       placeholderBuilder: placeholderBuilder,
     );
   }

--- a/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
+++ b/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
@@ -82,8 +82,9 @@ class StreamVideoRenderer extends StatelessWidget {
 
     var mirror = participant.isLocal;
 
-    // If the track is local and it's a back camera, don't mirror the video.
-    if (participant.isLocal && videoTrack is RtcLocalTrack<CameraConstraints>) {
+    if (videoTrack is RtcLocalScreenShareTrack) {
+      mirror = false;
+    } else if (videoTrack is RtcLocalTrack<CameraConstraints>) {
       final isBackCamera =
           videoTrack.mediaConstraints.facingMode == FacingMode.environment;
       mirror = !isBackCamera;

--- a/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
+++ b/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
@@ -86,7 +86,7 @@ class StreamVideoRenderer extends StatelessWidget {
     if (participant.isLocal && videoTrack is RtcLocalTrack<CameraConstraints>) {
       final isBackCamera =
           videoTrack.mediaConstraints.facingMode == FacingMode.environment;
-      mirror = participant.isLocal && !isBackCamera;
+      mirror = !isBackCamera;
     }
 
     return VideoTrackRenderer(


### PR DESCRIPTION
---

### 🎯 Goal

Improve user experience by ensuring the video orientation matches user expectations. The change prevents mirroring for local back camera video streams, making the display more intuitive, especially in contexts where mirroring could confuse or degrade the viewing experience.

### 🛠 Implementation details

Modified the `StreamVideoRenderer` class to detect if a video stream is local and from the back camera. If these conditions are met, the video is not mirrored. This involved checking the `videoTrack`'s `mediaConstraints.facingMode` against `FacingMode.environment` to identify back camera usage and adjusting the `mirror` variable accordingly.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Before Image](https://i.imgur.com/SmVUv7t.jpg) | ![After Image](https://i.imgur.com/08DbBh8.jpg) |


### 🧪 Testing

1. Test with front camera to ensure existing mirroring behavior remains unaffected.
2. Switch to the back camera and confirm that mirroring is disabled.

This change targets the video rendering behavior, requiring live testing with video streams from both front and back cameras to validate the implementation.

### ☑️ Contributor Checklist

- [ ] Assigned code owner
- [ ] Initiated discussion in Slack channel
- [ ] Linked PR to GitHub issue

### ☑️ Reviewer Checklist

- [ ] Ensured functionality works as expected
- [ ] Verified no UI regressions
- [ ] Confirmed new feature operates correctly
- [ ] Reviewed documentation for accuracy

---
