### PR TITLE
chore(llc): added membersLimit parameter

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+✅ Added
+* Added `membersLimit` parameter to `getOrCreate()` and `join()` methods in `Call` class to limit number of members listed in the response.
+
 ## 0.8.3
 
 ✅ Added

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -566,7 +566,7 @@ class Call {
   /// Joins the call.
   ///
   /// - [connectOptions]: optional initial call configuration
-  /// - [membersLimit]: Sets the total number of members to return as part of the response.
+  /// - [membersLimit]: Sets the maximum number of members to return as part of the response.
   Future<Result<None>> join({
     CallConnectOptions? connectOptions,
     int? membersLimit,

--- a/packages/stream_video/lib/src/call/permissions/permissions_manager.dart
+++ b/packages/stream_video/lib/src/call/permissions/permissions_manager.dart
@@ -333,7 +333,7 @@ class PermissionsManager {
   }
 
   Future<Result<QueriedMembers>> queryMembers({
-    required Map<String, Object> filterConditions,
+    Map<String, Object> filterConditions = const {},
     String? next,
     String? prev,
     List<SortParamRequest> sorts = const [],

--- a/packages/stream_video/lib/src/call/state/mixins/state_call_actions_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_call_actions_mixin.dart
@@ -6,28 +6,28 @@ final _logger = taggedLogger(tag: 'SV:CoordNotifier');
 
 mixin StateCallActionsMixin on StateNotifier<CallState> {
   void setCallLive({required bool isLive}) {
-    _logger.e(() => '[setCallLive] isLive:$isLive');
+    _logger.v(() => '[setCallLive] isLive:$isLive');
     state = state.copyWith(
       isBackstage: !isLive,
     );
   }
 
   void setCallRecording({required bool isRecording}) {
-    _logger.e(() => '[setCallRecording] isRecording:$isRecording');
+    _logger.v(() => '[setCallRecording] isRecording:$isRecording');
     state = state.copyWith(
       isRecording: isRecording,
     );
   }
 
   void setCallTranscribing({required bool isTranscribing}) {
-    _logger.e(() => '[setCallTranscribing] isTranscribing:$isTranscribing');
+    _logger.v(() => '[setCallTranscribing] isTranscribing:$isTranscribing');
     state = state.copyWith(
       isTranscribing: isTranscribing,
     );
   }
 
   void setCallClosedCaptioning({required bool isCaptioning}) {
-    _logger.e(() => '[setCallClosedCaptioning] isCaptioning:$isCaptioning');
+    _logger.v(() => '[setCallClosedCaptioning] isCaptioning:$isCaptioning');
     state = state.copyWith(
       isCaptioning: isCaptioning,
     );
@@ -37,7 +37,7 @@ mixin StateCallActionsMixin on StateNotifier<CallState> {
     required bool isBroadcasting,
     String? hlsPlaylistUrl,
   }) {
-    _logger.e(
+    _logger.v(
       () => '[setCallBroadcasting] isBroadcasting:$isBroadcasting'
           ', hlsPlaylistUrl: $hlsPlaylistUrl',
     );

--- a/packages/stream_video/lib/src/coordinator/coordinator_client.dart
+++ b/packages/stream_video/lib/src/coordinator/coordinator_client.dart
@@ -77,6 +77,7 @@ abstract class CoordinatorClient {
     bool? notify,
     bool? video,
     DateTime? startsAt,
+    int? membersLimit,
     open.CallSettingsRequest? settingsOverride,
     Map<String, Object> custom = const {},
   });
@@ -87,6 +88,7 @@ abstract class CoordinatorClient {
     bool? create,
     String? migratingFrom,
     bool? video,
+    int? membersLimit,
   });
 
   Future<Result<None>> acceptCall({required StreamCallCid cid});

--- a/packages/stream_video/lib/src/coordinator/open_api/coordinator_client_open_api.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/coordinator_client_open_api.dart
@@ -442,6 +442,7 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
     bool? notify,
     bool? video,
     DateTime? startsAt,
+    int? membersLimit,
     CallSettingsRequest? settingsOverride,
     Map<String, Object> custom = const {},
   }) async {
@@ -469,6 +470,7 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
             settingsOverride: settingsOverride,
             custom: custom,
           ),
+          membersLimit: membersLimit,
           ring: ringing,
           notify: notify,
           video: video,
@@ -507,6 +509,7 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
     bool? create,
     String? migratingFrom,
     bool? video,
+    int? membersLimit,
   }) async {
     try {
       _logger.d(
@@ -528,6 +531,7 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
           create: create,
           ring: ringing,
           location: location,
+          membersLimit: membersLimit,
           migratingFrom: migratingFrom,
           video: video,
         ),
@@ -973,7 +977,7 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
   @override
   Future<Result<QueriedMembers>> queryMembers({
     required StreamCallCid callCid,
-    required Map<String, Object> filterConditions,
+    Map<String, Object> filterConditions = const {},
     String? next,
     String? prev,
     List<open.SortParamRequest> sorts = const [],

--- a/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
+++ b/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
@@ -145,6 +145,7 @@ class CoordinatorClientRetry extends CoordinatorClient {
     bool? notify,
     bool? video,
     DateTime? startsAt,
+    int? membersLimit,
     open.CallSettingsRequest? settingsOverride,
     Map<String, Object> custom = const {},
   }) {
@@ -157,6 +158,7 @@ class CoordinatorClientRetry extends CoordinatorClient {
         notify: notify,
         video: video,
         startsAt: startsAt,
+        membersLimit: membersLimit,
         settingsOverride: settingsOverride,
         custom: custom,
       ),
@@ -249,6 +251,7 @@ class CoordinatorClientRetry extends CoordinatorClient {
     bool? create,
     String? migratingFrom,
     bool? video,
+    int? membersLimit,
   }) {
     return _retryManager.execute(
       () => _delegate.joinCall(
@@ -394,7 +397,7 @@ class CoordinatorClientRetry extends CoordinatorClient {
   @override
   Future<Result<QueriedMembers>> queryMembers({
     required StreamCallCid callCid,
-    required Map<String, Object> filterConditions,
+    Map<String, Object> filterConditions = const {},
     String? next,
     String? prev,
     List<open.SortParamRequest> sorts = const [],

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+✅ Added
+* Added `membersLimit` parameter to `getOrCreate()` and `join()` methods in `Call` class to limit number of members listed in the response.
+
 ## 0.8.3
 
 ✅ Added


### PR DESCRIPTION
Added `membersLimit` parameter to `getOrCreate()` and `join()` that was missing previously. Connected to added doc page: https://github.com/GetStream/docs-content/pull/221