### PR TITLE
feat: Added pin/unpin for everyone method to Call

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2141,27 +2141,38 @@ class Call {
     return result;
   }
 
+  /// Pins/unpins the given session to the top of the participants list.
+  /// The change is done locally and won't affect other participants.
   Future<Result<None>> setParticipantPinned({
     required String sessionId,
     required String userId,
     required bool pinned,
   }) async {
-    final result = await _session?.setParticipantPinned(
-          sessionId: sessionId,
-          userId: userId,
-          pinned: pinned,
-        ) ??
-        Result.error('Session is null');
+    _stateManager.setParticipantPinned(
+      sessionId: sessionId,
+      userId: userId,
+      pinned: pinned,
+    );
 
-    if (result.isSuccess) {
-      _stateManager.setParticipantPinned(
-        sessionId: sessionId,
-        userId: userId,
-        pinned: pinned,
-      );
-    }
+    return const Result.success(none);
+  }
 
-    return result;
+  /// Pins/unpins the given session to the top of the participants list for everyone in the call.
+  /// You can execute this method only if you have the `pin-for-everyone` capability.
+  Future<Result<None>> setParticipantPinnedForEveryone({
+    required String sessionId,
+    required String userId,
+    required bool pinned,
+  }) async {
+    return pinned
+        ? _permissionsManager.pinForEveryone(
+            userId: userId,
+            sessionId: sessionId,
+          )
+        : _permissionsManager.unpinForEveryone(
+            userId: userId,
+            sessionId: sessionId,
+          );
   }
 
   /// Starts the livestreaming of the call.

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2141,14 +2141,13 @@ class Call {
     return result;
   }
 
-  /// Pins/unpins the given session to the top of the participants list.
-  /// The change is done locally and won't affect other participants.
+  @Deprecated('Use setParticipantPinnedLocally instead')
   Future<Result<None>> setParticipantPinned({
     required String sessionId,
     required String userId,
     required bool pinned,
   }) async {
-    _stateManager.setParticipantPinned(
+    setParticipantPinnedLocally(
       sessionId: sessionId,
       userId: userId,
       pinned: pinned,
@@ -2157,8 +2156,22 @@ class Call {
     return const Result.success(none);
   }
 
+  /// Pins/unpins the given session to the top of the participants list.
+  /// The change is done locally and won't affect other participants.
+  void setParticipantPinnedLocally({
+    required String sessionId,
+    required String userId,
+    required bool pinned,
+  }) {
+    _stateManager.setParticipantPinned(
+      sessionId: sessionId,
+      userId: userId,
+      pinned: pinned,
+    );
+  }
+
   /// Pins/unpins the given session to the top of the participants list for everyone in the call.
-  /// You can execute this method only if you have the `pin-for-everyone` capability.
+  /// This method requires current user to have the `pin-for-everyone` capability.
   Future<Result<None>> setParticipantPinnedForEveryone({
     required String sessionId,
     required String userId,

--- a/packages/stream_video/lib/src/call/call_events.dart
+++ b/packages/stream_video/lib/src/call/call_events.dart
@@ -7,6 +7,7 @@ import '../sfu/data/events/sfu_events.dart';
 import '../sfu/data/models/sfu_audio_level.dart';
 import '../sfu/data/models/sfu_call_grants.dart';
 import '../sfu/data/models/sfu_connection_info.dart';
+import '../sfu/data/models/sfu_pin.dart';
 import '../sfu/data/models/sfu_track_type.dart';
 import '../sfu/sfu_extensions.dart';
 import '../shared_emitter.dart';
@@ -134,6 +135,22 @@ class StreamCallDominantSpeakerChangedEvent extends StreamSfuCallEvent {
         ...super.props,
         userId,
         sessionId,
+      ];
+}
+
+/// Event that is triggered when pinned participants are updated
+class StreamPinsUpdatedEvent extends StreamSfuCallEvent {
+  const StreamPinsUpdatedEvent(
+    super.callCid, {
+    required this.pins,
+  });
+
+  final List<SfuPin> pins;
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        pins,
       ];
 }
 
@@ -941,6 +958,10 @@ extension SfuEventX on SfuEvent {
           state.callCid,
           userId: event.userId,
           sessionId: event.sessionId,
+        ),
+      final SfuPinsUpdatedEvent event => StreamPinsUpdatedEvent(
+          state.callCid,
+          pins: event.pins,
         ),
       final SfuTrackPublishedEvent event => StreamCallSfuTrackPublishedEvent(
           state.callCid,

--- a/packages/stream_video/lib/src/call/permissions/permissions_manager.dart
+++ b/packages/stream_video/lib/src/call/permissions/permissions_manager.dart
@@ -313,6 +313,42 @@ class PermissionsManager {
     );
   }
 
+  Future<Result<None>> pinForEveryone({
+    required String userId,
+    required String sessionId,
+  }) async {
+    if (!hasPermission(CallPermission.pinForEveryone)) {
+      _logger.w(() => '[pinForEveryone] rejected (no permission)');
+      return Result.error('Cannot pin session for everyone (no permission)');
+    }
+
+    _logger.d(() => '[pinForEveryone] pinning $userId for everyone');
+
+    return coordinatorClient.videoPin(
+      callCid: callCid,
+      sessionId: sessionId,
+      userId: userId,
+    );
+  }
+
+  Future<Result<None>> unpinForEveryone({
+    required String userId,
+    required String sessionId,
+  }) async {
+    if (!hasPermission(CallPermission.pinForEveryone)) {
+      _logger.w(() => '[unpinForEveryone] rejected (no permission)');
+      return Result.error('Cannot unpin session for everyone (no permission)');
+    }
+
+    _logger.d(() => '[unpinForEveryone] unpinning $userId for everyone');
+
+    return coordinatorClient.videoUnpin(
+      callCid: callCid,
+      sessionId: sessionId,
+      userId: userId,
+    );
+  }
+
   Future<Result<CallReaction>> sendReaction({
     required String reactionType,
     String? emojiCode,

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -814,16 +814,6 @@ class CallSession extends Disposable {
     }
   }
 
-  Future<Result<None>> setParticipantPinned({
-    required String sessionId,
-    required String userId,
-    required bool pinned,
-  }) async {
-    _logger.d(() => '[setParticipantPinned]');
-    // Nothing to do here, this is handled by the UI
-    return const Result.success(none);
-  }
-
   Future<Result<None>> updateViewportVisibility(
     VisibilityChange visibilityChange,
   ) async {

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -351,6 +351,8 @@ class CallSession extends Disposable {
       await onRtcManagerCreatedCallback?.call(rtcManager!);
       _rtcManagerSubject!.add(rtcManager!);
 
+      stateManager.sfuPinsUpdated(event.callState.pins);
+
       _logger.d(() => '[start] completed');
       return Result.success(
         (
@@ -436,6 +438,8 @@ class CallSession extends Disposable {
         for (final track in remoteTracks) {
           await _onRemoteTrackReceived(rtcManager!.subscriber, track);
         }
+
+        stateManager.sfuPinsUpdated(event.callState.pins);
 
         _logger.d(() => '[fastReconnect] completed');
         return Result.success(
@@ -546,6 +550,8 @@ class CallSession extends Disposable {
         stateManager.sfuTrackUnpublished(event);
       } else if (event is SfuDominantSpeakerChangedEvent) {
         stateManager.sfuDominantSpeakerChanged(event);
+      } else if (event is SfuPinsUpdatedEvent) {
+        stateManager.sfuPinsUpdated(event.pins);
       }
     });
   }

--- a/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
@@ -414,8 +414,8 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
           audioLevel: e.audioLevel,
           isSpeaking: e.isSpeaking,
           isDominantSpeaker: e.isDominantSpeaker,
-          isPinned: e.isPinned,
           viewportVisibility: e.viewportVisibility,
+          pin: e.pin,
         );
       } else {
         return e;

--- a/packages/stream_video/lib/src/call/state/mixins/state_participant_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_participant_mixin.dart
@@ -2,6 +2,7 @@ import 'package:state_notifier/state_notifier.dart';
 
 import '../../../call_state.dart';
 import '../../../logger/impl/tagged_logger.dart';
+import '../../../models/call_participant_pin.dart';
 import '../../../models/call_track_state.dart';
 import '../../../models/viewport_visibility.dart';
 import '../../../sfu/data/models/sfu_track_type.dart';
@@ -21,7 +22,11 @@ mixin StateParticipantMixin on StateNotifier<CallState> {
       callParticipants: state.callParticipants.map((participant) {
         if (participant.sessionId == sessionId &&
             participant.userId == userId) {
-          return participant.copyWith(isPinned: pinned);
+          return participant.copyWithPin(
+            participantPin: pinned
+                ? CallParticipantPin(isLocalPin: true, pinnedAt: DateTime.now())
+                : null,
+          );
         }
 
         return participant;

--- a/packages/stream_video/lib/src/call/state/mixins/state_sfu_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_sfu_mixin.dart
@@ -3,10 +3,12 @@ import 'package:state_notifier/state_notifier.dart';
 
 import '../../../call_state.dart';
 import '../../../logger/impl/tagged_logger.dart';
+import '../../../models/call_participant_pin.dart';
 import '../../../models/call_participant_state.dart';
 import '../../../models/call_preferences.dart';
 import '../../../models/call_track_state.dart';
 import '../../../sfu/data/events/sfu_events.dart';
+import '../../../sfu/data/models/sfu_pin.dart';
 import '../../../sfu/sfu_extensions.dart';
 
 final _logger = taggedLogger(tag: 'SV:CoordNotifier');
@@ -136,6 +138,33 @@ mixin StateSfuMixin on StateNotifier<CallState> {
           );
         }
         return participant;
+      }).toList(),
+    );
+  }
+
+  void sfuPinsUpdated(
+    List<SfuPin> pins,
+  ) {
+    state = state.copyWith(
+      callParticipants: state.callParticipants.map((participant) {
+        final pin = pins.firstWhereOrNull((it) {
+          return it.userId == participant.userId &&
+              it.sessionId == participant.sessionId;
+        });
+        if (pin != null) {
+          return participant.copyWithPin(
+            participantPin: CallParticipantPin(
+              isLocalPin: false,
+              pinnedAt: DateTime.now(),
+            ),
+          );
+        } else if (participant.pin != null && !participant.pin!.isLocalPin) {
+          return participant.copyWithPin(
+            participantPin: null,
+          );
+        } else {
+          return participant;
+        }
       }).toList(),
     );
   }

--- a/packages/stream_video/lib/src/coordinator/coordinator_client.dart
+++ b/packages/stream_video/lib/src/coordinator/coordinator_client.dart
@@ -272,4 +272,16 @@ abstract class CoordinatorClient {
     String? image,
     Map<String, Object> custom = const {},
   });
+
+  Future<Result<None>> videoPin({
+    required StreamCallCid callCid,
+    required String sessionId,
+    required String userId,
+  });
+
+  Future<Result<None>> videoUnpin({
+    required StreamCallCid callCid,
+    required String sessionId,
+    required String userId,
+  });
 }

--- a/packages/stream_video/lib/src/coordinator/open_api/coordinator_client_open_api.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/coordinator_client_open_api.dart
@@ -685,6 +685,64 @@ class CoordinatorClientOpenApi extends CoordinatorClient {
   }
 
   @override
+  Future<Result<None>> videoPin({
+    required StreamCallCid callCid,
+    required String sessionId,
+    required String userId,
+  }) async {
+    try {
+      final connectionResult = await _waitUntilConnected();
+      if (connectionResult is Failure) {
+        _logger.e(() => '[videoPin] no connection established');
+        return connectionResult;
+      }
+      final result = await _defaultApi.videoPin(
+        callCid.type.value,
+        callCid.id,
+        open.PinRequest(
+          sessionId: sessionId,
+          userId: userId,
+        ),
+      );
+      if (result == null) {
+        return Result.error('[videoPin] result is null');
+      }
+      return const Result.success(none);
+    } catch (e, stk) {
+      return Result.failure(VideoErrors.compose(e, stk));
+    }
+  }
+
+  @override
+  Future<Result<None>> videoUnpin({
+    required StreamCallCid callCid,
+    required String sessionId,
+    required String userId,
+  }) async {
+    try {
+      final connectionResult = await _waitUntilConnected();
+      if (connectionResult is Failure) {
+        _logger.e(() => '[videoUnpin] no connection established');
+        return connectionResult;
+      }
+      final result = await _defaultApi.videoUnpin(
+        callCid.type.value,
+        callCid.id,
+        open.UnpinRequest(
+          sessionId: sessionId,
+          userId: userId,
+        ),
+      );
+      if (result == null) {
+        return Result.error('[videoUnpin] result is null');
+      }
+      return const Result.success(none);
+    } catch (e, stk) {
+      return Result.failure(VideoErrors.compose(e, stk));
+    }
+  }
+
+  @override
   Future<Result<None>> updateUserPermissions({
     required StreamCallCid callCid,
     required String userId,

--- a/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
+++ b/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
@@ -432,6 +432,42 @@ class CoordinatorClientRetry extends CoordinatorClient {
   }
 
   @override
+  Future<Result<None>> videoPin({
+    required StreamCallCid callCid,
+    required String sessionId,
+    required String userId,
+  }) {
+    return _retryManager.execute(
+      () => _delegate.videoPin(
+        callCid: callCid,
+        sessionId: sessionId,
+        userId: userId,
+      ),
+      (error, nextAttemptDelay) async {
+        _logRetry('videoPin', error, nextAttemptDelay);
+      },
+    );
+  }
+
+  @override
+  Future<Result<None>> videoUnpin({
+    required StreamCallCid callCid,
+    required String sessionId,
+    required String userId,
+  }) {
+    return _retryManager.execute(
+      () => _delegate.videoUnpin(
+        callCid: callCid,
+        sessionId: sessionId,
+        userId: userId,
+      ),
+      (error, nextAttemptDelay) async {
+        _logRetry('videoUnpin', error, nextAttemptDelay);
+      },
+    );
+  }
+
+  @override
   Future<Result<None>> sendCustomEvent({
     required StreamCallCid callCid,
     required String eventType,

--- a/packages/stream_video/lib/src/models/call_participant_pin.dart
+++ b/packages/stream_video/lib/src/models/call_participant_pin.dart
@@ -1,0 +1,9 @@
+class CallParticipantPin {
+  const CallParticipantPin({
+    required this.isLocalPin,
+    required this.pinnedAt,
+  });
+
+  final bool isLocalPin;
+  final DateTime pinnedAt;
+}

--- a/packages/stream_video/lib/src/models/call_participant_pin.dart
+++ b/packages/stream_video/lib/src/models/call_participant_pin.dart
@@ -1,4 +1,6 @@
-class CallParticipantPin {
+import 'package:equatable/equatable.dart';
+
+class CallParticipantPin with EquatableMixin {
   const CallParticipantPin({
     required this.isLocalPin,
     required this.pinnedAt,
@@ -6,4 +8,7 @@ class CallParticipantPin {
 
   final bool isLocalPin;
   final DateTime pinnedAt;
+
+  @override
+  List<Object?> get props => [isLocalPin, pinnedAt];
 }

--- a/packages/stream_video/lib/src/models/call_participant_state.dart
+++ b/packages/stream_video/lib/src/models/call_participant_state.dart
@@ -198,7 +198,6 @@ class CallParticipantState
         audioLevels,
         isSpeaking,
         isDominantSpeaker,
-        isPinned,
         pin,
         reaction,
         viewportVisibility,

--- a/packages/stream_video/lib/src/models/call_participant_state.dart
+++ b/packages/stream_video/lib/src/models/call_participant_state.dart
@@ -5,6 +5,7 @@ import '../sfu/data/models/sfu_connection_quality.dart';
 import '../sfu/data/models/sfu_track_type.dart';
 import '../sorting/call_participant_sorting_presets.dart';
 import '../utils/string.dart';
+import 'call_participant_pin.dart';
 import 'call_reaction.dart';
 import 'call_track_state.dart';
 import 'user_info.dart';
@@ -30,7 +31,7 @@ class CallParticipantState
     List<double>? audioLevels,
     this.isSpeaking = false,
     this.isDominantSpeaker = false,
-    this.isPinned = false,
+    this.pin,
     this.reaction,
     this.viewportVisibility = ViewportVisibility.unknown,
   }) : audioLevels = audioLevels ?? [audioLevel];
@@ -55,9 +56,11 @@ class CallParticipantState
 
   final bool isSpeaking;
   final bool isDominantSpeaker;
-  final bool isPinned;
+  final CallParticipantPin? pin;
   final CallReaction? reaction;
   final ViewportVisibility viewportVisibility;
+
+  bool get isPinned => pin != null;
 
   /// Returns a copy of this [CallParticipantState] with the given fields
   /// replaced with the new values.
@@ -79,7 +82,7 @@ class CallParticipantState
     List<double>? audioLevels,
     bool? isSpeaking,
     bool? isDominantSpeaker,
-    bool? isPinned,
+    CallParticipantPin? pin,
     CallReaction? reaction,
     ViewportVisibility? viewportVisibility,
   }) {
@@ -99,7 +102,7 @@ class CallParticipantState
       audioLevels: audioLevels ?? this.audioLevels,
       isSpeaking: isSpeaking ?? this.isSpeaking,
       isDominantSpeaker: isDominantSpeaker ?? this.isDominantSpeaker,
-      isPinned: isPinned ?? this.isPinned,
+      pin: pin ?? this.pin,
       reaction: reaction ?? this.reaction,
       viewportVisibility: viewportVisibility ?? this.viewportVisibility,
     );
@@ -120,6 +123,31 @@ class CallParticipantState
       audioLevel: audioLevel,
       audioLevels: audioLevels,
       isSpeaking: isSpeaking,
+    );
+  }
+
+  CallParticipantState copyWithPin({
+    required CallParticipantPin? participantPin,
+  }) {
+    return CallParticipantState(
+      userId: userId,
+      roles: roles,
+      name: name,
+      custom: custom,
+      image: image,
+      sessionId: sessionId,
+      trackIdPrefix: trackIdPrefix,
+      publishedTracks: publishedTracks,
+      isLocal: isLocal,
+      connectionQuality: connectionQuality,
+      isOnline: isOnline,
+      audioLevel: audioLevel,
+      audioLevels: audioLevels,
+      isSpeaking: isSpeaking,
+      isDominantSpeaker: isDominantSpeaker,
+      pin: participantPin,
+      reaction: reaction,
+      viewportVisibility: viewportVisibility,
     );
   }
 
@@ -171,6 +199,7 @@ class CallParticipantState
         isSpeaking,
         isDominantSpeaker,
         isPinned,
+        pin,
         reaction,
         viewportVisibility,
       ];

--- a/packages/stream_video/lib/src/sfu/data/events/sfu_event_mapper_extensions.dart
+++ b/packages/stream_video/lib/src/sfu/data/events/sfu_event_mapper_extensions.dart
@@ -12,6 +12,7 @@ import '../models/sfu_error.dart';
 import '../models/sfu_goaway_reason.dart';
 import '../models/sfu_model_mapper_extensions.dart';
 import '../models/sfu_participant.dart';
+import '../models/sfu_pin.dart';
 import '../models/sfu_publish_options.dart';
 import '../models/sfu_track_type.dart';
 import '../models/sfu_video_layer_setting.dart';
@@ -124,6 +125,10 @@ extension SfuEventMapper on sfu_events.SfuEvent {
           userId: dominantSpeakerChanged.userId,
           sessionId: dominantSpeakerChanged.sessionId,
         );
+      case sfu_events.SfuEvent_EventPayload.pinsUpdated:
+        return SfuPinsUpdatedEvent(
+          pins: pinsUpdated.pins.map((p) => p.toDomain()).toList(),
+        );
       case sfu_events.SfuEvent_EventPayload.trackPublished:
         return SfuTrackPublishedEvent(
           userId: trackPublished.userId,
@@ -187,6 +192,7 @@ extension SfuCallStateExtension on sfu_models.CallState {
       participants: participants.map((it) => it.toDomain()).toList(),
       participantCount: participantCount.toDomain(),
       startedAt: startedAt.toDateTime(),
+      pins: pins.map((it) => it.toDomain()).toList(),
     );
   }
 }
@@ -226,7 +232,6 @@ extension SfuParticipantExtension on sfu_models.Participant {
   }
 }
 
-/// TODO
 extension SfuConnectionQualityExtension on sfu_models.ConnectionQuality {
   SfuConnectionQuality toDomain() {
     switch (this) {
@@ -244,7 +249,6 @@ extension SfuConnectionQualityExtension on sfu_models.ConnectionQuality {
   }
 }
 
-/// TODO
 extension SfuGoAwayReasonExtension on sfu_models.GoAwayReason {
   SfuGoAwayReason toDomain() {
     switch (this) {
@@ -260,7 +264,6 @@ extension SfuGoAwayReasonExtension on sfu_models.GoAwayReason {
   }
 }
 
-/// TODO
 extension SfuTrackTypeExtension on sfu_models.TrackType {
   SfuTrackType toDomain() {
     switch (this) {
@@ -280,7 +283,6 @@ extension SfuTrackTypeExtension on sfu_models.TrackType {
   }
 }
 
-/// TODO
 extension SfuErrorCodeExtension on sfu_models.ErrorCode {
   SfuErrorCode toDomain() {
     switch (this) {
@@ -399,6 +401,15 @@ extension on sfu_models.PublishOption {
       maxTemporalLayers: maxTemporalLayers,
       bitrate: bitrate,
       fps: fps,
+    );
+  }
+}
+
+extension on sfu_models.Pin {
+  SfuPin toDomain() {
+    return SfuPin(
+      userId: userId,
+      sessionId: sessionId,
     );
   }
 }

--- a/packages/stream_video/lib/src/sfu/data/events/sfu_events.dart
+++ b/packages/stream_video/lib/src/sfu/data/events/sfu_events.dart
@@ -12,6 +12,7 @@ import '../models/sfu_connection_info.dart';
 import '../models/sfu_error.dart';
 import '../models/sfu_goaway_reason.dart';
 import '../models/sfu_participant.dart';
+import '../models/sfu_pin.dart';
 import '../models/sfu_publish_options.dart';
 import '../models/sfu_track_type.dart';
 import '../models/sfu_video_sender.dart';
@@ -192,6 +193,18 @@ class SfuDominantSpeakerChangedEvent extends SfuEvent {
 
   @override
   List<Object> get props => [userId, sessionId];
+}
+
+@internal
+class SfuPinsUpdatedEvent extends SfuEvent {
+  const SfuPinsUpdatedEvent({
+    required this.pins,
+  });
+
+  final List<SfuPin> pins;
+
+  @override
+  List<Object> get props => [pins];
 }
 
 @internal

--- a/packages/stream_video/lib/src/sfu/data/models/sfu_call_state.dart
+++ b/packages/stream_video/lib/src/sfu/data/models/sfu_call_state.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 
 import 'sfu_participant.dart';
+import 'sfu_pin.dart';
 
 @immutable
 class SfuCallState with EquatableMixin {
@@ -9,11 +10,13 @@ class SfuCallState with EquatableMixin {
     required this.participants,
     required this.participantCount,
     required this.startedAt,
+    required this.pins,
   });
 
   final List<SfuParticipant> participants;
   final SfuParticipantCount participantCount;
   final DateTime startedAt;
+  final List<SfuPin> pins;
 
   @override
   String toString() {

--- a/packages/stream_video/lib/src/sfu/data/models/sfu_pin.dart
+++ b/packages/stream_video/lib/src/sfu/data/models/sfu_pin.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+
+class SfuPin with EquatableMixin {
+  SfuPin({
+    required this.userId,
+    required this.sessionId,
+  });
+
+  final String userId;
+  final String sessionId;
+
+  @override
+  List<Object?> get props => [userId, sessionId];
+}

--- a/packages/stream_video/lib/src/sorting/call_participant_state_sorting.dart
+++ b/packages/stream_video/lib/src/sorting/call_participant_state_sorting.dart
@@ -40,8 +40,16 @@ int publishingAudio(CallParticipantState a, CallParticipantState b) {
 
 /// A comparator which prioritizes participants who are pinned.
 int pinned(CallParticipantState a, CallParticipantState b) {
-  if (a.isPinned && !b.isPinned) return -1;
-  if (!a.isPinned && b.isPinned) return 1;
+  if (a.pin != null && b.pin != null) {
+    if (!a.pin!.isLocalPin && b.pin!.isLocalPin) return -1;
+    if (a.pin!.isLocalPin && !b.pin!.isLocalPin) return 1;
+    if (a.pin!.pinnedAt.isAfter(b.pin!.pinnedAt)) return -1;
+    if (a.pin!.pinnedAt.isBefore(b.pin!.pinnedAt)) return 1;
+  }
+
+  if (a.pin != null && b.pin == null) return -1;
+  if (a.pin == null && b.pin != null) return 1;
+
   return 0;
 }
 

--- a/packages/stream_video/test/call_participant_state_sorting_test.dart
+++ b/packages/stream_video/test/call_participant_state_sorting_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_video/src/models/call_participant_pin.dart';
 import 'package:stream_video/src/models/call_participant_state.dart';
 import 'package:stream_video/src/models/call_track_state.dart';
 import 'package:stream_video/src/models/viewport_visibility.dart';
@@ -26,7 +27,7 @@ void main() {
       isDominantSpeaker: false,
       audioLevel: 0,
       viewportVisibility: ViewportVisibility.visible,
-      isPinned: false,
+      pin: null,
     ),
 
     // Presenter, video, audio
@@ -47,7 +48,7 @@ void main() {
       isDominantSpeaker: false,
       audioLevel: 0,
       viewportVisibility: ViewportVisibility.visible,
-      isPinned: false,
+      pin: null,
     ),
 
     // Muted
@@ -64,7 +65,7 @@ void main() {
       isDominantSpeaker: false,
       audioLevel: 0,
       viewportVisibility: ViewportVisibility.visible,
-      isPinned: false,
+      pin: null,
     ),
 
     // Dominant speaker
@@ -81,7 +82,7 @@ void main() {
       isDominantSpeaker: true,
       audioLevel: 0,
       viewportVisibility: ViewportVisibility.visible,
-      isPinned: false,
+      pin: null,
     ),
 
     // Presenter only
@@ -98,7 +99,7 @@ void main() {
       isDominantSpeaker: false,
       audioLevel: 0,
       viewportVisibility: ViewportVisibility.visible,
-      isPinned: false,
+      pin: null,
     ),
 
     // pinned
@@ -118,7 +119,7 @@ void main() {
       isDominantSpeaker: false,
       audioLevel: 0,
       viewportVisibility: ViewportVisibility.visible,
-      isPinned: true,
+      pin: CallParticipantPin(isLocalPin: true, pinnedAt: DateTime.now()),
     ),
   ];
 


### PR DESCRIPTION
FLU-66

Added `setParticipantPinnedForEveryone()` method to `Call` object that allows for pinning given session to the top of the list for everyone in the call. It requires user to have `pin-for-everyone` permission set in the Dashboard. 

The `setParticipantPinned()` method is still available and as before will only pin the session locally.