### PR TITLE
chore: AGP 8 compatibility

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FLUTTER_VERSION: "3.24.3"
+  FLUTTER_VERSION: "3.27.1"
   FLUTTER_CHANNEL: stable
   ENV_PROPERTIES: ${{ secrets.ENV_PROPERTIES }}
   MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/dogfooding/android/app/build.gradle
+++ b/dogfooding/android/app/build.gradle
@@ -1,3 +1,10 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "com.google.gms.google-services"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
 if (keystorePropertiesFile.exists()) {
@@ -26,13 +33,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-// START: FlutterFire Configuration
-apply plugin: 'com.google.gms.google-services'
-// END: FlutterFire Configuration
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -100,6 +100,5 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:multidex:1.0.3'
 }

--- a/dogfooding/android/app/src/debug/AndroidManifest.xml
+++ b/dogfooding/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.getstream.video.flutter.dogfooding">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/dogfooding/android/app/src/main/AndroidManifest.xml
+++ b/dogfooding/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.getstream.video.flutter.dogfooding">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-feature android:name="android.hardware.camera"/>

--- a/dogfooding/android/app/src/profile/AndroidManifest.xml
+++ b/dogfooding/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.getstream.video.flutter.dogfooding">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/dogfooding/android/build.gradle
+++ b/dogfooding/android/build.gradle
@@ -1,19 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
-        // START: FlutterFire Configuration
-        classpath 'com.google.gms:google-services:4.3.14'
-        // END: FlutterFire Configuration
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/dogfooding/android/settings.gradle
+++ b/dogfooding/android/settings.gradle
@@ -1,11 +1,26 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.3.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "com.google.gms.google-services" version "4.4.0" apply false
+}
+
+include ":app"

--- a/dogfooding/pubspec.yaml
+++ b/dogfooding/pubspec.yaml
@@ -13,10 +13,10 @@ dependencies:
   cupertino_icons: ^1.0.8
   device_info_plus: ^10.1.2
   envied: ^0.5.4+1
-  firebase_auth: ^5.3.1
-  firebase_core: ^3.6.0
-  firebase_crashlytics: ^4.1.3
-  firebase_messaging: ^15.1.3
+  firebase_auth: ^5.3.4
+  firebase_core: ^3.9.0
+  firebase_crashlytics: ^4.2.0
+  firebase_messaging: ^15.1.6
   fl_chart: ^0.69.0
   flutter:
     sdk: flutter
@@ -33,7 +33,7 @@ dependencies:
   rxdart: ^0.28.0
   share_plus: ^10.0.2
   shared_preferences: ^2.3.2
-  stream_chat_flutter: ^8.1.0
+  stream_chat_flutter: ^9.0.0
   stream_video_flutter: ^0.6.1
   stream_video_push_notification: ^0.6.1
   stream_video_screen_sharing: ^0.6.1

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased 
+
+🚧 Breaking changes
+
+* The package is now compatible with Gradle 8. The minimum required Java version is now 17.
+
 ## 0.6.1
 
 * Updated minimum Flutter version to 3.24.5

--- a/packages/stream_video/lib/src/coordinator/open_api/open_api_extensions.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/open_api_extensions.dart
@@ -450,6 +450,6 @@ extension DeviceExt on open.Device {
 
 extension DeviceListExt on List<open.Device> {
   List<PushDevice> toPushDevices() {
-    return map((it) => it.toPushDevice()).whereNotNull().toList();
+    return map((it) => it.toPushDevice()).nonNulls.toList();
   }
 }

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   synchronized: ^3.1.0
   system_info2: ^4.0.0
   tart: ^0.5.1
-  thermal: ^1.1.8
+  thermal: ^1.1.10
   uuid: ^4.2.1
   web: ^1.0.0
   web_socket_channel: ^3.0.1

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased 
+
+🚧 Breaking changes
+
+* The package is now compatible with Gradle 8. The minimum required Java version is now 17.
+* Updated the `flutter_callkit_incoming` package to version 2.5.0, which also requires Java 17.
+
 ## 0.6.1
 
 * Updated minimum Flutter version to 3.24.5

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Updated minimum Flutter version to 3.24.5
 
 ✅ Added
-* Added the 'call.collectUserFeedback()' method which allows users to send call quality rating. These ratings are visible on the Dashboard and are aggregated in call stats for easy tracking. For a sample implementation, please refer to the [cookbook](https://getstream.io/video/docs/flutter/ui-cookbook/call-quality-rating/).
+* Added the `call.collectUserFeedback()` method which allows users to send call quality rating. These ratings are visible on the Dashboard and are aggregated in call stats for easy tracking. For a sample implementation, please refer to the [documentation](https://getstream.io/video/docs/flutter/user-rating/).
 * Added device thermal status reporting to better optimize call quality.
 * Added the `StreamVideoPushNotificationManager.ensureFullScreenIntentPermission()` method. This resolves an issue on some Android 14 devices where full-screen notifications would not appear due to missing permissions.
 You can now invoke this method to show a settings screen, allowing users to enable the required permission if it's not already enabled.

--- a/packages/stream_video_flutter/android/build.gradle
+++ b/packages/stream_video_flutter/android/build.gradle
@@ -1,17 +1,6 @@
-group 'io.getstream.video.flutter.stream_video_flutter'
-version '1.0-SNAPSHOT'
-
-buildscript {
-    ext.kotlin_version = '1.9.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+plugins {
+    id "com.android.library"
+    id "kotlin-android"
 }
 
 allprojects {
@@ -20,9 +9,6 @@ allprojects {
         mavenCentral()
     }
 }
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     if (project.android.hasProperty("namespace")) {

--- a/packages/stream_video_flutter/android/settings.gradle
+++ b/packages/stream_video_flutter/android/settings.gradle
@@ -1,1 +1,27 @@
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.library" version "7.3.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+}
+
+include ":app"
+
 rootProject.name = 'stream_video_flutter'

--- a/packages/stream_video_flutter/android/src/main/AndroidManifest.xml
+++ b/packages/stream_video_flutter/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.getstream.video.flutter.stream_video_flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />

--- a/packages/stream_video_flutter/example/android/app/build.gradle
+++ b/packages/stream_video_flutter/example/android/app/build.gradle
@@ -29,10 +29,16 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace = "io.getstream.video.flutter.dogfooding"
+    }
+
     compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
+        //Required by flutter_local_notifications
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -70,6 +76,8 @@ flutter {
 }
 
 dependencies {
+    //Required by flutter_local_notifications
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'io.getstream:stream-log:1.1.3'
 }

--- a/packages/stream_video_flutter/example/android/app/src/debug/AndroidManifest.xml
+++ b/packages/stream_video_flutter/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.getstream.video.flutter.dogfooding">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/packages/stream_video_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/stream_video_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.getstream.video.flutter.dogfooding">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-feature android:name="android.hardware.camera"/>

--- a/packages/stream_video_flutter/example/android/app/src/profile/AndroidManifest.xml
+++ b/packages/stream_video_flutter/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
@@ -205,7 +205,7 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
 
     final participants = _participants
         .map((it) => _users[it.userId])
-        .whereNotNull()
+        .nonNulls
         .map((e) => e.toUserInfo())
         .toList();
     return Scaffold(

--- a/packages/stream_video_push_notification/CHANGELOG.md
+++ b/packages/stream_video_push_notification/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased 
+
+🚧 Breaking changes
+
+* The package is now compatible with Gradle 8. The minimum required Java version is now 17.
+* Updated the `flutter_callkit_incoming` package to version 2.5.0, which also requires Java 17.
+
 ## 0.6.1
 
 * Updated minimum Flutter version to 3.24.5

--- a/packages/stream_video_push_notification/android/build.gradle
+++ b/packages/stream_video_push_notification/android/build.gradle
@@ -1,14 +1,6 @@
-buildscript {
-    ext.kotlin_version = "1.9.10"
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:7.3.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-    }
+plugins {
+    id "com.android.library"
+    id "kotlin-android"
 }
 
 allprojects {
@@ -17,9 +9,6 @@ allprojects {
         mavenCentral()
     }
 }
-
-apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 
 android {
     if (project.android.hasProperty("namespace")) {

--- a/packages/stream_video_push_notification/android/settings.gradle
+++ b/packages/stream_video_push_notification/android/settings.gradle
@@ -1,1 +1,27 @@
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.library" version "7.3.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+}
+
+include ":app"
+
 rootProject.name = 'stream_video_push_notification'

--- a/packages/stream_video_push_notification/android/src/main/AndroidManifest.xml
+++ b/packages/stream_video_push_notification/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.stream_video_push_notification">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 </manifest>

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_webrtc: ^0.11.7
-  flutter_callkit_incoming: ^2.0.4+2
+  flutter_callkit_incoming: ^2.5.0
   json_annotation: ^4.9.0
   meta: ^1.9.1
   plugin_platform_interface: ^2.1.8


### PR DESCRIPTION
This pull request includes several updates to the Android build configurations and dependency versions across multiple files. The main changes involve migrating from the old `buildscript` and `apply plugin` syntax to the newer `plugins` block, as well as updating various dependencies to their latest versions.

### Build Configuration Updates:
* Migrated from `buildscript` and `apply plugin` to the `plugins` block in `dogfooding/android/app/build.gradle`, `packages/stream_video_flutter/android/build.gradle`, and `packages/stream_video_push_notification/android/build.gradle`. [[1]](diffhunk://#diff-2bdca7b22f85732560d4b82ccb49917660228cb55b19c7cf6f7cd260e8f0f9abR1-R7) [[2]](diffhunk://#diff-1c766d3332acba1026fde7a540d0ea0243cd378d90808774dafb4d46bc3ac73cL1-R3) [[3]](diffhunk://#diff-c5cb84595dd74b31e94c452a63bf5ab348c5575e7cadb1bae5536b379566990dL1-R3)
* Updated `settings.gradle` files to include Flutter plugin management and repository configurations. [[1]](diffhunk://#diff-d60951a2fb0a8ea4c2f332cd1fe48c696d35b81e030b61dc3d261adb8cc38999L1-R26) [[2]](diffhunk://#diff-d8938c399016494159b22765feb3d950b0200c7b6804b313ee871933dc3a8a9cR1-R26) [[3]](diffhunk://#diff-e9c14f91434b91e9d3dd2c83265f9b526088c3a004d79dfffeca7d4223f04e25R1-R26)

### Dependency Updates:
* Updated Firebase and other dependencies in `dogfooding/pubspec.yaml` to their latest versions. [[1]](diffhunk://#diff-a612dd00cba4c1c817a45d3fe36e5b23dbe0988416828e52d2a1faa25155f3ebL16-R19) [[2]](diffhunk://#diff-a612dd00cba4c1c817a45d3fe36e5b23dbe0988416828e52d2a1faa25155f3ebL36-R36)
* Updated the `thermal` dependency in `packages/stream_video/pubspec.yaml`.

### Code Simplification:
* Replaced `whereNotNull()` with `nonNulls` in `open_api_extensions.dart` and `lobby_view.dart`. [[1]](diffhunk://#diff-4dbade20eac833811012163af79bc84ba3ae703906c88584e9a1ff5cf30f2c79L453-R453) [[2]](diffhunk://#diff-a483052e3c4eeabd9e5b4a728801b85d6cc5af076be4daecb51d3b7be718a760L208-R208)

### Manifest File Updates:
* Removed the `package` attribute from various `AndroidManifest.xml` files to simplify the manifest structure. [[1]](diffhunk://#diff-4dc5fd4708b1aedd8a3cfe307a1bd35fcd9324e9ccebbb4d6ef328bff0f1a554L1-R1) [[2]](diffhunk://#diff-f9f28b99f627f3434d60ed343602e49ff02d02395fd297c5f377c75322f791bbL1-R1) [[3]](diffhunk://#diff-4dc5fd4708b1aedd8a3cfe307a1bd35fcd9324e9ccebbb4d6ef328bff0f1a554L1-R1) [[4]](diffhunk://#diff-f50ae25b23779599b085661a1467bcc7e37af504413888d2cad21f30744aacf3L1-R1) [[5]](diffhunk://#diff-5b8d9920951a24e8922d3b583843f4c9bc855d6cc1fdfd39af773a5f5d5d5a1bL1-R1) [[6]](diffhunk://#diff-c87d2b730a6ce1f8672b552842cd7908c277264aa5221651511cbce3db9c28e9L1-R1) [[7]](diffhunk://#diff-63c2bd59471e0b6a8996ac7063bd00fc9ecdf705732ff3673a08fe346f43ac05L1-R1)