### PR TITLE
feat: Set bundlePolicy for the peerconnection

### DIFF
--- a/packages/stream_video/lib/src/types/other.dart
+++ b/packages/stream_video/lib/src/types/other.dart
@@ -38,6 +38,8 @@ class RTCConfiguration {
     return <String, dynamic>{
       // only supports unified plan
       'sdpSemantics': 'unified-plan',
+      'bundlePolicy':
+          'max-bundle', // https://linear.app/stream/issue/FLU-91/peerconnection-rtp-bundle
       if (iceServersMap.isNotEmpty) 'iceServers': iceServersMap,
       if (iceCandidatePoolSize != null)
         'iceCandidatePoolSize': iceCandidatePoolSize,

--- a/packages/stream_video/test/src/types/rtc_configuration_test.dart
+++ b/packages/stream_video/test/src/types/rtc_configuration_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_video/stream_video.dart' show RTCConfiguration;
+
+void main() {
+  test('Verify default configurations', () {
+    const sut = RTCConfiguration();
+    final map = sut.toMap();
+
+    expect(map['sdpSemantics'], 'unified-plan');
+    expect(map['bundlePolicy'], 'max-bundle');
+  });
+}


### PR DESCRIPTION
Fixes FLU-91

### 🎯 Goal

RTP BUNDLE is a mechanism in [RTP](https://bloggeek.me/webrtcglossary/rtp/) that enables using a single socket/connection to send multiple media types.

This is typically used to send audio and video over the same connection, and allows reducing the number of opened sockets and pinholes that need to be managed and reduces the resources required to get a session work through a firewall or [NAT](https://bloggeek.me/webrtcglossary/nat/) device.

### 🛠 Implementation details

Sets the `bundlePolicy` and includes a unit test

### 🎨 UI Changes

No UI change

### 🧪 Testing

Added a test to verify the field is set. We should do some manual call tests

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
