### PR TITLE
chore: bump webrtc version

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -18,7 +18,8 @@ command:
 
     # Dependencies used in the project.
     dependencies:
-      stream_webrtc_flutter: ^0.12.12
+      dart_webrtc: ^1.4.10
+      stream_webrtc_flutter: ^0.12.12+1
 
 scripts:
   postclean:

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   battery_plus: ^6.2.0
   collection: ^1.18.0
   connectivity_plus: ^6.0.4
-  dart_webrtc: ^1.5.2+hotfix.1
+  dart_webrtc: ^1.4.10
   device_info_plus: ^10.1.2
   equatable: ^2.0.5
   fixnum: ^1.1.0
@@ -31,7 +31,7 @@ dependencies:
   rxdart: ^0.28.0
   sdp_transform: ^0.3.2
   state_notifier: ^1.0.0
-  stream_webrtc_flutter: ^0.12.12
+  stream_webrtc_flutter: ^0.12.12+1
   synchronized: ^3.1.0
   system_info2: ^4.0.0
   tart: ^0.5.1

--- a/packages/stream_video_flutter/example/pubspec.yaml
+++ b/packages/stream_video_flutter/example/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   stream_video: ^0.8.3
   stream_video_flutter: ^0.8.3
   stream_video_push_notification: ^0.8.3
-  stream_webrtc_flutter: ^0.12.12
+  stream_webrtc_flutter: ^0.12.12+1
 
 dependency_overrides:
   stream_video:

--- a/packages/stream_video_flutter/pubspec.yaml
+++ b/packages/stream_video_flutter/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   rate_limiter: ^1.0.0
   stream_video: ^0.8.3
-  stream_webrtc_flutter: ^0.12.12
+  stream_webrtc_flutter: ^0.12.12+1
   visibility_detector: ^0.4.0+2
 
 dev_dependencies:

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   stream_video: ^0.8.3
   uuid: ^4.2.1
   shared_preferences: ^2.3.2
-  stream_webrtc_flutter: ^0.12.12
+  stream_webrtc_flutter: ^0.12.12+1
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
and downgrade dart_webrtc

### 🎯 Goal

New dart_webrtc has a bug for stats reporting. This version changes has a downgrade for dart_webrtc to make it work on web.



### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
