### PR TITLE
fix(stream_video): ensure thermal and battery_plus methods are only called on available platforms on sfu stats reporter

### DIFF
--- a/packages/stream_video/lib/src/call/sfu_stats_reporter.dart
+++ b/packages/stream_video/lib/src/call/sfu_stats_reporter.dart
@@ -21,10 +21,14 @@ class SfuStatsReporter {
     required this.callSession,
     required this.stateManager,
   }) {
-    _thermalStatusSubscription =
-        Thermal().onThermalStatusChanged.listen((ThermalStatus status) {
-      _thermalStatus = status;
-    });
+    final thermalStatusAvailable =
+        CurrentPlatform.isAndroid || CurrentPlatform.isIos;
+    if (thermalStatusAvailable) {
+      _thermalStatusSubscription =
+          Thermal().onThermalStatusChanged.listen((ThermalStatus status) {
+        _thermalStatus = status;
+      });
+    }
 
     _mediaDeviceSubscription =
         RtcMediaDeviceNotifier.instance.onDeviceChange.listen(
@@ -74,7 +78,12 @@ class SfuStatsReporter {
       return;
     }
 
-    final lowPowerMode = await Battery().isInBatterySaveMode;
+    final batterySaveModeAvailable = CurrentPlatform.isAndroid ||
+        CurrentPlatform.isIos ||
+        CurrentPlatform.isMacOS ||
+        CurrentPlatform.isWindows;
+    final lowPowerMode =
+        batterySaveModeAvailable && await Battery().isInBatterySaveMode;
 
     sfu_models.AndroidState? androidState;
     sfu_models.AppleState? appleState;


### PR DESCRIPTION
### 🎯 Goal

The changes made on stream_video, specifically on the file sfu_stats_reporter.dart, avoid two unhandled exceptions on the web implementation of the package, due to methods from thermal and battery_plus that were being called on web and are not implemented in those platforms. The problem is best described on #836.

### 🛠 Implementation details

The fix was implemented by checking if the platform the code is running supports the methods that would be called, `isInBatterySaveMode()` and `getThermalStatus()`.

### 🎨 UI Changes

None.

### 🧪 Testing

The change can be tested by first running the package on web and verifying the error, before the PR, and running the same thing with the fixed code from this PR.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
