### PR TITLE
fix(android): add missing MANAGE_OWN_CALLS permission due to foreground service with phoneCall type

### DIFF
--- a/packages/stream_video_flutter/android/src/main/AndroidManifest.xml
+++ b/packages/stream_video_flutter/android/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
### 🎯 Goal

This PR aims to avoid errors on manufacturers that enforce the MANAGE_OWN_CALLS permission when using a foreground service of type phoneCall. It fixes #907 .

### 🛠 Implementation details

The MANAGE_OWN_CALLS permission was added on the AndroidManifest of stream_video_flutter package.

### 🧪 Testing

We were able to reproduce the issue on a Samsung device, but I'm not sure it's on all Samsung devices. The permission is a prerequisite from Android, as explained on #907.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
