### PR TITLE
Store previous sorting of participants before sorting again

### DIFF
--- a/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
@@ -54,7 +54,7 @@ class StreamCallParticipants extends StatefulWidget {
   final Call call;
 
   /// The list of participants to display.
-  final Iterable<CallParticipantState> participants;
+  final List<CallParticipantState> participants;
 
   /// Used for filtering the call participants.
   final Filter<CallParticipantState> filter;
@@ -105,6 +105,8 @@ class _StreamCallParticipantsState extends State<StreamCallParticipants> {
   List<CallParticipantState> _participants = [];
   CallParticipantState? _screenShareParticipant;
 
+  List<String> _sortedParticipantKeys = [];
+
   @override
   void initState() {
     _recalculateParticipants();
@@ -125,6 +127,22 @@ class _StreamCallParticipantsState extends State<StreamCallParticipants> {
 
   void _recalculateParticipants() {
     final participants = [...widget.participants].where(widget.filter).toList();
+
+    for (final participant in participants) {
+      final index =
+          _sortedParticipantKeys.indexOf(participant.uniqueParticipantKey);
+      if (index == -1) {
+        _sortedParticipantKeys.add(participant.uniqueParticipantKey);
+      }
+    }
+
+    // First apply previous sorting on new participants list
+    participants.sort(
+      (a, b) => _sortedParticipantKeys
+          .indexOf(a.uniqueParticipantKey)
+          .compareTo(_sortedParticipantKeys.indexOf(b.uniqueParticipantKey)),
+    );
+
     mergeSort(participants, compare: widget.sort);
 
     final screenShareParticipant = participants.firstWhereOrNull(
@@ -137,6 +155,9 @@ class _StreamCallParticipantsState extends State<StreamCallParticipants> {
         return true;
       },
     );
+
+    _sortedParticipantKeys =
+        participants.map((e) => e.uniqueParticipantKey).toList();
 
     if (mounted) {
       setState(() {


### PR DESCRIPTION
### 🎯 Goal

Fixes FLU-82
Prevent jumping around of participant locations

### 🛠 Implementation details

Some sorting rules are not applied when participants are visible. However, because we weren't storing the result of the previous sort participants were jumping back to their previous position. By keeping the sort result and applying that to the new set of participants we make sure participants only jump around when we want them to.

### 🧪 Testing

You can start a call with many participants and try to play with who's talking or screen sharing for example.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
