### PR TITLE
fix: Update device_info and webrtc dependencies

### DIFF
--- a/dogfooding/pubspec.yaml
+++ b/dogfooding/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   app_links: ^6.3.2
   crypto: ^3.0.5
   cupertino_icons: ^1.0.8
-  device_info_plus: ^10.1.2
+  device_info_plus: ">=10.1.2 <12.0.0"
   envied: ^0.5.4+1
   firebase_auth: ^5.4.0
   firebase_core: ^3.10.0
@@ -33,7 +33,7 @@ dependencies:
   rxdart: ^0.28.0
   share_plus: ^10.0.2
   shared_preferences: ^2.3.2
-  stream_chat_flutter: ^9.4.0
+  stream_chat_flutter: ^9.5.0
   stream_video_flutter: ^0.8.3
   stream_video_push_notification: ^0.8.3
   stream_video_screen_sharing: ^0.8.3

--- a/melos.yaml
+++ b/melos.yaml
@@ -18,7 +18,10 @@ command:
 
     # Dependencies used in the project.
     dependencies:
-      stream_webrtc_flutter: ^0.12.9+1
+      dart_webrtc: ^1.4.9
+      device_info_plus: '>=10.1.2 <12.0.0'
+      stream_chat_flutter: ^9.5.0
+      stream_webrtc_flutter: ^0.12.12+2
 
 scripts:
   postclean:
@@ -48,7 +51,7 @@ scripts:
     description: |
       Run `dart analyze` in all packages.
        Flags all compiler `errors` in the project.
-  
+
   analyze:error:
     run: |
       melos exec -c 5 --ignore="*example*" -- \
@@ -129,7 +132,7 @@ scripts:
     description: Removes all the ignored files from the coverage report.
     packageFilters:
       dirExists: coverage
-      
+
   build:example:android:
     run: |
       cd ./packages/stream_video_flutter/example && 

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.3+1
+* Update stream_webrtc_flutter and device_info_plus dependencies
+
 ## 0.8.3
 
 ✅ Added

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_video
 description: The Official Low-level Client for Stream Video, a service for
   building video calls, audio rooms, and live-streaming applications.
-version: 0.8.3
+version: 0.8.3+1
 homepage: https://getstream.io/video/
 repository: https://github.com/GetStream/stream-video-flutter
 issue_tracker: https://github.com/GetStream/stream-video-flutter/issues
@@ -16,7 +16,7 @@ dependencies:
   collection: ^1.18.0
   connectivity_plus: ^6.0.4
   dart_webrtc: ^1.4.9
-  device_info_plus: ^10.1.2
+  device_info_plus: ">=10.1.2 <12.0.0"
   equatable: ^2.0.5
   fixnum: ^1.1.0
   flutter:
@@ -31,7 +31,7 @@ dependencies:
   rxdart: ^0.28.0
   sdp_transform: ^0.3.2
   state_notifier: ^1.0.0
-  stream_webrtc_flutter: ^0.12.9+1
+  stream_webrtc_flutter: ^0.12.12+2
   synchronized: ^3.1.0
   system_info2: ^4.0.0
   tart: ^0.5.1

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.3+1
+* Update stream_webrtc_flutter and device_info_plus dependencies
+
 ## 0.8.3
 
 ✅ Added

--- a/packages/stream_video_flutter/example/pubspec.yaml
+++ b/packages/stream_video_flutter/example/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   cupertino_icons: ^1.0.5
-  device_info_plus: ^10.1.2
+  device_info_plus: ">=10.1.2 <12.0.0"
   envied: ^0.3.0+3
   firebase_core: ^3.6.0
   firebase_messaging: ^15.1.3
@@ -30,7 +30,7 @@ dependencies:
   stream_video: ^0.8.3
   stream_video_flutter: ^0.8.3
   stream_video_push_notification: ^0.8.3
-  stream_webrtc_flutter: ^0.12.9+1
+  stream_webrtc_flutter: ^0.12.12+2
 
 dependency_overrides:
   stream_video:

--- a/packages/stream_video_flutter/pubspec.yaml
+++ b/packages/stream_video_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_video_flutter
 description: The Official UI package for Stream Video, a service for building
   video calls, audio rooms, and live-streaming applications.
-version: 0.8.3
+version: 0.8.3+1
 homepage: https://getstream.io/video/
 repository: https://github.com/GetStream/stream-video-flutter
 issue_tracker: https://github.com/GetStream/stream-video-flutter/issues
@@ -24,7 +24,7 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   rate_limiter: ^1.0.0
   stream_video: ^0.8.3
-  stream_webrtc_flutter: ^0.12.9+1
+  stream_webrtc_flutter: ^0.12.12+2
   visibility_detector: ^0.4.0+2
 
 dev_dependencies:

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   stream_video: ^0.8.3
   uuid: ^4.2.1
   shared_preferences: ^2.3.2
-  stream_webrtc_flutter: ^0.12.9+1
+  stream_webrtc_flutter: ^0.12.12+2
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
### 🎯 Goal

We should support latest dependencies.

### 🛠 Implementation details

This updates `device_info_plus` to allow the latest version and also forces webrtc library to use the latest.



### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
