### PR TITLE
Always create a new track on web

### DIFF
--- a/packages/stream_video/lib/src/webrtc/rtc_track/rtc_local_track.dart
+++ b/packages/stream_video/lib/src/webrtc/rtc_track/rtc_local_track.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:stream_webrtc_flutter/stream_webrtc_flutter.dart' as rtc;
 
 import '../../exceptions/video_exception.dart';
@@ -366,6 +367,11 @@ extension RtcLocalScreenShareTrackExt on RtcLocalScreenShareTrack {
   bool compareScreenShareMode(MediaConstraints? constraints) {
     if (constraints is! ScreenShareConstraints) {
       return true;
+    }
+
+    // On web we always get a new media track and deviceId is `null`.
+    if (kIsWeb) {
+      return false;
     }
 
     return mediaConstraints.useiOSBroadcastExtension ==


### PR DESCRIPTION
### 🎯 Goal

Fix screen sharing on web.
Fixes FLU-124

### 🛠 Implementation details

When starting to share your screen on web the `_setTrackEnabled` is called, but the deviceId is always `null` for the requirements. Therefore `compareScreenShareMode` is always true, even though we should create a new track.

The callback is then set to the wrong track, the old one: https://github.com/GetStream/stream-video-flutter/blob/main/packages/stream_video/lib/src/call/call.dart#L2428-L2430

Debugging showed that on the actual track the onEnded callback was `null`: https://github.com/flutter-webrtc/dart-webrtc/blob/main/lib/src/media_stream_track_impl.dart#L16


### 🧪 Testing

Test by running on web and start screen sharing only tabs and stop them using the browser tools.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
