### PR TITLE
chore: added members to call state

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -458,14 +458,6 @@ class Call {
         return _stateManager.coordinatorCallBroadcastingStopped(event);
       case StreamCallBroadcastingFailedEvent _:
         return _stateManager.coordinatorCallBroadcastingFailed(event);
-      case StreamCallRingingEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
-      case StreamCallMissedEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
-      case StreamCallSessionEndedEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
-      case StreamCallSessionStartedEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
       case StreamCallUpdatedEvent _:
         return _stateManager.callMetadataChanged(
           event.metadata,
@@ -493,6 +485,20 @@ class Call {
               event.participantsCountByRole.values.fold(0, (a, b) => a + b),
           anonymousCount: event.anonymousParticipantCount,
         );
+      case StreamCallRingingEvent _:
+        return _stateManager.callMetadataChanged(event.metadata);
+      case StreamCallMissedEvent _:
+        return _stateManager.callMetadataChanged(event.metadata);
+      case StreamCallSessionEndedEvent _:
+        return _stateManager.callMetadataChanged(event.metadata);
+      case StreamCallSessionStartedEvent _:
+        return _stateManager.callMetadataChanged(event.metadata);
+      case StreamCallMemberAddedEvent _:
+        return _stateManager.callMetadataChanged(event.metadata);
+      case StreamCallMemberRemovedEvent _:
+        return _stateManager.callMetadataChanged(event.metadata);
+      case StreamCallMemberUpdatedEvent _:
+        return _stateManager.callMetadataChanged(event.metadata);
       default:
         break;
     }

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -485,6 +485,16 @@ class Call {
               event.participantsCountByRole.values.fold(0, (a, b) => a + b),
           anonymousCount: event.anonymousParticipantCount,
         );
+      case StreamCallMemberAddedEvent _:
+        return _stateManager.coordinatorCallMemberAdded(event);
+      case StreamCallMemberRemovedEvent _:
+        return _stateManager.coordinatorCallMemberRemoved(event);
+      case StreamCallMemberUpdatedEvent _:
+        return _stateManager.coordinatorCallMemberUpdated(event);
+      case StreamCallUserBlockedEvent _:
+        return _stateManager.coordinatorCallUserBlocked(event);
+      case StreamCallUserUnblockedEvent _:
+        return _stateManager.coordinatorCallUserUnblocked(event);
       case StreamCallRingingEvent _:
         return _stateManager.callMetadataChanged(event.metadata);
       case StreamCallMissedEvent _:
@@ -493,12 +503,7 @@ class Call {
         return _stateManager.callMetadataChanged(event.metadata);
       case StreamCallSessionStartedEvent _:
         return _stateManager.callMetadataChanged(event.metadata);
-      case StreamCallMemberAddedEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
-      case StreamCallMemberRemovedEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
-      case StreamCallMemberUpdatedEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
+
       default:
         break;
     }

--- a/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
@@ -98,7 +98,8 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
 
       if (everyoneElseRejected) {
         _logger.d(
-            () => '[coordinatorCallRejected] everyone rejected, disconnecting');
+          () => '[coordinatorCallRejected] everyone rejected, disconnecting',
+        );
         state = state.copyWith(
           status: CallStatus.disconnected(
             DisconnectReason.rejected(
@@ -115,7 +116,8 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
     } else {
       if (rejectedBy.keys.contains(state.createdByUserId)) {
         _logger.d(
-            () => '[coordinatorCallRejected] creator rejected, disconnecting');
+          () => '[coordinatorCallRejected] creator rejected, disconnecting',
+        );
         state = state.copyWith(
           status: CallStatus.disconnected(
             DisconnectReason.rejected(
@@ -514,11 +516,5 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
           .where((userId) => userId != event.user.id)
           .toList(),
     );
-  }
-}
-
-extension on List<CallParticipantState> {
-  bool hasSingle(String userId) {
-    return length == 1 && firstOrNull?.userId == userId;
   }
 }

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -158,6 +158,15 @@ class CallState extends Equatable {
 
   bool get createdByMe => createdByUserId == currentUserId;
 
+  List<CallMemberState> get ringingMembers {
+    return callMembers
+        .where((member) =>
+            member.callAcceptedAt == null &&
+            member.callRejectedAt == null &&
+            member.userId != currentUserId)
+        .toList();
+  }
+
   /// Returns a copy of this [CallState] with the given fields replaced
   /// with the new values.
   CallState copyWith({

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -160,10 +160,12 @@ class CallState extends Equatable {
 
   List<CallMemberState> get ringingMembers {
     return callMembers
-        .where((member) =>
-            member.callAcceptedAt == null &&
-            member.callRejectedAt == null &&
-            member.userId != currentUserId)
+        .where(
+          (member) =>
+              member.callAcceptedAt == null &&
+              member.callRejectedAt == null &&
+              member.userId != currentUserId,
+        )
         .toList();
   }
 

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -3,6 +3,7 @@ import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 
 import 'call/call_type.dart';
+import 'models/call_member_state.dart';
 import 'models/models.dart';
 import 'webrtc/rtc_media_device/rtc_media_device.dart';
 
@@ -36,6 +37,7 @@ class CallState extends Equatable {
       audioOutputDevice: null,
       ownCapabilities: List.unmodifiable(const []),
       callParticipants: List.unmodifiable(const []),
+      callMembers: List.unmodifiable(const []),
       capabilitiesByRole: const {},
       createdAt: null,
       updatedAt: null,
@@ -75,6 +77,7 @@ class CallState extends Equatable {
     required this.rtmpIngress,
     required this.ownCapabilities,
     required this.callParticipants,
+    required this.callMembers,
     required this.capabilitiesByRole,
     required this.videoInputDevice,
     required this.audioInputDevice,
@@ -118,6 +121,7 @@ class CallState extends Equatable {
   final RtcMediaDevice? audioOutputDevice;
   final List<CallPermission> ownCapabilities;
   final List<CallParticipantState> callParticipants;
+  final List<CallMemberState> callMembers;
   final Map<String, List<String>> capabilitiesByRole;
   final DateTime? createdAt;
   final DateTime? startsAt;
@@ -152,6 +156,8 @@ class CallState extends Equatable {
     return callParticipants.where((element) => element.isSpeaking).toList();
   }
 
+  bool get createdByMe => createdByUserId == currentUserId;
+
   /// Returns a copy of this [CallState] with the given fields replaced
   /// with the new values.
   CallState copyWith({
@@ -176,6 +182,7 @@ class CallState extends Equatable {
     RtcMediaDevice? audioOutputDevice,
     List<CallPermission>? ownCapabilities,
     List<CallParticipantState>? callParticipants,
+    List<CallMemberState>? callMembers,
     Map<String, List<String>>? capabilitiesByRole,
     DateTime? createdAt,
     DateTime? updatedAt,
@@ -216,6 +223,7 @@ class CallState extends Equatable {
       audioOutputDevice: audioOutputDevice ?? this.audioOutputDevice,
       ownCapabilities: ownCapabilities ?? this.ownCapabilities,
       callParticipants: callParticipants ?? this.callParticipants,
+      callMembers: callMembers ?? this.callMembers,
       capabilitiesByRole: capabilitiesByRole ?? this.capabilitiesByRole,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
@@ -265,6 +273,7 @@ class CallState extends Equatable {
       liveEndedAt: metadata.session.liveEndedAt,
       timerEndsAt: metadata.session.timerEndsAt,
       capabilitiesByRole: capabilitiesByRole,
+      callMembers: metadata.toCallMembers(),
     );
   }
 

--- a/packages/stream_video/lib/src/coordinator/open_api/open_api_mapper_extensions.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/open_api_mapper_extensions.dart
@@ -8,7 +8,6 @@ import '../models/coordinator_events.dart';
 import 'event/event_type.dart';
 import 'event/open_api_event.dart';
 import 'open_api_extensions.dart';
-import '../../../../open_api/video/coordinator/api.dart' as open;
 
 extension WebsocketEventMapperExt on OpenApiEvent {
   /// Returns [CoordinatorEvent].
@@ -396,6 +395,5 @@ extension WebsocketEventMapperExt on OpenApiEvent {
       case EventType.unknown:
         return const CoordinatorUnknownEvent();
     }
-    return const CoordinatorUnsupportedEvent();
   }
 }

--- a/packages/stream_video/lib/src/models/call_member_state.dart
+++ b/packages/stream_video/lib/src/models/call_member_state.dart
@@ -17,6 +17,16 @@ class CallMemberState with EquatableMixin {
     this.callAcceptedAt,
   });
 
+  factory CallMemberState.fromCallMember(CallMember member, CallUser? user) {
+    return CallMemberState(
+      userId: member.userId,
+      roles: member.roles,
+      name: user?.name ?? member.userId,
+      custom: member.custom,
+      image: user?.image,
+    );
+  }
+
   final String userId;
   final List<String> roles;
   final String name;

--- a/packages/stream_video/lib/src/models/call_member_state.dart
+++ b/packages/stream_video/lib/src/models/call_member_state.dart
@@ -1,0 +1,50 @@
+import 'package:collection/collection.dart';
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+import 'call_metadata.dart';
+import 'user_info.dart';
+
+@immutable
+class CallMemberState with EquatableMixin {
+  const CallMemberState({
+    required this.userId,
+    required this.roles,
+    required this.name,
+    required this.custom,
+    this.image,
+  });
+
+  final String userId;
+  final List<String> roles;
+  final String name;
+  final Map<String, Object?> custom;
+  final String? image;
+
+  @override
+  List<Object?> get props => [userId, roles, name, custom];
+
+  UserInfo toUserInfo() => UserInfo(
+        id: userId,
+        role: roles.firstOrNull ?? '',
+        name: name,
+        image: image,
+      );
+}
+
+extension CallMemberStateMetadataX on CallMetadata {
+  List<CallMemberState> toCallMembers() {
+    return members.values.map((member) {
+      final user = users.values.firstWhereOrNull(
+        (user) => user.id == member.userId,
+      );
+      return CallMemberState(
+        userId: member.userId,
+        roles: member.roles,
+        name: user?.name ?? member.userId,
+        custom: member.custom,
+        image: user?.image,
+      );
+    }).toList();
+  }
+}

--- a/packages/stream_video/lib/src/models/call_member_state.dart
+++ b/packages/stream_video/lib/src/models/call_member_state.dart
@@ -13,6 +13,8 @@ class CallMemberState with EquatableMixin {
     required this.name,
     required this.custom,
     this.image,
+    this.callRejectedAt,
+    this.callAcceptedAt,
   });
 
   final String userId;
@@ -21,8 +23,19 @@ class CallMemberState with EquatableMixin {
   final Map<String, Object?> custom;
   final String? image;
 
+  final DateTime? callRejectedAt;
+  final DateTime? callAcceptedAt;
+
   @override
-  List<Object?> get props => [userId, roles, name, custom];
+  List<Object?> get props => [
+        userId,
+        roles,
+        name,
+        custom,
+        image,
+        callRejectedAt,
+        callAcceptedAt,
+      ];
 
   UserInfo toUserInfo() => UserInfo(
         id: userId,
@@ -30,6 +43,26 @@ class CallMemberState with EquatableMixin {
         name: name,
         image: image,
       );
+
+  CallMemberState copyWith({
+    String? userId,
+    List<String>? roles,
+    String? name,
+    Map<String, Object?>? custom,
+    String? image,
+    DateTime? callRejectedAt,
+    DateTime? callAcceptedAt,
+  }) {
+    return CallMemberState(
+      userId: userId ?? this.userId,
+      roles: roles ?? this.roles,
+      name: name ?? this.name,
+      custom: custom ?? this.custom,
+      image: image ?? this.image,
+      callRejectedAt: callRejectedAt ?? this.callRejectedAt,
+      callAcceptedAt: callAcceptedAt ?? this.callAcceptedAt,
+    );
+  }
 }
 
 extension CallMemberStateMetadataX on CallMetadata {

--- a/packages/stream_video_flutter/lib/src/call_screen/incoming_call/incoming_call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/incoming_call/incoming_call_content.dart
@@ -91,10 +91,8 @@ class _StreamIncomingCallContentState extends State<StreamIncomingCallContent> {
     final callingLabelTextStyle =
         widget.callingLabelTextStyle ?? theme.callingLabelTextStyle;
 
-    final users = widget.callState.callMembers
-        .where((m) => m.userId != widget.callState.currentUserId)
-        .map((e) => e.toUserInfo())
-        .toList();
+    final users =
+        widget.callState.ringingMembers.map((e) => e.toUserInfo()).toList();
 
     return CallBackground(
       participants: users,

--- a/packages/stream_video_flutter/lib/src/call_screen/incoming_call/incoming_call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/incoming_call/incoming_call_content.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
 import '../../../stream_video_flutter.dart';

--- a/packages/stream_video_flutter/lib/src/call_screen/incoming_call/incoming_call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/incoming_call/incoming_call_content.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 import '../../../stream_video_flutter.dart';
@@ -89,8 +91,10 @@ class _StreamIncomingCallContentState extends State<StreamIncomingCallContent> {
     final callingLabelTextStyle =
         widget.callingLabelTextStyle ?? theme.callingLabelTextStyle;
 
-    final users =
-        widget.callState.otherParticipants.map((e) => e.toUserInfo()).toList();
+    final users = widget.callState.callMembers
+        .where((m) => m.userId != widget.callState.currentUserId)
+        .map((e) => e.toUserInfo())
+        .toList();
 
     return CallBackground(
       participants: users,

--- a/packages/stream_video_flutter/lib/src/call_screen/outgoing_call/outgoing_call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/outgoing_call/outgoing_call_content.dart
@@ -99,10 +99,8 @@ class _StreamOutgoingCallContentState extends State<StreamOutgoingCallContent> {
     final callingLabelTextStyle =
         widget.callingLabelTextStyle ?? theme.callingLabelTextStyle;
 
-    final participants = widget.callState.callMembers
-        .where((m) => m.userId != widget.callState.currentUserId)
-        .map((e) => e.toUserInfo())
-        .toList();
+    final participants =
+        widget.callState.ringingMembers.map((e) => e.toUserInfo()).toList();
 
     final child = Material(
       color: Colors.transparent,

--- a/packages/stream_video_flutter/lib/src/call_screen/outgoing_call/outgoing_call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/outgoing_call/outgoing_call_content.dart
@@ -99,8 +99,10 @@ class _StreamOutgoingCallContentState extends State<StreamOutgoingCallContent> {
     final callingLabelTextStyle =
         widget.callingLabelTextStyle ?? theme.callingLabelTextStyle;
 
-    final participants =
-        widget.callState.otherParticipants.map((e) => e.toUserInfo()).toList();
+    final participants = widget.callState.callMembers
+        .where((m) => m.userId != widget.callState.currentUserId)
+        .map((e) => e.toUserInfo())
+        .toList();
 
     final child = Material(
       color: Colors.transparent,


### PR DESCRIPTION
This PR adds `callMembers` to `CallState` and uses it in ringing cases instead of participants. It also removes the logic of creating participants from members since it's no longer needed.