### PR TITLE
chore: bump thermal package to support Android <=9

### DIFF
--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   synchronized: ^3.1.0
   system_info2: ^4.0.0
   tart: ^0.5.1
-  thermal: ^1.1.10
+  thermal: ^1.1.11
   uuid: ^4.2.1
   web: ^1.0.0
   web_socket_channel: ^3.0.1


### PR DESCRIPTION
Solves: [FLU-48]

Bumping `thermal` to the version with [our change](https://github.com/muxable/flutter_thermal/pull/9) merged where Android <=9 is supported.