### PR TITLE
dogfooding: allow env switching on web

### DIFF
--- a/dogfooding/lib/utils/consts.dart
+++ b/dogfooding/lib/utils/consts.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show appFlavor;
 import 'package:stream_video_flutter/stream_video_flutter.dart';
 
@@ -9,5 +10,5 @@ bool get kIsProd => switch (appFlavor) {
       'dev' => false,
       'beta' => false,
       'prod' => true,
-      _ => true,
+      _ => !kIsWeb, // On our web builds we enable non-prod features.
     };


### PR DESCRIPTION
### 🎯 Goal

We want to use pronto on web, but we currently only have demo available. We don't build web with multiple flavors.

### 🛠 Implementation details

On web always assume non-prod environment.

### 🎨 UI Changes

No UI changes

### 🧪 Testing



### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
