### PR TITLE
fix(Android): fixes ending the call when in PiP

### DIFF
--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## Unreleased 
 
 🚧 Breaking changes
-* The package is now compatible with Gradle 8. The minimum required Java version is now 17.
-* Updated the `flutter_callkit_incoming` package to version 2.5.0, which also requires Java 17.
+* https://github.com/GetStream/stream-video-flutter/pull/820: The package is now compatible with Gradle 8. The minimum required Java version is now 17.
+* https://github.com/GetStream/stream-video-flutter/pull/820: Updated the `flutter_callkit_incoming` package to version 2.5.0, which also requires Java 17.
 
 ✅ Added
-* Added out-of-the-box support for blur background filters and image filters. As well as the option to create custom video filters. For complete documentation of those features please check [here.](https://getstream.io/video/docs/flutter/advanced/apply-video-filters/)
+* https://github.com/GetStream/stream-video-flutter/pull/799: Added out-of-the-box support for blur background filters and image filters. As well as the option to create custom video filters. For complete documentation of those features please check [here.](https://getstream.io/video/docs/flutter/advanced/apply-video-filters/)
+
+🐞 Fixed
+* https://github.com/GetStream/stream-video-flutter/pull/822: Fixed issues when ending the call while in Picture in Picture mode on Android. 
 
 ## 0.6.1
 

--- a/packages/stream_video_flutter/android/build.gradle
+++ b/packages/stream_video_flutter/android/build.gradle
@@ -44,7 +44,6 @@ android {
         implementation 'androidx.media:media:1.1.0'
         implementation 'androidx.appcompat:appcompat:1.1.0'
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
-        implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
         implementation "io.github.crow-misia.libyuv:libyuv-android:0.34.0"
         implementation "androidx.annotation:annotation:1.8.0"
         implementation 'com.google.mlkit:segmentation-selfie:16.0.0-beta5'

--- a/packages/stream_video_flutter/android/src/main/kotlin/io/getstream/video/flutter/stream_video_flutter/service/PictureInPictureHelper.kt
+++ b/packages/stream_video_flutter/android/src/main/kotlin/io/getstream/video/flutter/stream_video_flutter/service/PictureInPictureHelper.kt
@@ -13,7 +13,11 @@ class PictureInPictureHelper {
         const val PIP_ENABLED_PREF_KEY = "pip_enabled"
 
         fun disablePictureInPicture(activity: Activity) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                if (activity.isInPictureInPictureMode) {
+                    activity.moveTaskToBack(true) 
+                }
+
                 val params = PictureInPictureParams.Builder()
                 params.setAutoEnterEnabled(false)
                 activity.setPictureInPictureParams(params.build())

--- a/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
@@ -148,7 +148,8 @@ class _StreamCallParticipantsState extends State<StreamCallParticipants> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.layoutMode == ParticipantLayoutMode.pictureInPicture) {
+    if (_participants.isNotEmpty &&
+        widget.layoutMode == ParticipantLayoutMode.pictureInPicture) {
       return widget.callParticipantBuilder(
         context,
         widget.call,

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
@@ -112,6 +112,12 @@ class _StreamCallContentState extends State<StreamCallContent>
         WidgetsBinding.instance.removeObserver(this);
       }
     }
+
+    if (widget.callState.status != oldWidget.callState.status) {
+      if (widget.callState.status.isDisconnected) {
+        StreamVideoFlutterBackground.setPictureInPictureEnabled(enable: false);
+      }
+    }
   }
 
   @override


### PR DESCRIPTION
This pull request fixes the issues when ending the call while in Picture in Picture mode on Android. 

[`1`](diffhunk://#diff-d66727e797be3b1f71ebbf31fa6e48289f842aa4dacc106e1656a78a908ee39fL16-R20): Updated the `disablePictureInPicture` method to move the task to the back if the activity is in PiP mode.

[`2`](diffhunk://#diff-49f2b4ac60d9a3cd759f431e56e279e154389381085410130f697ee11027694bL151-R152): Added a check to ensure `_participants` is not empty before proceeding with the PiP layout mode.

[`3`](diffhunk://#diff-b5f5d4597cbc725270b58888c9f4b3dc1dae2958ab5490f014504ac0469fb29dR115-R120): Added logic to disable PiP mode when the call state status changes to disconnected.