### PR TITLE
fix: call preference initialization during ringing

### DIFF
--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -143,10 +143,12 @@ class _CallScreenState extends State<CallScreen> {
           },
           onCallDisconnected: (disconnectedProperties) {
             final reason = disconnectedProperties.reason;
+
+            Navigator.of(context).pop();
+
             if (reason is DisconnectReasonCancelled ||
                 reason is DisconnectReasonEnded ||
                 reason is DisconnectReasonLastParticipantLeft) {
-              Navigator.of(context).pop();
               showFeedbackDialog(context, call: widget.call);
             }
           },

--- a/packages/stream_video/lib/src/call/state/call_state_notifier.dart
+++ b/packages/stream_video/lib/src/call/state/call_state_notifier.dart
@@ -2,7 +2,7 @@ import 'package:state_notifier/state_notifier.dart';
 
 import '../../call_state.dart';
 import '../../logger/impl/tagged_logger.dart';
-import '../../models/call_preferences.dart';
+import '../../models/models.dart';
 import '../../state_emitter.dart';
 import 'mixins/state_call_actions_mixin.dart';
 import 'mixins/state_coordinator_mixin.dart';
@@ -19,16 +19,12 @@ class CallStateNotifier extends StateNotifier<CallState>
         StateRtcMixin,
         StateSfuMixin,
         StateCallActionsMixin {
-  CallStateNotifier(CallState initialState, this.callPreferences)
-      : super(initialState) {
+  CallStateNotifier(CallState initialState) : super(initialState) {
     callStateStream =
         MutableStateEmitterImpl<CallState>(initialState, sync: true);
   }
 
   final _logger = taggedLogger(tag: 'CallStateNotifier');
-
-  @override
-  final CallPreferences callPreferences;
 
   late final MutableStateEmitterImpl<CallState> callStateStream;
   CallState get callState => callStateStream.value;
@@ -41,6 +37,11 @@ class CallStateNotifier extends StateNotifier<CallState>
 
     super.state = value;
     callStateStream.value = value;
+  }
+
+  void updateCallPreferences(CallPreferences preferences) {
+    _logger.v(() => '[updateCallPreferences] $preferences');
+    state = state.copyWith(preferences: preferences);
   }
 
   @override

--- a/packages/stream_video/lib/src/call/state/mixins/state_sfu_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_sfu_mixin.dart
@@ -5,7 +5,6 @@ import '../../../call_state.dart';
 import '../../../logger/impl/tagged_logger.dart';
 import '../../../models/call_participant_pin.dart';
 import '../../../models/call_participant_state.dart';
-import '../../../models/call_preferences.dart';
 import '../../../models/call_track_state.dart';
 import '../../../sfu/data/events/sfu_events.dart';
 import '../../../sfu/data/models/sfu_pin.dart';
@@ -14,8 +13,6 @@ import '../../../sfu/sfu_extensions.dart';
 final _logger = taggedLogger(tag: 'SV:CoordNotifier');
 
 mixin StateSfuMixin on StateNotifier<CallState> {
-  CallPreferences get callPreferences;
-
   void sfuParticipantLeft(
     SfuParticipantLeftEvent event,
   ) {

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -12,8 +12,10 @@ class CallState extends Equatable {
   factory CallState({
     required String currentUserId,
     required StreamCallCid callCid,
+    required CallPreferences preferences,
   }) {
     return CallState._(
+      preferences: preferences,
       currentUserId: currentUserId,
       callCid: callCid,
       createdByUserId: '',
@@ -55,6 +57,7 @@ class CallState extends Equatable {
   }
 
   const CallState._({
+    required this.preferences,
     required this.currentUserId,
     required this.callCid,
     required this.createdByUserId,
@@ -94,6 +97,7 @@ class CallState extends Equatable {
     required this.custom,
   });
 
+  final CallPreferences preferences;
   final String currentUserId;
   final StreamCallCid callCid;
   final String createdByUserId;
@@ -151,6 +155,7 @@ class CallState extends Equatable {
   /// Returns a copy of this [CallState] with the given fields replaced
   /// with the new values.
   CallState copyWith({
+    CallPreferences? preferences,
     String? currentUserId,
     StreamCallCid? callCid,
     String? createdByUserId,
@@ -190,6 +195,7 @@ class CallState extends Equatable {
     Map<String, Object>? custom,
   }) {
     return CallState._(
+      preferences: preferences ?? this.preferences,
       currentUserId: currentUserId ?? this.currentUserId,
       callCid: callCid ?? this.callCid,
       createdByUserId: createdByUserId ?? this.createdByUserId,


### PR DESCRIPTION
Fixes FLU-47

This pull request addresses the management of call preferences, particularly during the ringing flow. Previously, call preferences set while creating a ringing call could be overlooked if `StreamVideo.incomingCall` was set beforehand when handling the ringing event. Additionally, default call properties have been added to the StreamVideo options for improved functionality.