### PR TITLE
feat: sync CallKit screen mute button with SDK mute action

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2149,6 +2149,9 @@ class Call {
         Result.error('Session is null');
 
     if (result.isSuccess) {
+      await _streamVideo.pushNotificationManager
+          ?.setCallMutedByCid(callCid.value, !enabled);
+
       _stateManager.participantSetMicrophoneEnabled(
         enabled: enabled,
       );

--- a/packages/stream_video/lib/src/push_notification/push_notification_manager.dart
+++ b/packages/stream_video/lib/src/push_notification/push_notification_manager.dart
@@ -107,6 +107,9 @@ abstract class PushNotificationManager {
   /// [uuid] is the unique identifier for the call.
   Future<void> setCallConnected(String uuid);
 
+  /// Sets call as muted/unmuted (iOS only).
+  Future<void> setCallMutedByCid(String cid, bool isMuted);
+
   /// Retrieves a list of active calls.
   Future<List<CallData>> activeCalls();
 

--- a/packages/stream_video_flutter/lib/src/call_screen/call_container.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_container.dart
@@ -131,6 +131,7 @@ class _StreamCallContainerState extends State<StreamCallContainer> {
       _callState = callState;
     });
     if (callState.status.isDisconnected) {
+      _callStateSubscription?.cancel();
       if (widget.onCallDisconnected != null) {
         final disconnectedStatus = callState.status as CallStatusDisconnected;
         final disconnectedProperties = CallDisconnectedProperties(


### PR DESCRIPTION
Resolves FLU-83

This PR makes sure that muting the call on the CallKit screen on iOS is synced with the mute in SDK in both directions