### PR TITLE
fix: don't handle deeplink on login

### DIFF
--- a/dogfooding/lib/app/app_content.dart
+++ b/dogfooding/lib/app/app_content.dart
@@ -183,14 +183,14 @@ class _StreamDogFoodingAppContentState
   }
 
   Future<void> _observeDeepLinks() async {
-    // The app was in the background.
-    if (!kIsWeb) {
-      final deepLinkSubscription = AppLinks().uriLinkStream.listen((uri) {
-        if (mounted) _handleDeepLink(uri);
-      });
+    if (kIsWeb) return;
 
-      _compositeSubscription.add(deepLinkSubscription);
-    }
+    // The app was in the background.
+    final deepLinkSubscription = AppLinks().uriLinkStream.listen((uri) {
+      if (mounted) _handleDeepLink(uri);
+    });
+
+    _compositeSubscription.add(deepLinkSubscription);
 
     // The app was terminated.
     try {


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_
Currently when you login on the web version of dogfooding it gives a grey/red screen. This fixes it.

### 🛠 Implementation details

_Describe the implementation_
After some debugging I found that pressing the login button (guest or email) calls `initPushNotificationManagerIfAvailable` which in turn handles deeplinks. For web the `initialUri` is not null, so it handles the deeplink and resets the AppInjector, which removes all existing dependencies.

As far as I know we don't need to handle deeplinks at all on web now.

### 🎨 UI Changes

No UI changes

### 🧪 Testing

Run a web build before and after.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
