### PR TITLE
fix(web): ensure screen sharing is ended when stopping it through browser

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2190,6 +2190,15 @@ class Call {
       _connectOptions = _connectOptions.copyWith(
         screenShare: enabled ? TrackOption.enabled() : TrackOption.disabled(),
       );
+
+      if (enabled) {
+        _session?.rtcManager
+            ?.getPublisherTrackByType(SfuTrackType.screenShare)
+            ?.mediaTrack
+            .onEnded = () {
+          setScreenShareEnabled(enabled: false);
+        };
+      }
     }
 
     return result;


### PR DESCRIPTION
### 🎯 Goal

This PR fixes #905.

### 🛠 Implementation details

It does so by listening to the mediaTrack onEnded event and disabling the screen sharing.

### 🧪 Testing

It can be tested through https://getstream.github.io/stream-video-flutter/ (where it doesn't work on the current version) and then testing with the modifications on this branch on web version.


### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
