### PR TITLE
fix(Android): Added method to ensure lock screen permission on Android

### DIFF
--- a/dogfooding/lib/screens/home_screen.dart
+++ b/dogfooding/lib/screens/home_screen.dart
@@ -13,6 +13,7 @@ import 'package:flutter_dogfooding/widgets/stream_button.dart';
 import 'package:stream_video_flutter/stream_video_flutter.dart';
 import 'package:stream_video_flutter/stream_video_flutter_background.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:stream_video_push_notification/stream_video_push_notification.dart';
 
 import '../app/user_auth_controller.dart';
 import '../di/injector.dart';
@@ -42,6 +43,8 @@ class _HomeScreenState extends State<HomeScreen> {
       Permission.camera,
       Permission.microphone,
     ].request();
+
+    StreamVideoPushNotificationManager.ensureFullIntentPermission();
 
     StreamBackgroundService.init(
       StreamVideo.instance,

--- a/dogfooding/lib/screens/home_screen.dart
+++ b/dogfooding/lib/screens/home_screen.dart
@@ -44,7 +44,7 @@ class _HomeScreenState extends State<HomeScreen> {
       Permission.microphone,
     ].request();
 
-    StreamVideoPushNotificationManager.ensureFullIntentPermission();
+    StreamVideoPushNotificationManager.ensureFullScreenIntentPermission();
 
     StreamBackgroundService.init(
       StreamVideo.instance,

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ✅ Added
 * Added the 'call.collectUserFeedback()' method which allows users to send call quality rating. These ratings are visible on the Dashboard and are aggregated in call stats for easy tracking. For a sample implementation, please refer to the [cookbook](https://getstream.io/video/docs/flutter/ui-cookbook/call-quality-rating/).
+* Added device thermal status reporting to better optimize call quality.
 
 ## 0.6.0
 

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -3,7 +3,7 @@
 ✅ Added
 * Added the 'call.collectUserFeedback()' method which allows users to send call quality rating. These ratings are visible on the Dashboard and are aggregated in call stats for easy tracking. For a sample implementation, please refer to the [cookbook](https://getstream.io/video/docs/flutter/ui-cookbook/call-quality-rating/).
 * Added device thermal status reporting to better optimize call quality.
-* Added the `StreamVideoPushNotificationManager.ensureFullIntentPermission()` method. This resolves an issue on some Android 14 devices where full-screen notifications would not appear due to missing permissions.
+* Added the `StreamVideoPushNotificationManager.ensureFullScreenIntentPermission()` method. This resolves an issue on some Android 14 devices where full-screen notifications would not appear due to missing permissions.
 You can now invoke this method to show a settings screen, allowing users to enable the required permission if it's not already enabled.
 
 🐞 Fixed

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ✅ Added
 * Added the 'call.collectUserFeedback()' method which allows users to send call quality rating. These ratings are visible on the Dashboard and are aggregated in call stats for easy tracking. For a sample implementation, please refer to the [cookbook](https://getstream.io/video/docs/flutter/ui-cookbook/call-quality-rating/).
+* Added device thermal status reporting to better optimize call quality.
+* Added the `StreamVideoPushNotificationManager.ensureFullIntentPermission()` method. This resolves an issue on some Android 14 devices where full-screen notifications would not appear due to missing permissions.
+You can now invoke this method to show a settings screen, allowing users to enable the required permission if it's not already enabled.
+
+🐞 Fixed
+* Resolved an issue where CallKit calls would not connect when accepted while the screen was locked.
+* Fixed a bug where the Android foreground service would not stop when the app was killed, keeping the call connection active.
 
 ## 0.6.0
 

--- a/packages/stream_video_push_notification/.metadata
+++ b/packages/stream_video_push_notification/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "2f708eb8396e362e280fac22cf171c2cb467343c"
+  revision: "2663184aa79047d0a33a14a3b607954f8fdd8730"
   channel: "stable"
 
 project_type: plugin
@@ -13,11 +13,14 @@ project_type: plugin
 migration:
   platforms:
     - platform: root
-      create_revision: 2f708eb8396e362e280fac22cf171c2cb467343c
-      base_revision: 2f708eb8396e362e280fac22cf171c2cb467343c
+      create_revision: 2663184aa79047d0a33a14a3b607954f8fdd8730
+      base_revision: 2663184aa79047d0a33a14a3b607954f8fdd8730
+    - platform: android
+      create_revision: 2663184aa79047d0a33a14a3b607954f8fdd8730
+      base_revision: 2663184aa79047d0a33a14a3b607954f8fdd8730
     - platform: ios
-      create_revision: 2f708eb8396e362e280fac22cf171c2cb467343c
-      base_revision: 2f708eb8396e362e280fac22cf171c2cb467343c
+      create_revision: 2663184aa79047d0a33a14a3b607954f8fdd8730
+      base_revision: 2663184aa79047d0a33a14a3b607954f8fdd8730
 
   # User provided section
 

--- a/packages/stream_video_push_notification/CHANGELOG.md
+++ b/packages/stream_video_push_notification/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ✅ Added
-* Added the `StreamVideoPushNotificationManager.ensureFullIntentPermission()` method. This resolves an issue on some Android 14 devices where full-screen notifications would not appear due to missing permissions.
+* Added the `StreamVideoPushNotificationManager.ensureFullScreenIntentPermission()` method. This resolves an issue on some Android 14 devices where full-screen notifications would not appear due to missing permissions.
 You can now invoke this method to show a settings screen, allowing users to enable the required permission if it's not already enabled.
 
 🐞 Fixed

--- a/packages/stream_video_push_notification/CHANGELOG.md
+++ b/packages/stream_video_push_notification/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+✅ Added
+* Added the `StreamVideoPushNotificationManager.ensureFullIntentPermission()` method. This resolves an issue on some Android 14 devices where full-screen notifications would not appear due to missing permissions.
+You can now invoke this method to show a settings screen, allowing users to enable the required permission if it's not already enabled.
+
+🐞 Fixed
+* Resolved an issue where CallKit calls would not connect when accepted while the screen was locked.
+
 ## 0.6.0
 
 🔄 Dependency updates

--- a/packages/stream_video_push_notification/android/.gitignore
+++ b/packages/stream_video_push_notification/android/.gitignore
@@ -1,0 +1,9 @@
+*.iml
+.gradle
+/local.properties
+/.idea/workspace.xml
+/.idea/libraries
+.DS_Store
+/build
+/captures
+.cxx

--- a/packages/stream_video_push_notification/android/build.gradle
+++ b/packages/stream_video_push_notification/android/build.gradle
@@ -1,0 +1,65 @@
+buildscript {
+    ext.kotlin_version = "1.9.10"
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+
+android {
+    if (project.android.hasProperty("namespace")) {
+        namespace = "com.example.stream_video_push_notification"
+    }
+
+    compileSdk = 34
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+
+    sourceSets {
+        main.java.srcDirs += "src/main/kotlin"
+        test.java.srcDirs += "src/test/kotlin"
+    }
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    dependencies {
+        testImplementation("org.jetbrains.kotlin:kotlin-test")
+        testImplementation("org.mockito:mockito-core:5.0.0")
+    }
+
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+
+            testLogging {
+               events "passed", "skipped", "failed", "standardOut", "standardError"
+               outputs.upToDateWhen {false}
+               showStandardStreams = true
+            }
+        }
+    }
+}

--- a/packages/stream_video_push_notification/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/stream_video_push_notification/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+networkTimeout=10000
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/packages/stream_video_push_notification/android/settings.gradle
+++ b/packages/stream_video_push_notification/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'stream_video_push_notification'

--- a/packages/stream_video_push_notification/android/src/main/AndroidManifest.xml
+++ b/packages/stream_video_push_notification/android/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.example.stream_video_push_notification">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+</manifest>

--- a/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/StreamVideoPushNotificationPlugin.kt
+++ b/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/StreamVideoPushNotificationPlugin.kt
@@ -31,7 +31,7 @@ class StreamVideoPushNotificationPlugin: FlutterPlugin, MethodCallHandler, Activ
   }
 
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-    if (call.method == "ensureFullIntentPermission") {
+    if (call.method == "ensureFullScreenIntentPermission") {
       val notificationManager = context?.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
       if (Build.VERSION.SDK_INT >= 34) {
         if (!notificationManager.canUseFullScreenIntent()) {

--- a/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/StreamVideoPushNotificationPlugin.kt
+++ b/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/StreamVideoPushNotificationPlugin.kt
@@ -1,0 +1,66 @@
+package io.getstream.video.flutter.stream_video_push_notification
+
+import android.app.Activity
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import com.hiennv.flutter_callkit_incoming.CallkitNotificationManager
+
+/** StreamVideoPushNotificationPlugin */
+class StreamVideoPushNotificationPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
+  private lateinit var channel : MethodChannel
+  private var activity: Activity? = null
+  private var context: Context? = null
+  private lateinit var callkitNotificationManager: CallkitNotificationManager
+
+  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+    context = flutterPluginBinding.applicationContext
+
+    channel = MethodChannel(flutterPluginBinding.binaryMessenger, "stream_video_push_notification")
+    channel.setMethodCallHandler(this)
+
+    callkitNotificationManager = CallkitNotificationManager(flutterPluginBinding.applicationContext)
+  }
+
+  override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+    if (call.method == "ensureFullIntentPermission") {
+      val notificationManager = context?.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      if (Build.VERSION.SDK_INT >= 34) {
+        if (!notificationManager.canUseFullScreenIntent()) {
+          callkitNotificationManager?.requestFullIntentPermission(activity)
+        }
+      }
+      result.success(true)
+    } else {
+      result.notImplemented()
+    }
+  }
+
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    channel.setMethodCallHandler(null)
+  }
+
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    activity = binding.activity
+  }
+
+  override fun onDetachedFromActivityForConfigChanges() {
+    activity = null
+  }
+
+  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+    activity = binding.activity
+  }
+
+  override fun onDetachedFromActivity() {
+    activity = null
+  }
+}

--- a/packages/stream_video_push_notification/ios/Classes/StreamVideoPushNotificationPlugin.swift
+++ b/packages/stream_video_push_notification/ios/Classes/StreamVideoPushNotificationPlugin.swift
@@ -6,7 +6,7 @@ public class StreamVideoPushNotificationPlugin: NSObject, FlutterPlugin {
     let persistentState: UserDefaults = UserDefaults.standard
     
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let mainChannel = FlutterMethodChannel(name: "stream_video_push_notifications", binaryMessenger: registrar.messenger())
+        let mainChannel = FlutterMethodChannel(name: "stream_video_push_notification", binaryMessenger: registrar.messenger())
         let instance = StreamVideoPushNotificationPlugin()
         
         registrar.addMethodCallDelegate(instance, channel: mainChannel)

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
@@ -418,9 +418,9 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
     _subscriptions.cancelAll();
   }
 
-  static Future ensureFullIntentPermission() {
+  static Future ensureFullScreenIntentPermission() {
     return StreamVideoPushNotificationPlatform.instance
-        .ensureFullIntentPermission();
+        .ensureFullScreenIntentPermission();
   }
 }
 

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
@@ -417,6 +417,11 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
   Future<void> dispose() async {
     _subscriptions.cancelAll();
   }
+
+  static Future ensureFullIntentPermission() {
+    return StreamVideoPushNotificationPlatform.instance
+        .ensureFullIntentPermission();
+  }
 }
 
 const _defaultPushParams = StreamVideoPushParams(

--- a/packages/stream_video_push_notification/lib/stream_video_push_notification_method_channel.dart
+++ b/packages/stream_video_push_notification/lib/stream_video_push_notification_method_channel.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:stream_video/stream_video.dart';
 
 import 'stream_video_push_notification_platform_interface.dart';
 
@@ -11,7 +12,7 @@ class MethodChannelStreamVideoPushNotification
     extends StreamVideoPushNotificationPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
-  final methodChannel = const MethodChannel('stream_video_push_notifications');
+  final methodChannel = const MethodChannel('stream_video_push_notification');
 
   CallerCustomizationFunction? callerCustomizationCallback;
 
@@ -50,5 +51,12 @@ class MethodChannelStreamVideoPushNotification
       pushParams['callbackHandler'] = backgroundCallback?.toRawHandle();
     }
     await methodChannel.invokeMethod<String>('initData', pushParams);
+  }
+
+  @override
+  Future<void> ensureFullIntentPermission() async {
+    if (!CurrentPlatform.isAndroid) return;
+
+    await methodChannel.invokeMethod<void>('ensureFullIntentPermission');
   }
 }

--- a/packages/stream_video_push_notification/lib/stream_video_push_notification_method_channel.dart
+++ b/packages/stream_video_push_notification/lib/stream_video_push_notification_method_channel.dart
@@ -54,9 +54,9 @@ class MethodChannelStreamVideoPushNotification
   }
 
   @override
-  Future<void> ensureFullIntentPermission() async {
+  Future<void> ensureFullScreenIntentPermission() async {
     if (!CurrentPlatform.isAndroid) return;
 
-    await methodChannel.invokeMethod<void>('ensureFullIntentPermission');
+    await methodChannel.invokeMethod<void>('ensureFullScreenIntentPermission');
   }
 }

--- a/packages/stream_video_push_notification/lib/stream_video_push_notification_platform_interface.dart
+++ b/packages/stream_video_push_notification/lib/stream_video_push_notification_platform_interface.dart
@@ -54,8 +54,8 @@ abstract class StreamVideoPushNotificationPlatform extends PlatformInterface {
     throw UnimplementedError('init() has not been implemented.');
   }
 
-  Future<void> ensureFullIntentPermission() {
+  Future<void> ensureFullScreenIntentPermission() {
     throw UnimplementedError(
-        'ensureFullIntentPermission() has not been implemented.');
+        'ensureFullScreenIntentPermission() has not been implemented.');
   }
 }

--- a/packages/stream_video_push_notification/lib/stream_video_push_notification_platform_interface.dart
+++ b/packages/stream_video_push_notification/lib/stream_video_push_notification_platform_interface.dart
@@ -51,6 +51,11 @@ abstract class StreamVideoPushNotificationPlatform extends PlatformInterface {
     CallerCustomizationFunction? callerCustomizationCallback,
     BackgroundVoipCallHandler? backgroundVoipCallHandler,
   ) {
-    throw UnimplementedError('platformVersion() has not been implemented.');
+    throw UnimplementedError('init() has not been implemented.');
+  }
+
+  Future<void> ensureFullIntentPermission() {
+    throw UnimplementedError(
+        'ensureFullIntentPermission() has not been implemented.');
   }
 }

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_webrtc: ^0.11.7
-  flutter_callkit_incoming: ^2.0.4+1
+  flutter_callkit_incoming: ^2.0.4+2
   json_annotation: ^4.9.0
   meta: ^1.9.1
   plugin_platform_interface: ^2.1.8
@@ -25,7 +25,7 @@ dependencies:
   stream_video: ^0.6.0
   uuid: ^4.2.1
   shared_preferences: ^2.3.2
-  
+
 dev_dependencies:
   build_runner: ^2.4.4
   flutter_lints: ^2.0.2
@@ -50,7 +50,8 @@ flutter:
       ios:
         pluginClass: StreamVideoPushNotificationPlugin
       android:
-        default_package: stream_video_push_notification
+        package: io.getstream.video.flutter.stream_video_push_notification
+        pluginClass: StreamVideoPushNotificationPlugin
 
 topics:
   - video


### PR DESCRIPTION
With the Android 14, the handling of full-screen notification permissions [has changed](https://source.android.com/docs/core/permissions/fsi-limits#:~:text=To%20prevent%20ad%20spam%20and,provide%20calling%20and%20alarm%20functionalities). To improve this within our SDK, we've introduced a `StreamVideoPushNotificationManager.ensureFullIntentPermission()` method. This method checks whether the necessary permission is granted. If the permission is not granted, it will direct the user to the settings page where they can enable it.