### PR TITLE
fix: fix for PiP still active when app foregrounded on iOS

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+🐞 Fixed
+* (iOS) Fixed an issue where PiP will not stop when bringing app back to foreground
+
 ## 0.8.3
 
 ✅ Added

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+🐞 Fixed
+* (iOS) Fixed an issue where PiP will not stop when bringing app back to foreground
+
 ## 0.8.3
 
 ✅ Added

--- a/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamPictureInPictureController.swift
+++ b/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamPictureInPictureController.swift
@@ -9,7 +9,6 @@ import stream_webrtc_flutter
 
 /// A controller class for picture-in-picture whenever that is possible.
 final class StreamPictureInPictureController: NSObject, AVPictureInPictureControllerDelegate {
-
     // MARK: - Properties
 
     /// The RTCVideoTrack for which the picture-in-picture session is created.
@@ -80,7 +79,12 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
         self.contentViewController = contentViewController
         self.canStartPictureInPictureAutomaticallyFromInline =
             canStartPictureInPictureAutomaticallyFromInline
+
         super.init()
+
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleAppDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     // MARK: - AVPictureInPictureControllerDelegate
@@ -179,4 +183,15 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
     private func didUpdatePictureInPictureActiveState(_ isActive: Bool) {
         trackStateAdapter.isEnabled = isActive
     }
+
+    @objc private func handleAppDidBecomeActive() {
+        guard
+            let pictureInPictureController,
+            pictureInPictureController.isPictureInPictureActive == true
+        else {
+            return
+        }
+        pictureInPictureController.stopPictureInPicture()
+    }
+
 }


### PR DESCRIPTION
This pull request addresses a bug in the iOS Picture-in-Picture (PiP) functionality where PiP remains active even after bringing the app back to the foreground..
