### PR TITLE
fix: do not unsubscribe screen share track when zooming

### DIFF
--- a/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
@@ -131,7 +131,7 @@ class ScreenShareContent extends StatefulWidget {
 }
 
 class _ScreenShareContentState extends State<ScreenShareContent> {
-  double _currentScale = 1;
+  bool _isZoomed = false;
 
   @override
   Widget build(BuildContext context) {
@@ -155,16 +155,19 @@ class _ScreenShareContentState extends State<ScreenShareContent> {
             return InteractiveViewer(
               maxScale: 4,
               onInteractionUpdate: (details) {
-                setState(() {
-                  _currentScale = details.scale;
-                });
+                final isZoomed = details.scale > 1.0;
+                if (_isZoomed != isZoomed) {
+                  setState(() {
+                    _isZoomed = isZoomed;
+                  });
+                }
               },
               child: StreamVideoRenderer(
                 call: widget.call,
                 participant: widget.participant,
                 videoFit: VideoFit.contain,
                 videoTrackType: SfuTrackType.screenShare,
-                persistTrackIfNotVisible: _currentScale > 1.0,
+                persistTrackIfNotVisible: _isZoomed,
               ),
             );
           },

--- a/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
@@ -104,7 +104,7 @@ class ScreenShareCallParticipantsContent extends StatelessWidget {
 }
 
 /// A widget that renders a screen sharing track in the screen.
-class ScreenShareContent extends StatelessWidget {
+class ScreenShareContent extends StatefulWidget {
   /// Creates a new instance of [ScreenShareContent].
   const ScreenShareContent({
     super.key,
@@ -127,14 +127,21 @@ class ScreenShareContent extends StatelessWidget {
   final BorderRadius borderRadius;
 
   @override
+  State<ScreenShareContent> createState() => _ScreenShareContentState();
+}
+
+class _ScreenShareContentState extends State<ScreenShareContent> {
+  double _currentScale = 1;
+
+  @override
   Widget build(BuildContext context) {
     final theme = StreamVideoTheme.of(context);
-    final screenShareTrack = participant.screenShareTrack;
+    final screenShareTrack = widget.participant.screenShareTrack;
 
     return ClipRRect(
-      borderRadius: borderRadius,
+      borderRadius: widget.borderRadius,
       child: ColoredBox(
-        color: backgroundColor,
+        color: widget.backgroundColor,
         child: Builder(
           builder: (context) {
             if (screenShareTrack == null) {
@@ -146,11 +153,18 @@ class ScreenShareContent extends StatelessWidget {
             }
 
             return InteractiveViewer(
+              maxScale: 4,
+              onInteractionUpdate: (details) {
+                setState(() {
+                  _currentScale = details.scale;
+                });
+              },
               child: StreamVideoRenderer(
-                call: call,
-                participant: participant,
+                call: widget.call,
+                participant: widget.participant,
                 videoFit: VideoFit.contain,
                 videoTrackType: SfuTrackType.screenShare,
+                persistTrackIfNotVisible: _currentScale > 1.0,
               ),
             );
           },

--- a/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
+++ b/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
@@ -18,6 +18,7 @@ class StreamVideoRenderer extends StatefulWidget {
     this.placeholderBuilder = _defaultPlaceholderBuilder,
     this.videoFit = VideoFit.cover,
     this.onSizeChanged,
+    this.persistTrackIfNotVisible = false,
   });
 
   /// Represents a call.
@@ -37,6 +38,11 @@ class StreamVideoRenderer extends StatefulWidget {
 
   /// Called when the size of the widget changes.
   final ValueSetter<Size>? onSizeChanged;
+
+  /// If the track should be persisted when not visible. Otherwise it will be unnsubscribed.
+  /// This is useful for screen sharing, where the track should be persisted even when not visible.
+  /// Defaults to false.
+  final bool persistTrackIfNotVisible;
 
   @override
   State<StreamVideoRenderer> createState() => _StreamVideoRendererState();
@@ -187,7 +193,7 @@ class _StreamVideoRendererState extends State<StreamVideoRenderer> {
     // If the dimension hasn't changed, don't update the subscription.
     if (prevDim == newDim) return;
 
-    if (newDim.isEmpty) {
+    if (newDim.isEmpty && !widget.persistTrackIfNotVisible) {
       // Remove the video subscription of the track.
       widget.call.removeSubscription(
         userId: widget.participant.userId,


### PR DESCRIPTION
resolves FLU-131

This PR addresses an issue with our track visibility logic. We currently unsubscribe from video tracks when their visibility falls below 30% to conserve resources. However, this had an unintended side effect: when users zoom in on a screen share track using InteractiveViewer, the zoom could reduce the track's visible area below the threshold, causing it to be unsubscribed.

This fix ensures that the screen share track remains subscribed even when zoomed in, preserving the user experience during screen sharing.