### PR TITLE
chore: bump flutter callkit incoming

### DIFF
--- a/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
@@ -485,6 +485,9 @@ const _defaultPushParams = StreamVideoPushParams(
     subtitle: 'Missed call',
     callbackText: 'Call back',
   ),
+  callingNotification: NotificationParams(
+    showNotification: false,
+  ),
   android: AndroidParams(
     isCustomNotification: true,
     isShowLogo: false,

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_params.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_params.dart
@@ -17,6 +17,7 @@ class StreamVideoPushParams extends CallKitParams {
     super.textAccept,
     super.textDecline,
     super.missedCallNotification,
+    super.callingNotification,
     super.extra,
     super.headers,
     super.android,
@@ -34,6 +35,7 @@ class StreamVideoPushParams extends CallKitParams {
     super.textAccept,
     super.textDecline,
     super.missedCallNotification,
+    super.callingNotification,
     super.extra,
     super.headers,
     super.android,
@@ -52,6 +54,7 @@ class StreamVideoPushParams extends CallKitParams {
     String? textAccept,
     String? textDecline,
     NotificationParams? missedCallNotification,
+    NotificationParams? callingNotification,
     Map<String, Object?>? extra,
     Map<String, Object?>? headers,
     AndroidParams? android,
@@ -69,6 +72,7 @@ class StreamVideoPushParams extends CallKitParams {
       textDecline: textDecline ?? this.textDecline,
       missedCallNotification:
           missedCallNotification ?? this.missedCallNotification,
+      callingNotification: callingNotification ?? this.callingNotification,
       extra: extra ?? this.extra,
       headers: headers ?? this.headers,
       android: android ?? this.android,
@@ -92,6 +96,8 @@ class StreamVideoPushParams extends CallKitParams {
       textDecline: other.textDecline,
       missedCallNotification:
           missedCallNotification?.merge(other.missedCallNotification),
+      callingNotification:
+          callingNotification?.merge(other.callingNotification),
       extra: other.extra,
       headers: other.headers,
       android: android?.merge(other.android),

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_params.g.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_params.g.dart
@@ -14,14 +14,18 @@ StreamVideoPushParams _$StreamVideoPushParamsFromJson(
       appName: json['appName'] as String?,
       avatar: json['avatar'] as String?,
       handle: json['handle'] as String?,
-      type: json['type'] as int?,
-      duration: json['duration'] as int?,
+      type: (json['type'] as num?)?.toInt(),
+      duration: (json['duration'] as num?)?.toInt(),
       textAccept: json['textAccept'] as String?,
       textDecline: json['textDecline'] as String?,
       missedCallNotification: json['missedCallNotification'] == null
           ? null
           : NotificationParams.fromJson(
               json['missedCallNotification'] as Map<String, dynamic>),
+      callingNotification: json['callingNotification'] == null
+          ? null
+          : NotificationParams.fromJson(
+              json['callingNotification'] as Map<String, dynamic>),
       extra: json['extra'] as Map<String, dynamic>?,
       headers: json['headers'] as Map<String, dynamic>?,
       android: json['android'] == null
@@ -45,6 +49,7 @@ Map<String, dynamic> _$StreamVideoPushParamsToJson(
       'textAccept': instance.textAccept,
       'textDecline': instance.textDecline,
       'missedCallNotification': instance.missedCallNotification?.toJson(),
+      'callingNotification': instance.callingNotification?.toJson(),
       'extra': instance.extra,
       'headers': instance.headers,
       'android': instance.android?.toJson(),

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   firebase_messaging: ^15.2.0
   flutter:
     sdk: flutter
-  flutter_callkit_incoming: ^2.5.0
+  flutter_callkit_incoming: ^2.5.2
   json_annotation: ^4.9.0
   meta: ^1.9.1
   plugin_platform_interface: ^2.1.8


### PR DESCRIPTION
fixes FLU-95

Bumps the `flutter_callkit_incoming` version to the latest release and disables the new outgoing call notification, which is enabled by default, since we have a similar feature on our end.