### PR TITLE
feat: Add audioLevels and activeSpeakers

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+✅ Added
+* Added `CallParticipantState.audioLevels` with the 10 last audio levels of the participant.
+* Added `CallState.activeSpeakers` to get list of currently active speakers.
+
 ## 0.8.2
 
 ✅ Added 

--- a/packages/stream_video/lib/src/call/state/mixins/state_sfu_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_sfu_mixin.dart
@@ -106,7 +106,7 @@ mixin StateSfuMixin on StateNotifier<CallState> {
               level.sessionId == participant.sessionId;
         });
         if (levelInfo != null) {
-          return participant.copyWith(
+          return participant.copyWithUpdatedAudioLevels(
             audioLevel: levelInfo.level,
             isSpeaking: levelInfo.isSpeaking,
           );
@@ -207,17 +207,18 @@ mixin StateSfuMixin on StateNotifier<CallState> {
     final participants = state.callParticipants.map((it) {
       if (it.userId == participant.userId &&
           it.sessionId == participant.sessionId) {
-        return it.copyWith(
-          name: participant.userName,
-          custom: participant.custom,
-          image: participant.userImage,
-          trackIdPrefix: participant.trackLookupPrefix,
-          audioLevel: participant.audioLevel,
-          isSpeaking: participant.isSpeaking,
-          isDominantSpeaker: participant.isDominantSpeaker,
-          connectionQuality: participant.connectionQuality,
-          roles: participant.roles,
-        );
+        return it
+            .copyWith(
+              name: participant.userName,
+              custom: participant.custom,
+              image: participant.userImage,
+              trackIdPrefix: participant.trackLookupPrefix,
+              isSpeaking: participant.isSpeaking,
+              isDominantSpeaker: participant.isDominantSpeaker,
+              connectionQuality: participant.connectionQuality,
+              roles: participant.roles,
+            )
+            .copyWithUpdatedAudioLevels(audioLevel: participant.audioLevel);
       } else {
         return it;
       }

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -141,6 +141,10 @@ class CallState extends Equatable {
     return callParticipants.where((element) => !element.isLocal).toList();
   }
 
+  List<CallParticipantState> get activeSpeakers {
+    return callParticipants.where((element) => element.isSpeaking).toList();
+  }
+
   /// Returns a copy of this [CallState] with the given fields replaced
   /// with the new values.
   CallState copyWith({

--- a/packages/stream_video/lib/src/models/call_participant_state.dart
+++ b/packages/stream_video/lib/src/models/call_participant_state.dart
@@ -14,7 +14,7 @@ import 'viewport_visibility.dart';
 class CallParticipantState
     with EquatableMixin
     implements Comparable<CallParticipantState> {
-  const CallParticipantState({
+  CallParticipantState({
     required this.userId,
     required this.roles,
     required this.name,
@@ -27,12 +27,13 @@ class CallParticipantState
     this.connectionQuality = SfuConnectionQuality.unspecified,
     this.isOnline = false,
     this.audioLevel = 0,
+    List<double>? audioLevels,
     this.isSpeaking = false,
     this.isDominantSpeaker = false,
     this.isPinned = false,
     this.reaction,
     this.viewportVisibility = ViewportVisibility.unknown,
-  });
+  }) : audioLevels = audioLevels ?? [audioLevel];
 
   final String userId;
   final List<String> roles;
@@ -45,7 +46,13 @@ class CallParticipantState
   final bool isLocal;
   final SfuConnectionQuality connectionQuality;
   final bool isOnline;
+
+  /// The audio level for the user.
   final double audioLevel;
+
+  /// List of the last 10 audio levels.
+  final List<double> audioLevels;
+
   final bool isSpeaking;
   final bool isDominantSpeaker;
   final bool isPinned;
@@ -73,6 +80,14 @@ class CallParticipantState
     CallReaction? reaction,
     ViewportVisibility? viewportVisibility,
   }) {
+    final levels = audioLevels;
+    if (audioLevel != null) {
+      levels.add(audioLevel);
+      while (levels.length > 10) {
+        levels.removeAt(0);
+      }
+    }
+
     return CallParticipantState(
       userId: userId ?? this.userId,
       roles: roles ?? this.roles,
@@ -86,6 +101,7 @@ class CallParticipantState
       connectionQuality: connectionQuality ?? this.connectionQuality,
       isOnline: isOnline ?? this.isOnline,
       audioLevel: audioLevel ?? this.audioLevel,
+      audioLevels: levels,
       isSpeaking: isSpeaking ?? this.isSpeaking,
       isDominantSpeaker: isDominantSpeaker ?? this.isDominantSpeaker,
       isPinned: isPinned ?? this.isPinned,
@@ -119,7 +135,7 @@ class CallParticipantState
         'publishedTracks: $publishedTracks, '
         'isLocal: $isLocal, '
         'connectionQuality: $connectionQuality, isOnline: $isOnline, '
-        'audioLevel: $audioLevel, isSpeaking: $isSpeaking, '
+        'audioLevel: $audioLevel, audioLevels: $audioLevels, isSpeaking: $isSpeaking, '
         'isDominantSpeaker: $isDominantSpeaker, isPinned: $isPinned, '
         'reaction: $reaction, viewportVisibility: $viewportVisibility}';
   }
@@ -138,6 +154,7 @@ class CallParticipantState
         connectionQuality,
         isOnline,
         audioLevel,
+        audioLevels,
         isSpeaking,
         isDominantSpeaker,
         isPinned,

--- a/packages/stream_video/lib/src/models/call_participant_state.dart
+++ b/packages/stream_video/lib/src/models/call_participant_state.dart
@@ -47,7 +47,7 @@ class CallParticipantState
   final SfuConnectionQuality connectionQuality;
   final bool isOnline;
 
-  /// The audio level for the user.
+  /// The latest audio level for the user.
   final double audioLevel;
 
   /// List of the last 10 audio levels.

--- a/packages/stream_video/lib/src/models/call_participant_state.dart
+++ b/packages/stream_video/lib/src/models/call_participant_state.dart
@@ -61,6 +61,8 @@ class CallParticipantState
 
   /// Returns a copy of this [CallParticipantState] with the given fields
   /// replaced with the new values.
+  ///
+  /// If you want to update the audioLevel, consider using [copyWithUpdatedAudioLevels].
   CallParticipantState copyWith({
     String? userId,
     List<String>? roles,
@@ -74,20 +76,13 @@ class CallParticipantState
     SfuConnectionQuality? connectionQuality,
     bool? isOnline,
     double? audioLevel,
+    List<double>? audioLevels,
     bool? isSpeaking,
     bool? isDominantSpeaker,
     bool? isPinned,
     CallReaction? reaction,
     ViewportVisibility? viewportVisibility,
   }) {
-    final levels = audioLevels;
-    if (audioLevel != null) {
-      levels.add(audioLevel);
-      while (levels.length > 10) {
-        levels.removeAt(0);
-      }
-    }
-
     return CallParticipantState(
       userId: userId ?? this.userId,
       roles: roles ?? this.roles,
@@ -101,12 +96,30 @@ class CallParticipantState
       connectionQuality: connectionQuality ?? this.connectionQuality,
       isOnline: isOnline ?? this.isOnline,
       audioLevel: audioLevel ?? this.audioLevel,
-      audioLevels: levels,
+      audioLevels: audioLevels ?? this.audioLevels,
       isSpeaking: isSpeaking ?? this.isSpeaking,
       isDominantSpeaker: isDominantSpeaker ?? this.isDominantSpeaker,
       isPinned: isPinned ?? this.isPinned,
       reaction: reaction ?? this.reaction,
       viewportVisibility: viewportVisibility ?? this.viewportVisibility,
+    );
+  }
+
+  /// Copies the current state and adds the latest [audioLevel] to the last 10 [audioLevels].
+  CallParticipantState copyWithUpdatedAudioLevels({
+    required double audioLevel,
+    bool? isSpeaking,
+  }) {
+    final levels = audioLevels;
+    levels.add(audioLevel);
+    while (levels.length > 10) {
+      levels.removeAt(0);
+    }
+
+    return copyWith(
+      audioLevel: audioLevel,
+      audioLevels: audioLevels,
+      isSpeaking: isSpeaking,
     );
   }
 

--- a/packages/stream_video/test/call_participant_state_sorting_test.dart
+++ b/packages/stream_video/test/call_participant_state_sorting_test.dart
@@ -51,7 +51,7 @@ void main() {
     ),
 
     // Muted
-    const CallParticipantState(
+    CallParticipantState(
       name: 'C',
       userId: '3',
       sessionId: '3',


### PR DESCRIPTION
FLU-44

### 🎯 Goal

Add audioLevels and active speakers to match the swift sdk.

### 🛠 Implementation details

activeSpeakers is very similar to `otherParticipants` and `localParticipant`, so not fancy.

The list of audioLevels is maintained when doing `copyWith(audioLevel:...)`, so this level is added to the list every time the level changes.

I had to remove `const` to keep the API clean.
We can keep it const by adding a private field like this:
```dart
  final List<double>? _audioLevels;
  /// List of the last 10 audio levels.
   List<double> get audioLevels => _audioLevels ?? [audioLevel];
```
But I don't think it's worth it.


### 🎨 UI Changes

No UI changes

### 🧪 Testing




### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
