### PR TITLE
fix: CallKit now displays appropriate video and audio call labels.

### DIFF
--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -612,6 +612,7 @@ class StreamVideo extends Disposable {
 
     final createdById = payload['created_by_id'] as String?;
     final createdByName = payload['created_by_display_name'] as String?;
+    final hasVideo = payload['video'] as String?;
 
     final type = payload['type'] as String?;
     if (type == 'call.missed') {
@@ -644,6 +645,7 @@ class StreamVideo extends Disposable {
             handle: createdById,
             nameCaller: createdByName,
             callCid: callCid,
+            hasVideo: hasVideo != 'false',
           ),
         );
         return true;

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+✅ Added
+
+- CallKit now displays appropriate video and audio call labels.
+
 ## 0.4.2
 
 ✅ Added

--- a/packages/stream_video_push_notification/CHANGELOG.md
+++ b/packages/stream_video_push_notification/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+✅ Added
+
+- CallKit now displays appropriate video and audio call labels.
+
 ## 0.4.2
 * Sync version with `stream_video_flutter` 0.4.2
 

--- a/packages/stream_video_push_notification/ios/Classes/StreamVideoPKDelegateManager.swift
+++ b/packages/stream_video_push_notification/ios/Classes/StreamVideoPKDelegateManager.swift
@@ -82,6 +82,8 @@ public class StreamVideoPKDelegateManager: NSObject, PKPushRegistryDelegate {
         let callCid = streamDict?["call_cid"] as? String ?? ""
         let createdByName = streamDict?["created_by_display_name"] as? String
         let createdById = streamDict?["created_by_id"] as? String
+        let videoIncluded = streamDict?["video"] as? String
+        let videoData = videoIncluded == "false" ? 0 : 1
 
         var callUUID = UUID().uuidString;
 
@@ -95,7 +97,7 @@ public class StreamVideoPKDelegateManager: NSObject, PKPushRegistryDelegate {
         data.callKitData.uuid = callUUID
         data.callKitData.nameCaller = createdByName ?? defaultCallText
         data.callKitData.handle = createdById ?? defaultCallText
-        data.callKitData.type = 1 //video
+        data.callKitData.type = videoData
         data.callKitData.extra = ["callCid": callCid]
         
         // Show call incoming notification.


### PR DESCRIPTION
CallKit now displays if the call is an audio or video call on the incoming CallKit screen.

Fixes #708 