### PR TITLE
fix: prevent some actions impossible on desktop

### DIFF
--- a/dogfooding/lib/screens/home_screen.dart
+++ b/dogfooding/lib/screens/home_screen.dart
@@ -40,13 +40,15 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   void initState() {
-    [
-      Permission.notification,
-      Permission.camera,
-      Permission.microphone,
-    ].request();
+    if (CurrentPlatform.isMobile || CurrentPlatform.isWeb) {
+      [
+        Permission.notification,
+        Permission.camera,
+        Permission.microphone,
+      ].request();
 
-    StreamVideoPushNotificationManager.ensureFullScreenIntentPermission();
+      StreamVideoPushNotificationManager.ensureFullScreenIntentPermission();
+    }
 
     StreamBackgroundService.init(
       StreamVideo.instance,

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
@@ -67,7 +67,7 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
     this.callerCustomizationCallback,
     this.registerApnDeviceToken = false,
   }) : _client = client {
-    if (CurrentPlatform.isWeb) return;
+    if (!CurrentPlatform.isMobile) return;
 
     SharedPreferences.getInstance().then((prefs) => _sharedPreferences = prefs);
 
@@ -363,7 +363,7 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
 
   @override
   Future<List<CallData>> activeCalls() async {
-    if (CurrentPlatform.isWeb) return [];
+    if (!CurrentPlatform.isMobile) return [];
 
     final activeCalls = await FlutterCallkitIncoming.activeCalls();
     if (activeCalls is! List) return [];
@@ -395,7 +395,7 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
         .toList();
 
     // This is a workaround for the issue in flutter_callkit_incoming
-    // where second CallKit call overrids data in showCallkitIncoming native method
+    // where second CallKit call overrides data in showCallkitIncoming native method
     // and it's not possible to end the call by callCid
     if (activeCalls.length == calls.length) {
       await endAllCalls();


### PR DESCRIPTION
### 🎯 Goal

When running the app on macOS it works, but it does throw a lot of exceptions. I want to prevent those exceptions.

### 🛠 Implementation details

Some things that are no longer done on macOS when you run the app:
`_tryConsumingIncomingCallFromTerminatedState`
`streamVideo.observeCoreCallKitEvents`
request permissions for notification, camera and microphone. Permission handler doesn't support those platforms.
Setup the StreamVideoPushNotificationManager.

It also enables the "IN-APP INCOMING SCREEN" for desktop and web.

### 🎨 UI Changes

No UI changes

### 🧪 Testing

Run macOS app with breakpoints enabled, before and after.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
