### PR TITLE
fix: Always build both platforms on push event

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -44,7 +44,7 @@ jobs:
     name: Build and Distribute Dogfooding Ios
     runs-on: macos-latest
     timeout-minutes: 60
-    if: ${{ inputs.build_ios != false }}
+    if: ${{ github.event_name == 'push' || inputs.build_ios == true }}
     steps:
       - name: Install Bot SSH Key
         uses: webfactory/ssh-agent@v0.9.0
@@ -99,7 +99,7 @@ jobs:
     name: Build and Distribute Dogfooding Android
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: ${{ inputs.build_android != false }}
+    if: ${{ github.event_name == 'push' || inputs.build_android == true }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
### 🎯 Goal

Run workflow on push

### 🛠 Implementation details

I assumed `inputs.build_x` would be null or undefined, so that's why I checked for `!= false`, but apparently default is false for on push because here nothing runs: https://github.com/GetStream/stream-video-flutter/actions/runs/13544785120

So now I check if the event_name is 'push'.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
