### PR TITLE
fix(llc): multiple screen sharing sources

### DIFF
--- a/packages/stream_video/lib/src/webrtc/rtc_manager.dart
+++ b/packages/stream_video/lib/src/webrtc/rtc_manager.dart
@@ -1173,9 +1173,6 @@ extension RtcManagerTrackHelper on RtcManager {
       if (enabled &&
           track is RtcLocalScreenShareTrack &&
           !track.compareScreenShareMode(constraints)) {
-        // If existing screen share track has different broadcast extension constraints, unpublish it and create a new one.
-        await unpublishTrack(trackId: track.trackId);
-
         return _createAndPublishTrack(
           trackType: trackType,
           constraints: constraints,


### PR DESCRIPTION
With the changes in how we handle RTC transceivers during codec negotiation implementation, we no longer need to unpublish the previous screen sharing track when we start screen sharing with new constraints. The transceiver will be reused for the new track.