### PR TITLE
fix: leave call when leaving livestream

### DIFF
--- a/packages/stream_video_flutter/lib/src/livestream/livestream_player.dart
+++ b/packages/stream_video_flutter/lib/src/livestream/livestream_player.dart
@@ -258,6 +258,7 @@ class _LivestreamPlayerState extends State<LivestreamPlayer>
 
   Future<void> _leave() async {
     _logger.d(() => '[leave] no args');
+    await call.leave();
     // play tone
     final bool popped;
     if (mounted) {


### PR DESCRIPTION
### 🎯 Goal

When a user leaves the livestream it should no longer be a participant of the call

### 🛠 Implementation details

When leaving the widget we now also leave the actual call.

### 🎨 UI Changes

No relevant changes

### 🧪 Testing

I tested it with the live stream tutorial. First the counter did not go down when somebody left the livestream, now the viewing counter does go down.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
