### PR TITLE
chore: improve app distribution for dev and prod

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
 
   workflow_dispatch:
     inputs:
@@ -48,7 +50,7 @@ jobs:
     name: Build and Distribute Dogfooding Ios
     runs-on: macos-15
     timeout-minutes: 60
-    if: ${{ github.event_name == 'push' || inputs.build_ios == true }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'release'  || inputs.build_ios == true }}
     steps:
       - name: Install Bot SSH Key
         uses: webfactory/ssh-agent@v0.9.0
@@ -88,9 +90,11 @@ jobs:
       - name: Set build flavor to Env
         run: |
           if [[ ${{ github.event_name == 'workflow_dispatch' }} == true ]]; then
-          FLAVOR=${{ inputs.flavor }}
+            FLAVOR=${{ inputs.flavor }}
+          elif [[ ${{ github.event_name == 'release' }} == true ]]; then
+            FLAVOR=prod
           else
-          FLAVOR=beta
+            FLAVOR=beta
           fi
           echo "FLAVOR=$FLAVOR" >> $GITHUB_ENV
 
@@ -103,7 +107,7 @@ jobs:
     name: Build and Distribute Dogfooding Android
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ github.event_name == 'push' || inputs.build_android == true }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'release'  || inputs.build_android == true }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -146,9 +150,11 @@ jobs:
       - name: Set build flavor to Env
         run: |
           if [[ ${{ github.event_name == 'workflow_dispatch' }} == true ]]; then
-          echo "FLAVOR=${{ inputs.flavor }}" >> $GITHUB_ENV
+            echo "FLAVOR=${{ inputs.flavor }}" >> $GITHUB_ENV
+          elif [[ ${{ github.event_name == 'release' }} == true ]]; then
+            echo "FLAVOR=prod" >> $GITHUB_ENV
           else
-          echo "FLAVOR=beta" >> $GITHUB_ENV
+            echo "FLAVOR=beta" >> $GITHUB_ENV
           fi
 
       - name: Build and Distribute
@@ -160,7 +166,7 @@ jobs:
     name: Build and Deploy Dogfooding Web
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event_name == 'push' || inputs.build_web == true }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'release'  || inputs.build_web == true }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/dogfooding/android/fastlane/Fastfile
+++ b/dogfooding/android/fastlane/Fastfile
@@ -26,12 +26,15 @@ platform :android do
         
     build_appbundle(flavor: options[:flavor])
 
+    is_prod = options[:flavor] == 'prod'
+
     upload_to_play_store(
-      track: 'internal',
+      track: is_prod ? 'production' : 'internal',
       aab: "../build/app/outputs/bundle/#{options[:flavor]}Release/app-#{options[:flavor]}-release.aab",
       skip_upload_screenshots: true,
       skip_upload_images: true,
-      release_status: "draft"
+      skip_upload_changelogs: true,
+      release_status: is_prod ? "draft" : "completed"
     )
   end
 end

--- a/dogfooding/android/fastlane/Fastfile
+++ b/dogfooding/android/fastlane/Fastfile
@@ -34,7 +34,7 @@ platform :android do
       skip_upload_screenshots: true,
       skip_upload_images: true,
       skip_upload_changelogs: true,
-      release_status: is_prod ? "draft" : "completed"
+      release_status: "completed"
     )
   end
 end

--- a/dogfooding/ios/fastlane/Fastfile
+++ b/dogfooding/ios/fastlane/Fastfile
@@ -68,12 +68,14 @@ platform :ios do
         flavor: options[:flavor]
     )
 
+    is_prod = options[:flavor] == 'prod'
+
     begin
       upload_to_testflight(
         api_key: appstore_api_key,
-        distribute_external: true,
-        notify_external_testers: true,
-        groups: ['Internal Testers', 'External Testers'],
+        distribute_external: is_prod,
+        notify_external_testers: false,
+        groups: is_prod ? ['Internal Testers', 'External Testers'] : ['Internal Testers'],
         changelog: 'Lots of amazing new features to test out!',
         reject_build_waiting_for_review: false,
         skip_waiting_for_build_processing: false,


### PR DESCRIPTION
### 🎯 Goal

Make app distribution for dogfooding easier

### 🛠 Implementation details

Depending on the flavor this either pushes to public beta testers or internal.
Previously production releases had to be made manually, now they are (or should be) made when you publish a new release.

Android test run: https://github.com/GetStream/stream-video-flutter/actions/runs/15185467581
iOS test run: https://github.com/GetStream/stream-video-flutter/actions/runs/15186409991

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
