### PR TITLE
fix: fixing on leave call callback

### DIFF
--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -115,11 +115,7 @@ class CallSession extends Disposable {
       sfu_models.Device? device;
       sfu_models.Browser? browser;
 
-      var os = sfu_models.OS(
-        name: SysInfo.operatingSystemName,
-        version: SysInfo.operatingSystemVersion,
-        architecture: SysInfo.rawKernelArchitecture,
-      );
+      var os = sfu_models.OS();
 
       if (CurrentPlatform.isAndroid) {
         final deviceInfo = await DeviceInfoPlugin().androidInfo;

--- a/packages/stream_video/lib/src/webrtc/peer_connection.dart
+++ b/packages/stream_video/lib/src/webrtc/peer_connection.dart
@@ -378,6 +378,7 @@ class StreamPeerConnection extends Disposable {
 
   @override
   Future<void> dispose() async {
+    _logger.d(() => '[dispose] no args');
     _dropRtcCallbacks();
     _stopObservingStats();
     onStreamAdded = null;

--- a/packages/stream_video/lib/src/webrtc/rtc_manager.dart
+++ b/packages/stream_video/lib/src/webrtc/rtc_manager.dart
@@ -226,6 +226,7 @@ class RtcManager extends Disposable {
 
   @override
   Future<void> dispose() async {
+    _logger.d(() => '[dispose] no args');
     for (final trackSid in [...publishedTracks.keys]) {
       await unpublishTrack(trackId: trackSid);
     }

--- a/packages/stream_video_flutter/lib/src/call_controls/call_controls.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/call_controls.dart
@@ -22,7 +22,6 @@ class StreamCallControls extends StatelessWidget {
   factory StreamCallControls.withDefaultOptions({
     required Call call,
     required CallParticipantState localParticipant,
-    VoidCallback? onLeaveCallTap,
     Color? backgroundColor,
     double? elevation,
     double? spacing,
@@ -33,7 +32,6 @@ class StreamCallControls extends StatelessWidget {
       options: defaultCallControlOptions(
         call: call,
         localParticipant: localParticipant,
-        onLeaveCallTap: onLeaveCallTap,
       ),
       backgroundColor: backgroundColor,
       elevation: elevation,

--- a/packages/stream_video_flutter/lib/src/call_controls/controls/default_control_options.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/controls/default_control_options.dart
@@ -6,7 +6,6 @@ import '../../../stream_video_flutter.dart';
 List<Widget> defaultCallControlOptions({
   required Call call,
   required CallParticipantState localParticipant,
-  VoidCallback? onLeaveCallTap,
 }) {
   return [
     ToggleSpeakerphoneOption(call: call),

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/call_app_bar.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/call_app_bar.dart
@@ -13,6 +13,7 @@ class CallAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.elevation = 1,
     this.backgroundColor,
     this.onBackPressed,
+    this.onLeaveCallTap,
     this.leading,
     this.leadingWidth,
     this.title,
@@ -36,6 +37,9 @@ class CallAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   /// The action to perform when the back button is pressed.
   final VoidCallback? onBackPressed;
+
+  /// The action to perform when the leave call button is tapped.
+  final VoidCallback? onLeaveCallTap;
 
   /// The leading widget to display.
   final Widget? leading;
@@ -84,7 +88,10 @@ class CallAppBar extends StatelessWidget implements PreferredSizeWidget {
             if (showLeaveCallAction)
               Transform.scale(
                 scale: 0.8,
-                child: LeaveCallOption(call: call),
+                child: LeaveCallOption(
+                  call: call,
+                  onLeaveCallTap: onLeaveCallTap,
+                ),
               ),
           ],
       title: title ??

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
@@ -216,6 +216,7 @@ class _StreamCallContentState extends State<StreamCallContent>
           CallAppBar(
             call: call,
             onBackPressed: widget.onBackPressed,
+            onLeaveCallTap: widget.onLeaveCallTap,
           ),
       body: Stack(
         children: [
@@ -250,7 +251,6 @@ class _StreamCallContentState extends State<StreamCallContent>
               StreamCallControls.withDefaultOptions(
                 call: call,
                 localParticipant: localParticipant,
-                onLeaveCallTap: widget.onLeaveCallTap,
               )
           : null,
     );


### PR DESCRIPTION
Fixes the onLeaveCallTap callback in `StreamCallContent` that was assigned to wrong widget