### PR TITLE
feat: enable google signin on macos

### DIFF
--- a/dogfooding/lib/screens/login_screen.dart
+++ b/dogfooding/lib/screens/login_screen.dart
@@ -247,10 +247,11 @@ class GoogleLoginButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Google SignIn plugin is only supported on Web, Android and iOS.
+    // Google SignIn plugin is supported on Web, Android, iOS and macOS.
     final isGoogleSignInSupported =
         defaultTargetPlatform == TargetPlatform.iOS ||
             defaultTargetPlatform == TargetPlatform.android ||
+            defaultTargetPlatform == TargetPlatform.macOS ||
             kIsWeb;
 
     final currentPlatform = Theme.of(context).platform.name;

--- a/dogfooding/macos/Runner.xcodeproj/project.pbxproj
+++ b/dogfooding/macos/Runner.xcodeproj/project.pbxproj
@@ -484,8 +484,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -611,9 +613,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -633,8 +637,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/dogfooding/macos/Runner/DebugProfile.entitlements
+++ b/dogfooding/macos/Runner/DebugProfile.entitlements
@@ -14,5 +14,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.google.GIDSignIn</string>
+    </array>
 </dict>
 </plist>

--- a/dogfooding/macos/Runner/Release.entitlements
+++ b/dogfooding/macos/Runner/Release.entitlements
@@ -14,5 +14,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.google.GIDSignIn</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
### 🎯 Goal

Enable google signin on the macos dogfooding app

### 🛠 Implementation details

The Google signin plugin supports macos. To enable it we need to add the `keychain-access-groups` entitlement and enable development signing. See: https://pub.dev/packages/google_sign_in_ios#macos-setup

### 🎨 UI Changes

![image (8)](https://github.com/user-attachments/assets/582d1fa1-f61a-4d93-acfc-3db603568fe6)

### 🧪 Testing

Run macos app and login with google


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
