### PR TITLE
Add `SfuErrorCode.liveEnded`

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -1116,25 +1116,27 @@ class Call {
     }
     // error event
     else if (sfuEvent is SfuErrorEvent) {
-      switch (sfuEvent.error.reconnectStrategy) {
-        case SfuReconnectionStrategy.rejoin:
-        case SfuReconnectionStrategy.fast:
-        case SfuReconnectionStrategy.migrate:
-          _logger.w(
-            () =>
-                '[onSfuEvent] SFU error: ${sfuEvent.error}, reconnect strategy: ${sfuEvent.error.reconnectStrategy}',
-          );
-          await _reconnect(sfuEvent.error.reconnectStrategy);
-          break;
-        case SfuReconnectionStrategy.disconnect:
-          _logger.w(
-            () => '[onSfuEvent] SFU error: ${sfuEvent.error}, leaving call',
-          );
-          await leave();
-          break;
-        case SfuReconnectionStrategy.unspecified:
-          _logger.w(() => '[onSfuEvent] SFU error: ${sfuEvent.error}');
-          break;
+      if (sfuEvent.error.code != SfuErrorCode.liveEnded) {
+        switch (sfuEvent.error.reconnectStrategy) {
+          case SfuReconnectionStrategy.rejoin:
+          case SfuReconnectionStrategy.fast:
+          case SfuReconnectionStrategy.migrate:
+            _logger.w(
+              () =>
+                  '[onSfuEvent] SFU error: ${sfuEvent.error}, reconnect strategy: ${sfuEvent.error.reconnectStrategy}',
+            );
+            await _reconnect(sfuEvent.error.reconnectStrategy);
+            break;
+          case SfuReconnectionStrategy.disconnect:
+            _logger.w(
+              () => '[onSfuEvent] SFU error: ${sfuEvent.error}, leaving call',
+            );
+            await leave();
+            break;
+          case SfuReconnectionStrategy.unspecified:
+            _logger.w(() => '[onSfuEvent] SFU error: ${sfuEvent.error}');
+            break;
+        }
       }
     }
   }

--- a/packages/stream_video/lib/src/sfu/data/events/sfu_event_mapper_extensions.dart
+++ b/packages/stream_video/lib/src/sfu/data/events/sfu_event_mapper_extensions.dart
@@ -312,6 +312,8 @@ extension SfuErrorCodeExtension on sfu_models.ErrorCode {
         return SfuErrorCode.tooManyRequests;
       case sfu_models.ErrorCode.ERROR_CODE_UNAUTHENTICATED:
         return SfuErrorCode.unauthenticated;
+      case sfu_models.ErrorCode.ERROR_CODE_LIVE_ENDED:
+        return SfuErrorCode.liveEnded;
       default:
         throw StateError('unexpected error code: $this');
     }

--- a/packages/stream_video/lib/src/sfu/data/models/sfu_error.dart
+++ b/packages/stream_video/lib/src/sfu/data/models/sfu_error.dart
@@ -34,6 +34,7 @@ enum SfuErrorCode {
   participantNotFound,
   participantMediaTransportFailure,
   callNotFound,
+  liveEnded,
   requestValidationFailed,
   unauthenticated,
   permissionDenied,

--- a/packages/stream_video/lib/src/ws/ws.dart
+++ b/packages/stream_video/lib/src/ws/ws.dart
@@ -24,6 +24,8 @@ enum StreamWebSocketCloseCode {
   //  */
   goingAway(1001),
 
+  policyViolation(1008),
+
   // /**
   //  * The error code used when the SFU connection is unhealthy.
   //  * Usually, this means that no message has been received from the SFU for
@@ -43,7 +45,9 @@ enum StreamWebSocketCloseCode {
   final int value;
 
   static bool isIntentionalClosure(int? code) =>
-      code == normalClosure.value || code == goingAway.value;
+      code == normalClosure.value ||
+      code == goingAway.value ||
+      code == policyViolation.value;
 }
 
 /// A simple wrapper around [WebSocketChannel] to make it easier to use.


### PR DESCRIPTION
### 🎯 Goal

Watch a livestream without errors.

### 🛠 Implementation details

When watching a livestream that stops being live we get an unmapped error. This maps the error to liveEnded.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
