### PR TITLE
chore: Ignore cxx files and fix package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@
 # Android related
 **/android/**/gradle-wrapper.jar
 .gradle/
+**/android/app/.cxx/
 **/android/captures/
 **/android/gradlew
 **/android/gradlew.bat

--- a/melos.yaml
+++ b/melos.yaml
@@ -18,7 +18,7 @@ command:
 
     # Dependencies used in the project.
     dependencies:
-      stream_webrtc_flutter: ^0.12.9
+      stream_webrtc_flutter: ^0.12.9+1
 
 scripts:
   postclean:


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

The `stream_webrtc_flutter` dependency was updated in the packages, but not in the melos.yaml file. Running melos bs would revert them.

`.gitignore` change is related to the flutter upgrade. See also https://github.com/flutter/flutter/issues/163220#issuecomment-2657214423

### 🎨 UI Changes

### 🧪 Testing


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
