### PR TITLE
Improve horizontal layout on very wide windows

### DIFF
--- a/dogfooding/lib/widgets/closed_captions_widget.dart
+++ b/dogfooding/lib/widgets/closed_captions_widget.dart
@@ -6,9 +6,17 @@ class ClosedCaptionsWidget extends StatelessWidget {
   const ClosedCaptionsWidget({
     super.key,
     required this.call,
+    this.maxCaptions = 2,
+    this.height = 80,
   });
 
   final Call call;
+
+  // The maximum number of captions to show.
+  final int? maxCaptions;
+
+  // The height of the captions widget.
+  final double? height;
 
   @override
   Widget build(BuildContext context) {
@@ -16,12 +24,16 @@ class ClosedCaptionsWidget extends StatelessWidget {
       stream: call.closedCaptions,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
-          final closedCaptions =
+          var closedCaptions =
               (snapshot.data as List<StreamClosedCaption>).reversed.toList();
+
+          if (maxCaptions != null && closedCaptions.length > maxCaptions!) {
+            closedCaptions = closedCaptions.sublist(0, maxCaptions!);
+          }
 
           return AnimatedContainer(
             duration: const Duration(milliseconds: 300),
-            height: !call.state.value.isCaptioning ? 0 : 130,
+            height: !call.state.value.isCaptioning ? 0 : height,
             // ignore: deprecated_member_use
             color: Colors.black.withOpacity(0.5),
             padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),

--- a/dogfooding/lib/widgets/closed_captions_widget.dart
+++ b/dogfooding/lib/widgets/closed_captions_widget.dart
@@ -12,10 +12,10 @@ class ClosedCaptionsWidget extends StatelessWidget {
 
   final Call call;
 
-  // The maximum number of captions to show.
+  /// The maximum number of captions to show.
   final int? maxCaptions;
 
-  // The height of the captions widget.
+  /// The height of the captions widget.
   final double? height;
 
   @override

--- a/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
@@ -46,11 +46,19 @@ class ScreenShareCallParticipantsContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const aspectRatio = 16 / 9;
+
+    final windowSize = MediaQuery.sizeOf(context);
+    final isWideWindow = windowSize.width / windowSize.height > aspectRatio;
+
     return CallParticipantsSpotlightView(
       call: call,
       spotlight: screenSharingParticipant,
       participants: participants,
       participantBuilder: screenShareParticipantBuilder,
+      barAlignment: isWideWindow
+          ? ParticipantsBarAlignment.right
+          : ParticipantsBarAlignment.bottom,
       spotlightBuilder: (context, call, participant) {
         final screenShareContentBuilder = this.screenShareContentBuilder;
         if (screenShareContentBuilder != null) {


### PR DESCRIPTION
### 🎯 Goal

Fixes FLU-114

Make the default video widgets work better when you have a wide, but not so high window.

### 🛠 Implementation details

This switches the layout of screen share view automatically to having participants on the right if your complete window is wider than 16/9. The 16/9 is the ratio of screen share view.

I also made the captions bar less high with options to get it back to the original values.

### 🎨 UI Changes

First screenshot focusses on the height of the caption bar, the second one also shows the change of screen sharing.

| Before | After |
| --- | --- |
| <img width="1929" alt="captions_before" src="https://github.com/user-attachments/assets/1bedc014-f5aa-4e75-b411-ed395e227338" /> | <img width="1988" alt="captions_after" src="https://github.com/user-attachments/assets/493d87e3-9a19-4abb-a167-ae3c1f5cec36" /> |
| <img width="1351" alt="screenshare_before" src="https://github.com/user-attachments/assets/924ba3a3-11f6-433d-81a6-5a6e80844c49" /> | <img width="1351" alt="screenshare_after" src="https://github.com/user-attachments/assets/9de55364-8f9c-4ea0-9410-6ce7d965ced6" /> |


### 🧪 Testing

Test on desktop, web or horizontal phone, as long as the phone is wider than 16/9.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
