### PR TITLE
fix: fixes screen sharing permission handling on Android

### DIFF
--- a/docusaurus/docs/Flutter/05-advanced/03-screen-sharing.mdx
+++ b/docusaurus/docs/Flutter/05-advanced/03-screen-sharing.mdx
@@ -114,7 +114,7 @@ With that, the setup for the broadcast upload extension is done.
 The Stream Video SDK has support for screen sharing from an Android device. The SDK is using the [Android Media Projection API](https://developer.android.com/guide/topics/large-screens/media-projection) for the capture. To initiate screen sharing, user consent is mandatory.
 
 When using the `ToggleScreenShareOption` within the` stream_video_flutter` package, permission handling is seamlessly integrated. However, if you opt to initiate screen sharing via the `setScreenShareEnabled()` method on the `Call` object, you will be responsible for securing the necessary permissions and initiating a foreground service. The foreground service is essential for displaying a notification to the user while screen sharing is active.
-It is also required to start [media projection foreground service](https://developer.android.com/reference/android/media/projection/MediaProjectionManager#getMediaProjection(int,%20android.content.Intent)) from Android version 10 onwards.
+It is required to start [media projection foreground service](https://developer.android.com/reference/android/media/projection/MediaProjectionManager#getMediaProjection(int,%20android.content.Intent)) from Android version 10 onwards.
 
 From android 14 onwards, it is also required to activly ask users for a permission to share their screen. You can do this by calling `call.requestScreenSharePermission()` method.
 Below is an example snippet that demonstrates how to use our built in `StreamBackgroundService` class to manage these requirements:

--- a/docusaurus/docs/Flutter/05-advanced/03-screen-sharing.mdx
+++ b/docusaurus/docs/Flutter/05-advanced/03-screen-sharing.mdx
@@ -114,15 +114,50 @@ With that, the setup for the broadcast upload extension is done.
 The Stream Video SDK has support for screen sharing from an Android device. The SDK is using the [Android Media Projection API](https://developer.android.com/guide/topics/large-screens/media-projection) for the capture. To initiate screen sharing, user consent is mandatory.
 
 When using the `ToggleScreenShareOption` within the` stream_video_flutter` package, permission handling is seamlessly integrated. However, if you opt to initiate screen sharing via the `setScreenShareEnabled()` method on the `Call` object, you will be responsible for securing the necessary permissions and initiating a foreground service. The foreground service is essential for displaying a notification to the user while screen sharing is active.
+It is also required to start [media projection foreground service](https://developer.android.com/reference/android/media/projection/MediaProjectionManager#getMediaProjection(int,%20android.content.Intent)) from Android version 10 onwards.
 
+From android 14 onwards, it is also required to activly ask users for a permission to share their screen. You can do this by calling `call.requestScreenSharePermission()` method.
 Below is an example snippet that demonstrates how to use our built in `StreamBackgroundService` class to manage these requirements:
 
 ```dart
-if (/*sharing enabled*/) {
-  await StreamBackgroundService().startScreenSharingNotificationService(call);
-} else {
-  await StreamBackgroundService().stopScreenSharingNotificationService();
-}
+  void startScreemSharing() {
+    if (CurrentPlatform.isAndroid) {
+      // Check if the user has granted permission to share their screen
+      if (!await call.requestScreenSharePermission()) {
+        return;
+      }
+
+      // Start the screen sharing notification service
+      await StreamBackgroundService()
+          .startScreenSharingNotificationService(call);
+    }
+
+    // Enable screen sharing
+    final result = await call.setScreenShareEnabled(
+      enabled: true,
+    );
+
+    // Stop the screen sharing notification service if the operation failed
+    if (CurrentPlatform.isAndroid && result.isFailure) {
+      await StreamBackgroundService()
+          .stopScreenSharingNotificationService();
+    }
+  }
+```
+
+Remember to stop the foreground service when the screen sharing is disabled:
+
+```dart
+  void stopScreenSharing() async {
+    final result = await call.setScreenShareEnabled(
+      enabled: false,
+    );
+
+    if (CurrentPlatform.isAndroid) {
+      await StreamBackgroundService()
+          .stopScreenSharingNotificationService();
+    }
+  }
 ```
 
 You can customize the notification content and behavior by initiating `StreamBackgroundService`:
@@ -143,13 +178,4 @@ StreamBackgroundService.init(
     }
   },
 );
-```
-
-In case of using `flutter_background` you will also need to add a media projection service declaration in `AndroidManifest.xml`.
-
-```xml
-<service android:name="de.julianassmann.flutter_background.IsolateHolderService"
-    android:foregroundServiceType="mediaProjection"
-    android:enabled="true"
-    android:exported="false"/>
 ```

--- a/docusaurus/docs/Flutter/05-advanced/03-screen-sharing.mdx
+++ b/docusaurus/docs/Flutter/05-advanced/03-screen-sharing.mdx
@@ -114,9 +114,9 @@ With that, the setup for the broadcast upload extension is done.
 The Stream Video SDK has support for screen sharing from an Android device. The SDK is using the [Android Media Projection API](https://developer.android.com/guide/topics/large-screens/media-projection) for the capture. To initiate screen sharing, user consent is mandatory.
 
 When using the `ToggleScreenShareOption` within the` stream_video_flutter` package, permission handling is seamlessly integrated. However, if you opt to initiate screen sharing via the `setScreenShareEnabled()` method on the `Call` object, you will be responsible for securing the necessary permissions and initiating a foreground service. The foreground service is essential for displaying a notification to the user while screen sharing is active.
-It is required to start [media projection foreground service](https://developer.android.com/reference/android/media/projection/MediaProjectionManager#getMediaProjection(int,%20android.content.Intent)) from Android version 10 onwards.
+It is required to start [media projection foreground service](https://developer.android.com/reference/android/media/projection/MediaProjectionManager#getMediaProjection(int,%20android.content.Intent)) from Android version 10 onward.
 
-From android 14 onwards, it is also required to activly ask users for a permission to share their screen. You can do this by calling `call.requestScreenSharePermission()` method.
+From android 14 onward, it is also required to actively ask users for a permission to share their screen. You can do this by calling `call.requestScreenSharePermission()` method.
 Below is an example snippet that demonstrates how to use our built in `StreamBackgroundService` class to manage these requirements:
 
 ```dart

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
@@ -1583,6 +1584,10 @@ class Call {
     }
 
     return result;
+  }
+
+  Future<bool> requestScreenSharePermission() {
+    return Helper.requestCapturePermission();
   }
 
   Future<Result<None>> setScreenShareEnabled({

--- a/packages/stream_video_flutter/lib/src/call_controls/controls/toggle_screen_sharing_option.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/controls/toggle_screen_sharing_option.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
 
 import '../../../stream_video_flutter.dart';
 
@@ -66,6 +67,10 @@ class ToggleScreenShareOption extends StatelessWidget {
 
         if (CurrentPlatform.isAndroid) {
           if (toggledEnabled) {
+            if (!await call.requestScreenSharePermission()) {
+              return;
+            }
+
             await StreamBackgroundService()
                 .startScreenSharingNotificationService(call);
           } else {


### PR DESCRIPTION
Adds permission request to `ToggleScreenShareOption` to handle requirements on Android 14 onwards. 