### PR TITLE
fix(llc): fix checks for local participant

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2192,16 +2192,13 @@ class Call {
       );
 
       if (enabled) {
-        _session?.rtcManager
-            ?.getPublisherTrackByType(SfuTrackType.screenShare)
-            ?.mediaTrack
-            .onEnded = () {
+        result.getDataOrNull()?.mediaTrack.onEnded = () {
           setScreenShareEnabled(enabled: false);
         };
       }
     }
 
-    return result;
+    return result.map((_) => none);
   }
 
   Future<Result<None>> setAudioInputDevice(RtcMediaDevice device) async {

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -328,7 +328,7 @@ class CallSession extends Disposable {
       } else {
         final currentUserId = stateManager.callState.currentUserId;
         final localParticipant = event.callState.participants.firstWhere(
-          (it) => it.userId == currentUserId,
+          (it) => it.userId == currentUserId && it.sessionId == sessionId,
         );
         final localTrackId = localParticipant.trackLookupPrefix;
 
@@ -890,7 +890,7 @@ class CallSession extends Disposable {
     return result.map((_) => none);
   }
 
-  Future<Result<None>> setScreenShareEnabled(
+  Future<Result<RtcLocalTrack>> setScreenShareEnabled(
     bool enabled, {
     ScreenShareConstraints? constraints,
   }) async {
@@ -904,7 +904,7 @@ class CallSession extends Disposable {
       constraints: constraints,
     );
 
-    return result.map((_) => none);
+    return result;
   }
 
   Future<Result<RtcLocalTrack<CameraConstraints>>> flipCamera() async {

--- a/packages/stream_video/lib/src/call/state/mixins/state_call_actions_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_call_actions_mixin.dart
@@ -34,7 +34,7 @@ mixin StateCallActionsMixin on StateNotifier<CallState> {
   }
 
   void setCallAudioProcessing({required bool isAudioProcessing}) {
-    _logger.e(
+    _logger.v(
       () => '[setCallAudioProcessing] isAudioProcessing:$isAudioProcessing',
     );
     state = state.copyWith(

--- a/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
@@ -305,11 +305,14 @@ extension on CallMetadata {
 
     for (final participant in participantsData) {
       final userId = participant.userId;
+      final sessionId = participant.userSessionId;
       final member = members[userId];
       final user = users[userId];
-      final currentState =
-          state.callParticipants.firstWhereOrNull((it) => it.userId == userId);
-      final isLocal = state.currentUserId == userId;
+      final currentState = state.callParticipants.firstWhereOrNull(
+        (it) => it.userId == userId && it.sessionId == sessionId,
+      );
+      final isLocal =
+          state.currentUserId == userId && state.sessionId == sessionId;
 
       result.add(
         currentState?.copyWith(
@@ -317,7 +320,7 @@ extension on CallMetadata {
               name: user?.name ?? '',
               custom: user?.custom ?? {},
               image: user?.image ?? '',
-              sessionId: participant.userSessionId,
+              sessionId: sessionId,
               isLocal: isLocal,
               isOnline: !isLocal,
             ) ??

--- a/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
@@ -309,10 +309,12 @@ extension on CallMetadata {
       final member = members[userId];
       final user = users[userId];
       final currentState = state.callParticipants.firstWhereOrNull(
-        (it) => it.userId == userId && it.sessionId == sessionId,
+        (it) =>
+            it.userId == userId &&
+            (sessionId == null || it.sessionId == sessionId),
       );
-      final isLocal =
-          state.currentUserId == userId && state.sessionId == sessionId;
+      final isLocal = state.currentUserId == userId &&
+          (sessionId == null || state.sessionId == sessionId);
 
       result.add(
         currentState?.copyWith(

--- a/packages/stream_video/lib/src/call/state/mixins/state_sfu_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_sfu_mixin.dart
@@ -195,7 +195,9 @@ mixin StateSfuMixin on StateNotifier<CallState> {
     _logger.d(
       () => '[sfuParticipantJoined] ${state.sessionId}; event: $event',
     );
-    final isLocal = state.currentUserId == event.participant.userId;
+    final isLocal = state.currentUserId == event.participant.userId &&
+        state.sessionId == event.participant.sessionId;
+
     final participant = CallParticipantState(
       userId: event.participant.userId,
       roles: event.participant.roles,

--- a/packages/stream_video/lib/src/sfu/sfu_extensions.dart
+++ b/packages/stream_video/lib/src/sfu/sfu_extensions.dart
@@ -7,7 +7,8 @@ import 'data/models/sfu_participant.dart';
 
 extension SfuParticipantX on SfuParticipant {
   CallParticipantState toParticipantState(CallState state) {
-    final isLocal = userId == state.currentUserId;
+    final isLocal =
+        userId == state.currentUserId && sessionId == state.sessionId;
     final existing = state.callParticipants.firstWhereOrNull(
       (it) => it.userId == userId,
     );


### PR DESCRIPTION
This pull request addresses a problem that occurs when a participant joins a call from multiple devices, leading to several issues with call controls. The fix ensures that we compare both the userId and sessionId, rather than just the userId, allowing us to differentiate between the same user participating in different sessions.

Fixes: https://github.com/GetStream/stream-video-flutter/issues/914
FLU-45