### PR TITLE
feat(llc): Added participants count in CallState

### DIFF
--- a/dogfooding/lib/widgets/call_duration_title.dart
+++ b/dogfooding/lib/widgets/call_duration_title.dart
@@ -27,7 +27,7 @@ class _CallDurationTitleState extends State<CallDurationTitle> {
   void initState() {
     super.initState();
 
-    widget.call.get().then((value) {
+    widget.call.get(watch: false).then((value) {
       _startedAt = value.foldOrNull(
               success: (callData) =>
                   callData.data.metadata.session.startedAt ?? DateTime.now()) ??

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,28 @@
+## Unreleased
+
+This release introduces a major rework of the join/reconnect flow in the Call class to support Reconnect V2, enhancing reconnection handling across various scenarios. Most updates are within the internals of the Call class, though some changes are outward-facing, including a few breaking changes.
+
+🔄 Changed
+* `Call.reject()` method will now always call `Call.leave()` method internally.
+
+🚧 Breaking changes
+* Removed the deprecated `Call.joinLobby()` method.
+* The `maxDuration` and `maxParticipants` parameters of `Call.getOrCreate()` are now combined into the `StreamLimitsSettings? limits` parameter.
+
+🔄 Dependency updates
+* Updated Firebase dependencies to resolve Xcode 16 build issues.
+
+✅ Added
+* Added the `registerPushDevice` optional parameter (default is `true`) to the `StreamVideo.connect()` method,allowing the prevention of automatic push token registration.
+* Added `participantCount` and `anonymousParticipantCount` to `CallState` reflecting the current number of participants in the call.
+* Introduced the `watch` parameter to `Call.get()` and `Call.getOrCreate()` methods (default is `true`). When set to `true`, this enables the `Call` to listen for coordinator events and update its state accordingly, even before the call is joined (`Call.join()`).
+
+🐞 Fixed
+* Automatic push token registration by `StreamVideo` now stores registered token in `SharedPreferences`, performing an API call only when the token changes.
+* Fixed premature ringing termination issues.
+* Resolved issues where ringing would not end when the caller terminates the call in an app-terminated state.
+* Fixed issue with call not ending in some cases when only one participant is left and `dropIfAloneInRingingFlow` is set to `true`.
+
 ## 0.5.5
 
 🐞 Fixed

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -16,6 +16,7 @@ This release introduces a major rework of the join/reconnect flow in the Call cl
 * Added the `registerPushDevice` optional parameter (default is `true`) to the `StreamVideo.connect()` method,allowing the prevention of automatic push token registration.
 * Added `participantCount` and `anonymousParticipantCount` to `CallState` reflecting the current number of participants in the call.
 * Introduced the `watch` parameter to `Call.get()` and `Call.getOrCreate()` methods (default is `true`). When set to `true`, this enables the `Call` to listen for coordinator events and update its state accordingly, even before the call is joined (`Call.join()`).
+* Added support for `targetResolution` setting set on the Dashboard to determine the max resolution the video stream.
 
 🐞 Fixed
 * Automatic push token registration by `StreamVideo` now stores registered token in `SharedPreferences`, performing an API call only when the token changes.

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -466,7 +466,7 @@ class Call {
     return result;
   }
 
-  /// Rejects the incomming call.
+  /// Rejects the incoming call.
   Future<Result<None>> reject({CallRejectReason? reason}) async {
     final state = this.state.value;
     _logger.i(() => '[reject] state: $state');

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -431,7 +431,7 @@ class Call {
     }
   }
 
-  /// Accepts the incomming call.
+  /// Accepts the incoming call.
   Future<Result<None>> accept() async {
     final state = this.state.value;
     _logger.i(() => '[accept] state: $state');

--- a/packages/stream_video/lib/src/call/state/mixins/state_participant_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_participant_mixin.dart
@@ -289,4 +289,14 @@ mixin StateParticipantMixin on StateNotifier<CallState> {
       }).toList(),
     );
   }
+
+  void setParticipantsCount({
+    required int totalCount,
+    required int anonymousCount,
+  }) {
+    state = state.copyWith(
+      participantCount: totalCount,
+      anonymousParticipantCount: anonymousCount,
+    );
+  }
 }

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -41,6 +41,8 @@ class CallState extends Equatable {
       localStats: null,
       latencyHistory: const [],
       blockedUserIds: const [],
+      participantCount: 0,
+      anonymousParticipantCount: 0,
       custom: const {},
     );
   }
@@ -76,6 +78,8 @@ class CallState extends Equatable {
     required this.localStats,
     required this.latencyHistory,
     required this.blockedUserIds,
+    required this.participantCount,
+    required this.anonymousParticipantCount,
     required this.custom,
   });
 
@@ -108,6 +112,8 @@ class CallState extends Equatable {
   final LocalStats? localStats;
   final List<int> latencyHistory;
   final List<String> blockedUserIds;
+  final int participantCount;
+  final int anonymousParticipantCount;
   final Map<String, Object> custom;
 
   String get callId => callCid.id;
@@ -154,6 +160,8 @@ class CallState extends Equatable {
     LocalStats? localStats,
     List<int>? latencyHistory,
     List<String>? blockedUserIds,
+    int? participantCount,
+    int? anonymousParticipantCount,
     Map<String, Object>? custom,
   }) {
     return CallState._(
@@ -186,6 +194,9 @@ class CallState extends Equatable {
       localStats: localStats ?? this.localStats,
       latencyHistory: latencyHistory ?? this.latencyHistory,
       blockedUserIds: blockedUserIds ?? this.blockedUserIds,
+      participantCount: participantCount ?? this.participantCount,
+      anonymousParticipantCount:
+          anonymousParticipantCount ?? this.anonymousParticipantCount,
       custom: custom ?? this.custom,
     );
   }
@@ -244,6 +255,8 @@ class CallState extends Equatable {
         localStats,
         latencyHistory,
         blockedUserIds,
+        participantCount,
+        anonymousParticipantCount,
         custom,
       ];
 

--- a/packages/stream_video/lib/src/coordinator/open_api/open_api_extensions.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/open_api_extensions.dart
@@ -374,6 +374,7 @@ extension CallSessionResponseExt on open.CallSessionResponse {
       endedAt: endedAt,
       liveStartedAt: liveStartedAt,
       liveEndedAt: liveEndedAt,
+      timerEndsAt: timerEndsAt,
     );
   }
 }

--- a/packages/stream_video/lib/src/models/call_session_data.dart
+++ b/packages/stream_video/lib/src/models/call_session_data.dart
@@ -16,6 +16,7 @@ class CallSessionData with EquatableMixin {
     this.liveStartedAt,
     this.endedAt,
     this.liveEndedAt,
+    this.timerEndsAt,
   });
 
   final String id;
@@ -27,6 +28,7 @@ class CallSessionData with EquatableMixin {
   final DateTime? endedAt;
   final DateTime? liveStartedAt;
   final DateTime? liveEndedAt;
+  final DateTime? timerEndsAt;
 
   @override
   List<Object?> get props => [
@@ -35,6 +37,7 @@ class CallSessionData with EquatableMixin {
         liveStartedAt,
         liveStartedAt,
         liveEndedAt,
+        timerEndsAt,
       ];
 }
 

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -766,7 +766,7 @@ class StreamVideo extends Disposable {
       callType: callType,
       id: id,
     );
-    final callResult = await call.get();
+    final callResult = await call.get(watch: false);
 
     return callResult.fold(
       failure: (failure) {

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,13 +1,27 @@
 ## Unreleased
 
+This release introduces a major rework of the join/reconnect flow in the Call class to support Reconnect V2, enhancing reconnection handling across various scenarios. Most updates are within the internals of the Call class, though some changes are outward-facing, including a few breaking changes.
+
+🔄 Changed
+* `Call.reject()` method will now always call `Call.leave()` method internally.
+
+🚧 Breaking changes
+* Removed the deprecated `Call.joinLobby()` method.
+* The `maxDuration` and `maxParticipants` parameters of `Call.getOrCreate()` are now combined into the `StreamLimitsSettings? limits` parameter.
+
 🔄 Dependency updates
-* Updated firebase dependencies to fix Xcode 16 build issues
+* Updated Firebase dependencies to resolve Xcode 16 build issues.
 
 ✅ Added
-* Added `registerPushDevice` optional parameter (default as true) to `StreamVideo.connect()` method that can prevent automatic push token registration.
+* Added the `registerPushDevice` optional parameter (default is `true`) to the `StreamVideo.connect()` method,allowing the prevention of automatic push token registration.
+* Added `participantCount` and `anonymousParticipantCount` to `CallState` reflecting the current number of participants in the call.
+* Introduced the `watch` parameter to `Call.get()` and `Call.getOrCreate()` methods (default is `true`). When set to `true`, this enables the `Call` to listen for coordinator events and update its state accordingly, even before the call is joined (`Call.join()`).
 
 🐞 Fixed
-* Automatic push token registration done by `StreamVideo` now stores registered token in `SharedPreferences` and will now only perform API call when token changes.
+* Automatic push token registration by `StreamVideo` now stores registered token in `SharedPreferences`, performing an API call only when the token changes.
+* Fixed premature ringing termination issues.
+* Resolved issues where ringing would not end when the caller terminates the call in an app-terminated state.
+* Fixed issue with call not ending in some cases when only one participant is left and `dropIfAloneInRingingFlow` is set to `true`.
 
 ## 0.5.5
 

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -16,6 +16,7 @@ This release introduces a major rework of the join/reconnect flow in the Call cl
 * Added the `registerPushDevice` optional parameter (default is `true`) to the `StreamVideo.connect()` method,allowing the prevention of automatic push token registration.
 * Added `participantCount` and `anonymousParticipantCount` to `CallState` reflecting the current number of participants in the call.
 * Introduced the `watch` parameter to `Call.get()` and `Call.getOrCreate()` methods (default is `true`). When set to `true`, this enables the `Call` to listen for coordinator events and update its state accordingly, even before the call is joined (`Call.join()`).
+* Added support for `targetResolution` setting set on the Dashboard to determine the max resolution the video stream.
 
 🐞 Fixed
 * Automatic push token registration by `StreamVideo` now stores registered token in `SharedPreferences`, performing an API call only when the token changes.


### PR DESCRIPTION
**Overview**

Handlers for the `call.session_participant_count_updated` event.
The Coordinator will occasionally deliver this event to all clients, and it will carry the most recent state of:

`anonymous_participant_count` and `participant_count_by_role`

**Implementation notes**

`watch` parameter is now added to `Call.get()` and `Call.getOrCreate()` methods. When set to `true` the coordinator events will be listened to even before joining the call.

The `CallState` is extended with `participantCount` and `anonymousParticipantCount` fields.
This values from the `call.session_participant_count_updated` event are used to update those fields but only when the call status isn't JOINED. Once the call is JOINED, these values will be populated from the SFU heart checks.