### PR TITLE
downgrade webrtc package

### DIFF
--- a/dogfooding/windows/flutter/generated_plugins.cmake
+++ b/dogfooding/windows/flutter/generated_plugins.cmake
@@ -14,11 +14,11 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_video
   permission_handler_windows
   record_windows
-  screen_brightness_windows
   share_plus
   stream_webrtc_flutter
   thumblr_windows
   url_launcher_windows
+  volume_controller
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/melos.yaml
+++ b/melos.yaml
@@ -20,8 +20,8 @@ command:
     dependencies:
       dart_webrtc: ^1.5.3
       device_info_plus: ">=10.1.2 <12.0.0"
-      stream_chat_flutter: ^9.6.0
-      stream_webrtc_flutter: ^1.0.4
+      stream_chat_flutter: ^9.8.0
+      stream_webrtc_flutter: ^1.0.3
 
 scripts:
   postclean:

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   rxdart: ^0.28.0
   sdp_transform: ^0.3.2
   state_notifier: ^1.0.0
-  stream_webrtc_flutter: ^1.0.4
+  stream_webrtc_flutter: ^1.0.3
   synchronized: ^3.1.0
   system_info2: ^4.0.0
   tart: ^0.5.1

--- a/packages/stream_video_flutter/example/pubspec.yaml
+++ b/packages/stream_video_flutter/example/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   stream_video: ^0.9.1
   stream_video_flutter: ^0.9.1
   stream_video_push_notification: ^0.9.1
-  stream_webrtc_flutter: ^1.0.4
+  stream_webrtc_flutter: ^1.0.3
 
 dependency_overrides:
   stream_video:

--- a/packages/stream_video_flutter/pubspec.yaml
+++ b/packages/stream_video_flutter/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   rate_limiter: ^1.0.0
   stream_video: ^0.9.1
-  stream_webrtc_flutter: ^1.0.4
+  stream_webrtc_flutter: ^1.0.3
   visibility_detector: ^0.4.0+2
 
 dev_dependencies:

--- a/packages/stream_video_noise_cancellation/pubspec.yaml
+++ b/packages/stream_video_noise_cancellation/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
   stream_video: ^0.9.1
-  stream_webrtc_flutter: ^1.0.4
+  stream_webrtc_flutter: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   stream_video: ^0.9.1
   uuid: ^4.2.1
   shared_preferences: ^2.3.2
-  stream_webrtc_flutter: ^1.0.4
+  stream_webrtc_flutter: ^1.0.3
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_
webrtc 1.0.4 was using a retracted version of webrtc-interface, so we retracted 1.0.4
This downgrades to 1.0.3



#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
