### PR TITLE
chore(dogfooding): upgrade AGP to 8.8

### DIFF
--- a/dogfooding/android/app/build.gradle
+++ b/dogfooding/android/app/build.gradle
@@ -41,7 +41,7 @@ android {
     }
 
     compileSdkVersion 34
-    ndkVersion flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -102,6 +102,8 @@ android {
         }
         release {
             signingConfig signingConfigs.release
+
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/dogfooding/android/app/proguard-rules.pro
+++ b/dogfooding/android/app/proguard-rules.pro
@@ -1,0 +1,17 @@
+#Flutter Wrapper
+-keep class io.flutter.plugin.**  { *; }
+-keep class io.flutter.util.**  { *; }
+-keep class io.flutter.view.**  { *; }
+-keep class io.flutter.plugins.**  { *; }
+
+-keep class com.hiennv.flutter_callkit_incoming.** { *; }
+
+-keep class java.beans.Transient.** {*;}
+-keep class java.beans.ConstructorProperties.** {*;}
+-keep class java.nio.file.Path.** {*;}
+
+-dontwarn java.beans.ConstructorProperties
+-dontwarn java.beans.Transient
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.OpenSSLProvider
+-dontwarn org.w3c.dom.bootstrap.DOMImplementationRegistry

--- a/dogfooding/android/gradle.properties
+++ b/dogfooding/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/dogfooding/android/gradle.properties
+++ b/dogfooding/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx2000M
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/dogfooding/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dogfooding/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip

--- a/dogfooding/android/settings.gradle
+++ b/dogfooding/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.1" apply false
+    id "com.android.application" version '8.8.0' apply false
     id "org.jetbrains.kotlin.android" version "1.9.10" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_
The android dogfooding build doesn't compile anymore, because the record_android plugin doesn't work well with AGP 7. Upgrading to AGP 8 makes the app compile again and future proof.

### 🛠 Implementation details

_Describe the implementation_
This also contains a proguard file, because proguard behaves different on AGP 8.

### 🎨 UI Changes

No UI changes

### 🧪 Testing

Run the app on android, optionally with `flutter run --release`

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
