### PR TITLE
fix hang-up behaviour

### DIFF
--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -134,6 +134,10 @@ class _CallScreenState extends State<CallScreen> {
         body: StreamCallContainer(
           call: widget.call,
           callConnectOptions: widget.connectOptions,
+          onCancelCallTap: () async {
+            await widget.call.reject();
+            await widget.call.leave();
+          },
           callContentBuilder: (
             BuildContext context,
             Call call,

--- a/dogfooding/lib/screens/home_screen.dart
+++ b/dogfooding/lib/screens/home_screen.dart
@@ -41,7 +41,8 @@ class _HomeScreenState extends State<HomeScreen> {
       onButtonClick: (call, type, serviceType) async {
         switch (serviceType) {
           case ServiceType.call:
-            call.end();
+            call.reject();
+            call.leave();
           case ServiceType.screenSharing:
             StreamVideoFlutterBackground.stopService(ServiceType.screenSharing);
             call.setScreenShareEnabled(enabled: false);


### PR DESCRIPTION
### 🎯 Goal

`call.end()` is permission based action (most likely should be invoked by a host/admin)
By default, we should `reject` and `leave`.


### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
