### PR TITLE
fix: fixes incorrect cid value crash

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unrelease
+## Unreleased
 ✅ Added
 
 * Added `callEvents` stream to `Call` that replaces `events` and `coordinatorEvents` streams (both are now deprecated)

--- a/packages/stream_video/lib/src/call/call_events.dart
+++ b/packages/stream_video/lib/src/call/call_events.dart
@@ -682,7 +682,7 @@ extension SfuEventX on SfuEvent {
   StreamCallEvent? mapToCallEvent(CallState state) {
     return switch (this) {
       final SfuJoinResponseEvent event => StreamCallJoinedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           participants: event.callState.participants
               .map((sfuParticipant) => sfuParticipant.toParticipantState(state))
               .toList(),
@@ -692,29 +692,29 @@ extension SfuEventX on SfuEvent {
         ),
       final SfuConnectionQualityChangedEvent event =>
         StreamCallConnectionQualityChangedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           connectionQualityUpdates: event.connectionQualityUpdates,
         ),
       final SfuAudioLevelChangedEvent event => StreamCallAudioLevelChangedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           audioLevels: event.audioLevels,
         ),
       final SfuParticipantJoinedEvent event => StreamCallParticipantJoinedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           participant: event.participant.toParticipantState(state),
         ),
       final SfuParticipantLeftEvent event => StreamCallParticipantLeftEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           participant: event.participant.toParticipantState(state),
         ),
       final SfuDominantSpeakerChangedEvent event =>
         StreamCallDominantSpeakerChangedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           userId: event.userId,
           sessionId: event.sessionId,
         ),
       final SfuTrackPublishedEvent event => StreamCallSfuTrackPublishedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           userId: event.userId,
           sessionId: event.sessionId,
           trackType: event.trackType,
@@ -722,14 +722,14 @@ extension SfuEventX on SfuEvent {
         ),
       final SfuTrackUnpublishedEvent event =>
         StreamCallSfuTrackUnpublishedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           userId: event.userId,
           sessionId: event.sessionId,
           trackType: event.trackType,
           participant: event.participant.toParticipantState(state),
         ),
       final SfuCallGrantsUpdated event => StreamCallGrantsUpdated(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           currentGrants: event.currentGrants,
           message: event.message,
         ),
@@ -743,12 +743,12 @@ extension CoordinatorCallEventX on CoordinatorCallEvent {
   StreamCallEvent? mapToCallEvent(CallState state) {
     return switch (this) {
       final CoordinatorConnectedEvent event => StreamCallConnectedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           connectionId: event.connectionId,
           userId: event.userId,
         ),
       final CoordinatorDisconnectedEvent event => StreamCallDisconnectedEvent(
-          StreamCallCid(cid: state.callId),
+          state.callCid,
           connectionId: event.connectionId,
           userId: event.userId,
           closeCode: event.closeCode,


### PR DESCRIPTION
The current event mapper uses the call ID instead of the CID ("abcd1234" instead of "default:abcd1234") leading to errors. This PR replaces it with the CID retrieved from state.