### PR TITLE
Feature/upgrade macos version

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -46,7 +46,7 @@ concurrency:
 jobs:
   build_and_deploy_ios:
     name: Build and Distribute Dogfooding Ios
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 60
     if: ${{ github.event_name == 'push' || inputs.build_ios == true }}
     steps:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -102,7 +102,7 @@ jobs:
   build_and_deploy_android:
     name: Build and Distribute Dogfooding Android
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     if: ${{ github.event_name == 'push' || inputs.build_android == true }}
     steps:
       - name: Checkout code

--- a/.github/workflows/stream_video_flutter_workflow.yml
+++ b/.github/workflows/stream_video_flutter_workflow.yml
@@ -65,7 +65,7 @@ jobs:
           melos run format:verify
 
   build:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout


### PR DESCRIPTION
### 🎯 Goal

Fixes FLU-72

### 🛠 Implementation details

Updates macos and xcode build version so we are compiled for iOS 18.
It also updates the Android timeout, because regular builds are already between 13 and 15 minutes and easily timeout.

### 🎨 UI Changes

No UI changes

### 🧪 Testing

Made a testrun: https://github.com/GetStream/stream-video-flutter/actions/runs/14329277823/job/40161329260


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
