### PR TITLE
fix: migrating to internet connection checker plus

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+🐞 Fixed
+* Migrated from `internet_connection_checker` to `internet_connection_checker_plus` due to [license issues](https://github.com/github/dmca/blob/master/2024/09/2024-09-04-internet-connection-checker-plus.md)
+
 ## 0.5.4
 
 🐞 Fixed

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -6,9 +6,9 @@ import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
-import 'package:internet_connection_checker/internet_connection_checker.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 
 import '../../stream_video.dart';
 import '../../version.g.dart';
@@ -830,22 +830,22 @@ class Call {
       tryFastReconnect = false;
     });
 
-    final connectionStatus = await InternetConnectionChecker.createInstance(
+    final connectionStatus = await InternetConnection.createInstance(
       checkInterval: const Duration(seconds: 1),
     )
         .onStatusChange
-        .firstWhere((status) => status == InternetConnectionStatus.connected)
+        .firstWhere((status) => status == InternetStatus.connected)
         .timeout(
       _reconnectTimeout,
       onTimeout: () {
         _logger.w(() => '[reconnect] timeout');
 
-        return InternetConnectionStatus.disconnected;
+        return InternetStatus.disconnected;
       },
     );
 
     //no internet connection after _reconnectTimeout, leave the call
-    if (connectionStatus != InternetConnectionStatus.connected) {
+    if (connectionStatus != InternetStatus.connected) {
       timer.cancel();
       await leave();
       return;

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   flutter_webrtc: ^0.11.7
   http: ^1.1.0
-  internet_connection_checker: ^2.0.0
+  internet_connection_checker_plus: ^2.5.2
   intl: ">=0.18.1 <=0.19.0"
   jose: ^0.3.4
   meta: ^1.9.1

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+🐞 Fixed
+* Migrated from `internet_connection_checker` to `internet_connection_checker_plus` due to [license issues](https://github.com/github/dmca/blob/master/2024/09/2024-09-04-internet-connection-checker-plus.md)
+
 ## 0.5.4
 
 🐞 Fixed


### PR DESCRIPTION
Due to [license issues](https://github.com/github/dmca/blob/master/2024/09/2024-09-04-internet-connection-checker-plus.md) `internet_connection_checker` version was reverted. This PR migrates to `internet_connection_checker_plus` instead.