### PR TITLE
fix(CallKit): fix for missing app icon in CallKit screen when app is terminated

### DIFF
--- a/packages/stream_video_push_notification/ios/Classes/StreamVideoPKDelegateManager.swift
+++ b/packages/stream_video_push_notification/ios/Classes/StreamVideoPKDelegateManager.swift
@@ -1,68 +1,79 @@
+import Flutter
 import Foundation
 import PushKit
-import Flutter
 import flutter_callkit_incoming
 
-public class StreamVideoPKDelegateManager: NSObject, PKPushRegistryDelegate, UNUserNotificationCenterDelegate {
+public class StreamVideoPKDelegateManager: NSObject, PKPushRegistryDelegate,
+    UNUserNotificationCenterDelegate
+{
     public static let shared = StreamVideoPKDelegateManager()
-    
+
     private var pushRegistry: PKPushRegistry?
     private var defaultData: [String: Any]?
     private var mainChannel: FlutterMethodChannel?
-    
+
     private override init() {
         super.init()
     }
-    
+
     @objc public func registerForPushNotifications() {
         pushRegistry = PKPushRegistry(queue: DispatchQueue.main)
         pushRegistry?.delegate = self
         pushRegistry?.desiredPushTypes = [.voIP]
     }
-    
+
     public func initChannel(mainChannel: FlutterMethodChannel) {
         self.mainChannel = mainChannel
     }
-    
+
     public func initData(data: [String: Any]) {
         defaultData = data
     }
-    
+
     // MARK: - PKPushRegistryDelegate
-    @objc public func pushRegistry(_ registry: PKPushRegistry, didUpdate pushCredentials: PKPushCredentials, for type: PKPushType) {
+    @objc public func pushRegistry(
+        _ registry: PKPushRegistry, didUpdate pushCredentials: PKPushCredentials,
+        for type: PKPushType
+    ) {
         let deviceToken = pushCredentials.token.map { String(format: "%02x", $0) }.joined()
         return StreamVideoPushNotificationPlugin.setDevicePushTokenVoIP(deviceToken: deviceToken)
     }
-    
-    @objc public func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType) {
+
+    @objc public func pushRegistry(
+        _ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType
+    ) {
         return StreamVideoPushNotificationPlugin.setDevicePushTokenVoIP(deviceToken: "")
     }
-    
-    @objc public func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
+
+    @objc public func pushRegistry(
+        _ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload,
+        for type: PKPushType, completion: @escaping () -> Void
+    ) {
         // Return if type is not voIP.
         guard type == .voIP else {
             return completion()
         }
-        
+
         let defaults = UserDefaults.standard
         let callbackHandle = defaults.object(forKey: "callback_handle") as? Int64
-        
+
         var streamDict = payload.dictionaryPayload["stream"] as? [String: Any]
-        
+
         let state = UIApplication.shared.applicationState
         if state == .background || state == .inactive {
             if state == .inactive, callbackHandle != nil {
                 DispatchQueue.main.async {
-                    let engine = FlutterEngine(name: "StreamVideoIsolate", project: nil, allowHeadlessExecution: true)
-                    let callbackInfo = FlutterCallbackCache.lookupCallbackInformation(callbackHandle!)
+                    let engine = FlutterEngine(
+                        name: "StreamVideoIsolate", project: nil, allowHeadlessExecution: true)
+                    let callbackInfo = FlutterCallbackCache.lookupCallbackInformation(
+                        callbackHandle!)
                     let entrypoint = callbackInfo?.callbackName
                     let uri = callbackInfo?.callbackLibraryPath
-                    
+
                     let isRunning = engine.run(withEntrypoint: entrypoint, libraryURI: uri)
                 }
-             }
-          
-            
+            }
+
             handleIncomingCall(streamDict: streamDict, state: state, completion: completion)
         } else if state == .active {
             mainChannel?.invokeMethod("customizeCaller", arguments: streamDict) { (response) in
@@ -70,22 +81,25 @@ public class StreamVideoPKDelegateManager: NSObject, PKPushRegistryDelegate, UNU
                     streamDict?["created_by_display_name"] = customData["name"] as? String
                     streamDict?["created_by_id"] = customData["handle"] as? String
                 }
-                
-                self.handleIncomingCall(streamDict: streamDict, state: state, completion: completion)
+
+                self.handleIncomingCall(
+                    streamDict: streamDict, state: state, completion: completion)
             }
         }
     }
-    
-    func handleIncomingCall(streamDict: [String: Any]?, state: UIApplication.State, completion: @escaping () -> Void) {
+
+    func handleIncomingCall(
+        streamDict: [String: Any]?, state: UIApplication.State, completion: @escaping () -> Void
+    ) {
         let defaultCallText = "Unknown Caller"
-        
+
         let callCid = streamDict?["call_cid"] as? String ?? ""
         let createdByName = streamDict?["created_by_display_name"] as? String
         let createdById = streamDict?["created_by_id"] as? String
         let videoIncluded = streamDict?["video"] as? String
         let videoData = videoIncluded == "false" ? 0 : 1
 
-        var callUUID = UUID().uuidString;
+        var callUUID = UUID().uuidString
 
         let data: StreamVideoPushParams
         if let jsonData = self.defaultData {
@@ -93,20 +107,22 @@ public class StreamVideoPKDelegateManager: NSObject, PKPushRegistryDelegate, UNU
         } else {
             data = StreamVideoPushParams(args: [String: Any]())
         }
-        
+
         data.callKitData.uuid = callUUID
         data.callKitData.nameCaller = createdByName ?? defaultCallText
         data.callKitData.handle = createdById ?? defaultCallText
         data.callKitData.type = videoData
         data.callKitData.extra = ["callCid": callCid]
-        
+        data.callKitData.iconName =
+            UserDefaults.standard.string(forKey: "callKit_iconName") ?? data.callKitData.iconName
+
         // Show call incoming notification.
         StreamVideoPushNotificationPlugin.showIncomingCall(
             data: data.callKitData,
             fromPushKit: true
         )
-        
+
         completion()
     }
-    
+
 }

--- a/packages/stream_video_push_notification/ios/Classes/StreamVideoPushNotificationPlugin.swift
+++ b/packages/stream_video_push_notification/ios/Classes/StreamVideoPushNotificationPlugin.swift
@@ -4,51 +4,61 @@ import flutter_callkit_incoming
 
 public class StreamVideoPushNotificationPlugin: NSObject, FlutterPlugin {
     let persistentState: UserDefaults = UserDefaults.standard
-    
+
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let mainChannel = FlutterMethodChannel(name: "stream_video_push_notification", binaryMessenger: registrar.messenger())
+        let mainChannel = FlutterMethodChannel(
+            name: "stream_video_push_notification", binaryMessenger: registrar.messenger())
         let instance = StreamVideoPushNotificationPlugin()
-        
+
         registrar.addMethodCallDelegate(instance, channel: mainChannel)
         StreamVideoPKDelegateManager.shared.initChannel(mainChannel: mainChannel)
     }
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
-            case "initData":
-                if let arguments = call.arguments as? [String: Any] {
-                    let handle = arguments["callbackHandler"] as? Int64
-                    persistentState.set(handle, forKey: "callback_handle")
-                    
-                    StreamVideoPKDelegateManager.shared.initData(data: arguments)
-                    result(nil)
-                } else {
-                    result(FlutterError(code: "INVALID_ARGUMENT", message: "Invalid argument", details: nil))
+        case "initData":
+            if let arguments = call.arguments as? [String: Any] {
+                let handle = arguments["callbackHandler"] as? Int64
+                persistentState.set(handle, forKey: "callback_handle")
+
+                if let iosData = arguments["ios"] as? [String: Any],
+                    let iconName = iosData["iconName"] as? String
+                {
+                    persistentState.set(iconName, forKey: "callKit_iconName")
                 }
-            default:
-                result(FlutterMethodNotImplemented)
+
+                StreamVideoPKDelegateManager.shared.initData(data: arguments)
+                result(nil)
+            } else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENT", message: "Invalid argument", details: nil))
+            }
+        default:
+            result(FlutterMethodNotImplemented)
         }
-    }       
-    
+    }
+
     @objc public static func setDevicePushTokenVoIP(deviceToken: String) {
         SwiftFlutterCallkitIncomingPlugin.sharedInstance?.setDevicePushTokenVoIP(deviceToken)
     }
-    
+
     @objc public static func startOutgoingCall(
         data: flutter_callkit_incoming.Data,
         fromPushKit: Bool
     ) {
         SwiftFlutterCallkitIncomingPlugin.sharedInstance?.startCall(data, fromPushKit: fromPushKit)
     }
-    
+
     @objc public static func showIncomingCall(
         data: flutter_callkit_incoming.Data,
         fromPushKit: Bool
     ) {
-        SwiftFlutterCallkitIncomingPlugin.sharedInstance?.showCallkitIncoming(data, fromPushKit: fromPushKit)
+        SwiftFlutterCallkitIncomingPlugin.sharedInstance?.showCallkitIncoming(
+            data, fromPushKit: fromPushKit)
     }
-    
+
     @objc public static func activeCalls() -> [[String: Any]]? {
-        SwiftFlutterCallkitIncomingPlugin.sharedInstance?.activeCalls();
+        SwiftFlutterCallkitIncomingPlugin.sharedInstance?.activeCalls()
     }
 }


### PR DESCRIPTION
The app icon asset name was not passed correctly to the CallKit configuration when a VoIP push was received while the app was terminated.