### PR TITLE
fix: fix app init delay

### DIFF
--- a/dogfooding/lib/app/app.dart
+++ b/dogfooding/lib/app/app.dart
@@ -31,9 +31,7 @@ class _StreamDogFoodingAppState extends State<StreamDogFoodingApp> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _appLoader ??= Future.wait([
-      _loadApp(context),
-    ]);
+    _appLoader ??= _loadApp(context);
   }
 
   @override

--- a/dogfooding/lib/app/app.dart
+++ b/dogfooding/lib/app/app.dart
@@ -33,8 +33,6 @@ class _StreamDogFoodingAppState extends State<StreamDogFoodingApp> {
     super.didChangeDependencies();
     _appLoader ??= Future.wait([
       _loadApp(context),
-      // Shows the splash screen for at least 3 seconds.
-      Future.delayed(const Duration(seconds: 3)),
     ]);
   }
 

--- a/dogfooding/lib/app/app_content.dart
+++ b/dogfooding/lib/app/app_content.dart
@@ -112,12 +112,12 @@ class _StreamDogFoodingAppContentState
     // i.e. the user is not logged in.
     if (!locator.isRegistered<StreamVideo>()) return;
 
+    // Observe call kit events.
+    _observeCallKitEvents();
     // Observes deep links.
     _observeDeepLinks();
     // Observe FCM messages.
     _observeFcmMessages();
-    // Observe call kit events.
-    _observeCallKitEvents();
   }
 
   void _tryConsumingIncomingCallFromTerminatedState() {


### PR DESCRIPTION
We had an artificial delay when initializing the app (to show the splash screen longer) that interfered with CallKit integration. When the app was started from a terminated state after a VoIP push was received (iOS), quickly accepting the call would not work because CallKit events were not observed.