### PR TITLE
chore: bumping webrtc dependency

### DIFF
--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   rxdart: ^0.28.0
   sdp_transform: ^0.3.2
   state_notifier: ^1.0.0
-  stream_webrtc_flutter: ^0.12.5+2
+  stream_webrtc_flutter: ^0.12.8
   synchronized: ^3.1.0
   system_info2: ^4.0.0
   tart: ^0.5.1

--- a/packages/stream_video_flutter/example/pubspec.yaml
+++ b/packages/stream_video_flutter/example/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   stream_video: ^0.7.2
   stream_video_flutter: ^0.7.2
   stream_video_push_notification: ^0.7.2
-  stream_webrtc_flutter: ^0.12.5+2
+  stream_webrtc_flutter: ^0.12.8
 
 dependency_overrides:
   stream_video:

--- a/packages/stream_video_flutter/pubspec.yaml
+++ b/packages/stream_video_flutter/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   rate_limiter: ^1.0.0
   stream_video: ^0.7.2
-  stream_webrtc_flutter: ^0.12.5+2
+  stream_webrtc_flutter: ^0.12.8
   visibility_detector: ^0.4.0+2
 
 dev_dependencies:

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   stream_video: ^0.7.2
   uuid: ^4.2.1
   shared_preferences: ^2.3.2
-  stream_webrtc_flutter: ^0.12.5+2
+  stream_webrtc_flutter: ^0.12.8
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
This pull request updates the `stream_webrtc_flutter` dependency across multiple files to ensure compatibility and take advantage of the latest improvements.

Dependency updates:

* [`packages/stream_video/pubspec.yaml`](diffhunk://#diff-48a465280a062b91a802680425bfc1431dd713332ad853d48b2972ac7278075fL33-R33): Updated `stream_webrtc_flutter` dependency from `^0.12.5+2` to `^0.12.8`.
* [`packages/stream_video_flutter/example/pubspec.yaml`](diffhunk://#diff-3af8756168dc6b6befd9081b79683a81589346dd2f0c11d510fdba4fe9375cd1L33-R33): Updated `stream_webrtc_flutter` dependency from `^0.12.5+2` to `^0.12.8`.
* [`packages/stream_video_flutter/pubspec.yaml`](diffhunk://#diff-580632d551a71a785c503628785be6c522ff1023f50c3261a1359aeec4daabf6L24-R24): Updated `stream_webrtc_flutter` dependency from `^0.12.5+2` to `^0.12.8`.
* [`packages/stream_video_push_notification/pubspec.yaml`](diffhunk://#diff-502ce2a35102ce924e79eb1a78ffb9d5d48b3c2546792408312da36a95593215L27-R27): Updated `stream_webrtc_flutter` dependency from `^0.12.5+2` to `^0.12.8`.