### PR TITLE
chore: Added CallPreferences to consumeIncomingCall method

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+✅ Added 
+* Added `CallPreferences? preferences` parameter to `consumeIncomingCall()` method in `StreamVideo` to make it possible to configure the consumed call.
+
 ## 0.8.1
 
 ✅ Added 

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -901,6 +901,7 @@ class StreamVideo extends Disposable {
   Future<Result<Call>> consumeIncomingCall({
     required String uuid,
     required String cid,
+    CallPreferences? preferences,
   }) async {
     _logger.d(() => '[consumeIncomingCall] uuid: $uuid, cid: $cid');
     final manager = pushNotificationManager;
@@ -926,6 +927,7 @@ class StreamVideo extends Disposable {
         ringing: true,
         metadata: callResult.data.metadata,
       ),
+      preferences: preferences,
     );
 
     return Result.success(call);

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+✅ Added 
+* Added `CallPreferences? preferences` parameter to `consumeIncomingCall()` method in `StreamVideo` to make it possible to configure the consumed call.
+
 ## 0.8.1
 
 ✅ Added 


### PR DESCRIPTION
[FLU-47]

Added CallPreferences parameter to `consumeIncoimgCall` method to allow call configuration when creating new call from ringing.