### PR TITLE
Allow Lobby components to use a custom instance of StreamVideo

### DIFF
--- a/packages/stream_video_flutter/lib/src/call_screen/lobby_video.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/lobby_video.dart
@@ -17,6 +17,7 @@ class StreamLobbyVideo extends StatefulWidget {
     this.userAvatarTheme,
     this.onMicrophoneTrackSet,
     this.onCameraTrackSet,
+    this.streamVideo,
   });
 
   /// Represents a call.
@@ -30,6 +31,11 @@ class StreamLobbyVideo extends StatefulWidget {
 
   final FutureOr<void> Function(RtcLocalAudioTrack?)? onMicrophoneTrackSet;
   final FutureOr<void> Function(RtcLocalCameraTrack?)? onCameraTrackSet;
+
+  /// An instance of [StreamVideo].
+  ///
+  /// If not provided, it will be obtained via StreamVideo.instance
+  final StreamVideo? streamVideo;
 
   @override
   State<StreamLobbyVideo> createState() => _StreamLobbyVideoState();
@@ -100,7 +106,8 @@ class _StreamLobbyVideoState extends State<StreamLobbyVideo> {
         widget.cardBackgroundColor ?? theme.cardBackgroundColor;
     final userAvatarTheme = widget.userAvatarTheme ?? theme.userAvatarTheme;
 
-    final currentUser = StreamVideo.instance.currentUser;
+    final currentUser =
+        (widget.streamVideo ?? StreamVideo.instance).currentUser;
 
     final cameraEnabled = _cameraTrack != null;
     final microphoneEnabled = _microphoneTrack != null;

--- a/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
@@ -20,6 +20,7 @@ class StreamLobbyView extends StatefulWidget {
     this.cardBackgroundColor,
     this.userAvatarTheme,
     this.participantAvatarTheme,
+    this.streamVideo,
   });
 
   /// Represents a call.
@@ -44,6 +45,11 @@ class StreamLobbyView extends StatefulWidget {
 
   /// Theme for the participant avatar.
   final StreamUserAvatarThemeData? participantAvatarTheme;
+
+  /// An instance of [StreamVideo].
+  ///
+  /// If not provided, it will be obtained via StreamVideo.instance
+  final StreamVideo? streamVideo;
 
   @override
   State<StreamLobbyView> createState() => _StreamLobbyViewState();
@@ -132,7 +138,8 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
   void _fetchCall() {
     // Obtains SFU credentials and picks the best server, but doesn't
     // connect to the call yet.
-    final currentUserId = StreamVideo.instance.currentUser.id;
+    final currentUserId =
+        (widget.streamVideo ?? StreamVideo.instance).currentUser.id;
     _logger.d(() => '[fetchCall] currentUserId: $currentUserId');
     _fetchSubscription?.cancel();
     _fetchSubscription = widget.call.getOrCreate().asStream().listen((result) {
@@ -158,7 +165,8 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
 
   void _listenEvents() {
     _eventSubscription?.cancel();
-    _eventSubscription = StreamVideo.instance.events.listen((event) {
+    _eventSubscription =
+        (widget.streamVideo ?? StreamVideo.instance).events.listen((event) {
       if (event is CoordinatorCallSessionParticipantLeftEvent) {
         _logger.d(() => '[listenEvents] #userLeft; user: ${event.user}');
         _participants.removeWhere(


### PR DESCRIPTION
### 🎯 Goal

This allows the `StreamLobbyView` and `StreamLobbyVideo` to use a custom instance of `StreamVideo`.

This ensures that apps which initialize Stream using `StreamVideo.create` can still use these components.

Resolves one of the suggestions in #741 

### 🛠 Implementation details

Add an optional `streamVideo` parameters to the constructors of `StreamLobbyView` and `StreamLobbyVideo`. If this parameter is omitted, the widgets will fall back to `StreamVideo.instance`.

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="" controls="controls" muted="muted" />
</td>
<td>
<video src="" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Pass in a non-singleton instance of `StreamVideo` to the two Lobby widgets and verify that they use the given instance. Also verify that the behaviour remains the same otherwise.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
