### PR TITLE
chore: call duration stream

### DIFF
--- a/dogfooding/lib/widgets/call_duration_title.dart
+++ b/dogfooding/lib/widgets/call_duration_title.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_dogfooding/theme/app_palette.dart';
 import 'package:flutter_dogfooding/utils/assets.dart';
@@ -19,39 +17,6 @@ class CallDurationTitle extends StatefulWidget {
 }
 
 class _CallDurationTitleState extends State<CallDurationTitle> {
-  late DateTime _startedAt;
-  Duration _duration = Duration.zero;
-  Timer? _timer;
-
-  @override
-  void initState() {
-    super.initState();
-
-    widget.call.get(watch: false).then((value) {
-      _startedAt = value.foldOrNull(
-              success: (callData) =>
-                  callData.data.metadata.session.startedAt ?? DateTime.now()) ??
-          DateTime.now();
-
-      _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-        if (!mounted) {
-          timer.cancel();
-          return;
-        }
-
-        setState(() {
-          _duration = DateTime.now().difference(_startedAt);
-        });
-      });
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     final videoTheme = StreamVideoTheme.of(context);
@@ -70,12 +35,18 @@ class _CallDurationTitleState extends State<CallDurationTitle> {
             width: 20,
           ),
           const SizedBox(width: 8),
-          Text(
-            '${_duration.inMinutes.toString().padLeft(2, '0')}:${_duration.inSeconds.remainder(60).toString().padLeft(2, '0')}',
-            style: videoTheme.textTheme.title3.apply(
-              color: AppColorPalette.secondaryText,
-            ),
-          ),
+          StreamBuilder<int>(
+              stream: widget.call.callDurationSecondsStream,
+              builder: (context, snapshot) {
+                final duration = Duration(seconds: snapshot.data ?? 0);
+
+                return Text(
+                  '${duration.inMinutes.toString().padLeft(2, '0')}:${duration.inSeconds.remainder(60).toString().padLeft(2, '0')}',
+                  style: videoTheme.textTheme.title3.apply(
+                    color: AppColorPalette.secondaryText,
+                  ),
+                );
+              }),
         ],
       ),
     );

--- a/dogfooding/lib/widgets/call_duration_title.dart
+++ b/dogfooding/lib/widgets/call_duration_title.dart
@@ -35,10 +35,10 @@ class _CallDurationTitleState extends State<CallDurationTitle> {
             width: 20,
           ),
           const SizedBox(width: 8),
-          StreamBuilder<int>(
-              stream: widget.call.callDurationSecondsStream,
+          StreamBuilder<Duration>(
+              stream: widget.call.callDurationStream,
               builder: (context, snapshot) {
-                final duration = Duration(seconds: snapshot.data ?? 0);
+                final duration = snapshot.data ?? Duration.zero;
 
                 return Text(
                   '${duration.inMinutes.toString().padLeft(2, '0')}:${duration.inSeconds.remainder(60).toString().padLeft(2, '0')}',

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+✅ Added
+* Added `callDurationSecondsStream` to the `Call` class, providing a Stream<int> that emits the current call duration in seconds.
+* Added `createdByUser` to the `CallState`
+
 ## 0.9.2
 
 🐞 Fixed

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -280,7 +280,7 @@ class Call {
       _streamVideo.state.activeCall.valueOrNull?.callCid == callCid;
 
   StateEmitter<CallState> get state => _stateManager.callStateStream;
-  Stream<int> get callDurationSecondsStream => _stateManager.durationStream;
+  Stream<Duration> get callDurationStream => _stateManager.durationStream;
 
   SharedEmitter<({CallStats publisherStats, CallStats subscriberStats})>
       get stats => _stats;

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -280,6 +280,7 @@ class Call {
       _streamVideo.state.activeCall.valueOrNull?.callCid == callCid;
 
   StateEmitter<CallState> get state => _stateManager.callStateStream;
+  Stream<int> get callDurationSecondsStream => _stateManager.durationStream;
 
   SharedEmitter<({CallStats publisherStats, CallStats subscriberStats})>
       get stats => _stats;

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -834,7 +834,7 @@ class CallSession extends Disposable {
       if (offer is! Success<rtc.RTCSessionDescription>) return;
 
       final sdp = offer.data.sdp;
-      final tracksInfo = await rtcManager!.getAnnouncedTracks(sdp: sdp);
+      final tracksInfo = await rtcManager?.getAnnouncedTracks(sdp: sdp) ?? [];
 
       if (tracksInfo.isEmpty) {
         _logger

--- a/packages/stream_video/lib/src/call/state/call_state_notifier.dart
+++ b/packages/stream_video/lib/src/call/state/call_state_notifier.dart
@@ -71,5 +71,6 @@ class CallStateNotifier extends StateNotifier<CallState>
     callStateStream.close();
     _durationTimer?.cancel();
     _durationTimer = null;
+    _durationTimerController.close();
   }
 }

--- a/packages/stream_video/lib/src/call/state/call_state_notifier.dart
+++ b/packages/stream_video/lib/src/call/state/call_state_notifier.dart
@@ -24,7 +24,7 @@ class CallStateNotifier extends StateNotifier<CallState>
   CallStateNotifier(CallState initialState) : super(initialState) {
     callStateStream =
         MutableStateEmitterImpl<CallState>(initialState, sync: true);
-    _durationTimerController = StreamController<int>.broadcast();
+    _durationTimerController = StreamController<Duration>.broadcast();
     _ensureStartDurationTimer();
   }
 
@@ -33,8 +33,10 @@ class CallStateNotifier extends StateNotifier<CallState>
   late final MutableStateEmitterImpl<CallState> callStateStream;
   CallState get callState => callStateStream.value;
 
-  Stream<int> get durationStream => _durationTimerController.stream.distinct();
-  late final StreamController<int> _durationTimerController;
+  Stream<Duration> get durationStream =>
+      _durationTimerController.stream.distinct();
+
+  late final StreamController<Duration> _durationTimerController;
   Timer? _durationTimer;
 
   @override
@@ -56,7 +58,7 @@ class CallStateNotifier extends StateNotifier<CallState>
       if (state.startedAt == null || state.endedAt != null) return;
 
       final duration = DateTime.now().difference(state.startedAt!);
-      _durationTimerController.add(duration.inSeconds);
+      _durationTimerController.add(duration);
     });
   }
 

--- a/packages/stream_video/lib/src/call/state/call_state_notifier.dart
+++ b/packages/stream_video/lib/src/call/state/call_state_notifier.dart
@@ -25,6 +25,7 @@ class CallStateNotifier extends StateNotifier<CallState>
     callStateStream =
         MutableStateEmitterImpl<CallState>(initialState, sync: true);
     _durationTimerController = StreamController<int>.broadcast();
+    _ensureStartDurationTimer();
   }
 
   final _logger = taggedLogger(tag: 'CallStateNotifier');
@@ -45,13 +46,12 @@ class CallStateNotifier extends StateNotifier<CallState>
     super.state = value;
     callStateStream.value = value;
 
-    if (state.startedAt != null) {
-      _ensureStartDurationTimer();
-    }
+    _ensureStartDurationTimer();
   }
 
   void _ensureStartDurationTimer() {
-    if (_durationTimer != null) return;
+    if (state.startedAt == null || _durationTimer != null) return;
+
     _durationTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
       if (state.startedAt == null || state.endedAt != null) return;
 

--- a/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
@@ -77,7 +77,9 @@ mixin StateLifecycleMixin on StateNotifier<CallState> {
       updatedAt: data.metadata.details.updatedAt,
       startsAt: data.metadata.details.startsAt,
       endedAt: data.metadata.details.endedAt,
-      createdByUserId: data.metadata.details.createdBy.id,
+      startedAt: data.metadata.session.startedAt ??
+          data.metadata.session.liveStartedAt,
+      createdByUser: data.metadata.details.createdBy,
       custom: data.metadata.details.custom,
       egress: data.metadata.details.egress,
       rtmpIngress: data.metadata.details.rtmpIngress,

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
@@ -19,7 +21,7 @@ class CallState extends Equatable {
       preferences: preferences,
       currentUserId: currentUserId,
       callCid: callCid,
-      createdByUserId: '',
+      createdByUser: CallUser.empty(),
       isRingingFlow: false,
       sessionId: '',
       status: CallStatus.idle(),
@@ -43,6 +45,7 @@ class CallState extends Equatable {
       updatedAt: null,
       startsAt: null,
       endedAt: null,
+      startedAt: null,
       liveStartedAt: null,
       liveEndedAt: null,
       timerEndsAt: null,
@@ -58,11 +61,11 @@ class CallState extends Equatable {
     );
   }
 
-  const CallState._({
+  CallState._({
     required this.preferences,
     required this.currentUserId,
     required this.callCid,
-    required this.createdByUserId,
+    required this.createdByUser,
     required this.isRingingFlow,
     required this.sessionId,
     required this.status,
@@ -86,6 +89,7 @@ class CallState extends Equatable {
     required this.updatedAt,
     required this.startsAt,
     required this.endedAt,
+    required this.startedAt,
     required this.liveStartedAt,
     required this.liveEndedAt,
     required this.timerEndsAt,
@@ -103,7 +107,7 @@ class CallState extends Equatable {
   final CallPreferences preferences;
   final String currentUserId;
   final StreamCallCid callCid;
-  final String createdByUserId;
+  final CallUser createdByUser;
   final bool isRingingFlow;
   final String sessionId;
   final CallStatus status;
@@ -127,6 +131,7 @@ class CallState extends Equatable {
   final DateTime? startsAt;
   final DateTime? endedAt;
   final DateTime? updatedAt;
+  final DateTime? startedAt;
   final DateTime? liveStartedAt;
   final DateTime? liveEndedAt;
   final DateTime? timerEndsAt;
@@ -158,6 +163,8 @@ class CallState extends Equatable {
 
   bool get createdByMe => createdByUserId == currentUserId;
 
+  String get createdByUserId => createdByUser.id;
+
   List<CallMemberState> get ringingMembers {
     return callMembers
         .where(
@@ -175,7 +182,7 @@ class CallState extends Equatable {
     CallPreferences? preferences,
     String? currentUserId,
     StreamCallCid? callCid,
-    String? createdByUserId,
+    CallUser? createdByUser,
     bool? isRingingFlow,
     String? sessionId,
     CallStatus? status,
@@ -199,6 +206,7 @@ class CallState extends Equatable {
     DateTime? updatedAt,
     DateTime? startsAt,
     DateTime? endedAt,
+    DateTime? startedAt,
     DateTime? liveStartedAt,
     DateTime? liveEndedAt,
     DateTime? timerEndsAt,
@@ -216,7 +224,7 @@ class CallState extends Equatable {
       preferences: preferences ?? this.preferences,
       currentUserId: currentUserId ?? this.currentUserId,
       callCid: callCid ?? this.callCid,
-      createdByUserId: createdByUserId ?? this.createdByUserId,
+      createdByUser: createdByUser ?? this.createdByUser,
       isRingingFlow: isRingingFlow ?? this.isRingingFlow,
       sessionId: sessionId ?? this.sessionId,
       status: status ?? this.status,
@@ -240,6 +248,7 @@ class CallState extends Equatable {
       updatedAt: updatedAt ?? this.updatedAt,
       startsAt: startsAt ?? this.startsAt,
       endedAt: endedAt ?? this.endedAt,
+      startedAt: startedAt ?? this.startedAt ?? this.liveStartedAt,
       liveStartedAt: liveStartedAt ?? this.liveStartedAt,
       liveEndedAt: liveEndedAt ?? this.liveEndedAt,
       timerEndsAt: timerEndsAt ?? this.timerEndsAt,
@@ -274,7 +283,8 @@ class CallState extends Equatable {
       updatedAt: metadata.details.updatedAt,
       startsAt: metadata.details.startsAt,
       endedAt: metadata.details.endedAt,
-      createdByUserId: metadata.details.createdBy.id,
+      startedAt: metadata.session.startedAt ?? metadata.session.liveStartedAt,
+      createdByUser: metadata.details.createdBy,
       custom: metadata.details.custom,
       egress: metadata.details.egress,
       rtmpIngress: metadata.details.rtmpIngress,
@@ -292,7 +302,7 @@ class CallState extends Equatable {
   List<Object?> get props => [
         currentUserId,
         callCid,
-        createdByUserId,
+        createdByUser,
         sessionId,
         status,
         isRecording,
@@ -314,6 +324,7 @@ class CallState extends Equatable {
         updatedAt,
         startsAt,
         endedAt,
+        startedAt,
         liveStartedAt,
         liveEndedAt,
         timerEndsAt,
@@ -331,7 +342,7 @@ class CallState extends Equatable {
   @override
   String toString() {
     return 'CallState(status: $status, currentUserId: $currentUserId,'
-        ' callCid: $callCid, createdByUserId: $createdByUserId,'
+        ' callCid: $callCid, createdByUser: $createdByUser,'
         ' sessionId: $sessionId, isRecording: $isRecording,'
         ' settings: $settings, egress: $egress, '
         ' videoInputDevice: $videoInputDevice,'

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
@@ -61,7 +59,7 @@ class CallState extends Equatable {
     );
   }
 
-  CallState._({
+  const CallState._({
     required this.preferences,
     required this.currentUserId,
     required this.callCid,

--- a/packages/stream_video/lib/src/models/call_metadata.dart
+++ b/packages/stream_video/lib/src/models/call_metadata.dart
@@ -143,6 +143,13 @@ class CallUser with EquatableMixin {
     this.deletedAt,
   });
 
+  factory CallUser.empty() => const CallUser(
+        id: '',
+        name: '',
+        roles: [],
+        image: '',
+      );
+
   final String id;
   final String name;
   final List<String> roles;

--- a/packages/stream_video_flutter/lib/src/livestream/livestream_player.dart
+++ b/packages/stream_video_flutter/lib/src/livestream/livestream_player.dart
@@ -191,10 +191,10 @@ class _LivestreamPlayerState extends State<LivestreamPlayer>
             ),
             Align(
               alignment: Alignment.bottomCenter,
-              child: StreamBuilder<int>(
-                stream: call.callDurationSecondsStream,
+              child: StreamBuilder<Duration>(
+                stream: call.callDurationStream,
                 builder: (context, snapshot) {
-                  final duration = Duration(seconds: snapshot.data ?? 0);
+                  final duration = snapshot.data ?? Duration.zero;
 
                   return LivestreamInfo(
                     call: call,

--- a/packages/stream_video_flutter/lib/src/livestream/livestream_player.dart
+++ b/packages/stream_video_flutter/lib/src/livestream/livestream_player.dart
@@ -103,13 +103,6 @@ class _LivestreamPlayerState extends State<LivestreamPlayer>
   /// Stores if the livestream is in cover or contain mode.
   bool _fullscreen = false;
 
-  /// Timer for updating duration.
-  late Timer _durationTimer;
-
-  /// Current duration of call.
-  final ValueNotifier<Duration> _duration =
-      ValueNotifier<Duration>(Duration.zero);
-
   @override
   void initState() {
     super.initState();
@@ -117,25 +110,12 @@ class _LivestreamPlayerState extends State<LivestreamPlayer>
     _callState = call.state.value;
 
     _connect();
-
-    final now = DateTime.now();
-    final currentTime = now.millisecondsSinceEpoch;
-    final startedAt = _callState.liveStartedAt?.millisecondsSinceEpoch ??
-        _callState.createdAt?.millisecondsSinceEpoch ??
-        now.millisecondsSinceEpoch;
-    _duration.value = Duration(milliseconds: currentTime - startedAt);
-
-    _durationTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      _duration.value = _duration.value + const Duration(seconds: 1);
-    });
   }
 
   @override
   void dispose() {
     _callStateSubscription?.cancel();
     _callStateSubscription = null;
-    _durationTimer.cancel();
-    _duration.dispose();
 
     super.dispose();
   }
@@ -211,9 +191,11 @@ class _LivestreamPlayerState extends State<LivestreamPlayer>
             ),
             Align(
               alignment: Alignment.bottomCenter,
-              child: ValueListenableBuilder<Duration>(
-                valueListenable: _duration,
-                builder: (context, duration, _) {
+              child: StreamBuilder<int>(
+                stream: call.callDurationSecondsStream,
+                builder: (context, snapshot) {
+                  final duration = Duration(seconds: snapshot.data ?? 0);
+
                   return LivestreamInfo(
                     call: call,
                     callState: widget.call.state.value,


### PR DESCRIPTION
resolves FLU-136

### 🎯 Goal

We aim to simplify the process for integrators to obtain the current call duration by providing them with a stream of the duration in seconds.

### 🛠 Implementation details

Added a Stream<int> in `CallStateNotifier` that is started whenever `startedAt` or `liveStartedAt` is set. The stream is exposed in `Call` as `callDurationSecondsStream`. 

### 🎨 UI Changes

The new stream is now also used in Dogfooding timer widget and `LivestreamPlayer` widget.
