### PR TITLE
feat: enable usage of external internet connection package or customization of health check endpoints

### DIFF
--- a/packages/stream_video/lib/src/models/call_preferences.dart
+++ b/packages/stream_video/lib/src/models/call_preferences.dart
@@ -1,4 +1,7 @@
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
+
 import 'call_client_publish_options.dart';
+import 'health_check_endpoint.dart';
 
 abstract class CallPreferences {
   Duration get connectTimeout;
@@ -10,6 +13,10 @@ abstract class CallPreferences {
 
   int get closedCaptionsVisibilityDurationMs;
   int get closedCaptionsVisibleCaptions;
+
+  InternetConnection? get internetConnectionInstance;
+  List<HealthCheckEndpoint>? get healthCheckEndpoints;
+  Duration get healthCheckInterval;
 }
 
 class DefaultCallPreferences implements CallPreferences {
@@ -21,6 +28,9 @@ class DefaultCallPreferences implements CallPreferences {
     this.clientPublishOptions,
     this.closedCaptionsVisibilityDurationMs = 2700,
     this.closedCaptionsVisibleCaptions = 2,
+    this.internetConnectionInstance,
+    this.healthCheckEndpoints,
+    this.healthCheckInterval = const Duration(seconds: 1),
   });
 
   @override
@@ -43,4 +53,13 @@ class DefaultCallPreferences implements CallPreferences {
 
   @override
   final int closedCaptionsVisibleCaptions;
+
+  @override
+  final InternetConnection? internetConnectionInstance;
+
+  @override
+  final List<HealthCheckEndpoint>? healthCheckEndpoints;
+
+  @override
+  final Duration healthCheckInterval;
 }

--- a/packages/stream_video/lib/src/models/health_check_endpoint.dart
+++ b/packages/stream_video/lib/src/models/health_check_endpoint.dart
@@ -1,0 +1,13 @@
+class HealthCheckEndpoint {
+  HealthCheckEndpoint({
+    required this.uri,
+    this.timeout = const Duration(seconds: 3),
+    this.headers = const {},
+    this.validStatusCodes = const [200],
+  });
+
+  final Uri uri;
+  final Duration timeout;
+  final Map<String, String> headers;
+  final List<int> validStatusCodes;
+}

--- a/packages/stream_video/lib/src/models/models.dart
+++ b/packages/stream_video/lib/src/models/models.dart
@@ -19,6 +19,7 @@ export 'call_status.dart';
 export 'call_track_state.dart';
 export 'disconnect_reason.dart';
 export 'guest_created_data.dart';
+export 'health_check_endpoint.dart';
 export 'push_device.dart';
 export 'push_provider.dart';
 export 'queried_calls.dart';


### PR DESCRIPTION
### 🎯 Goal

This PR aims to give the package's users a choice in how health checks are done, or even the choice to use their already existing instance of the internet_connection_checker_plus to avoid duplication of health checks. The package uses the four domains listed below:
![image](https://github.com/user-attachments/assets/d9e796b8-3360-48f1-9a5e-11e2e3d861a4)
We already had reports from more tech savvy users asking what those were, and that led us to implement a custom health check domain that only responds with a 204 status and is not dependent on our backend. Before starting to use stream-video-flutter, we already had that implemented using the internet_connection_checker_plus package, and we observed the domains were back when we started using stream-video-flutter. Thus, we implemented this on our fork to use the same instance of the InternetConnection to avoid multiple calls to health check endpoints being made.

### 🛠 Implementation details

The implementation consists of adding three new parameters to CallPreferences: `internetConnectionInstance`, `healthCheckEndpoints` (a `HealthCheckEndpoint` model was implemented too) and `healthCheckInterval`. If `internetConnectionInstance` is provided, it's used on the `Call` class as the instance. If `healthCheckEndpoints` are provided and the instance is not, the `Call` class creates a new InternetConnection instance with those endpoints, and uses the `healthCheckInterval` as the interval for health checks. All options are optional and defaults are provided, as to not disrupt existing users while providing the option if the need arises.

### 🧪 Testing

The changes can be tested by running the example app without setting any options and verifying the health checks continue to work, then providing custom endpoints and interval and checking those are called instead of the InternetConnection default's, and then creating an instance of InternetConnection and providing it on `internetConnectionInstance` and verifying that the configurations done on it are the ones being used by the package.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
