### PR TITLE
add video input selection dogfooding menu

### DIFF
--- a/dogfooding/lib/widgets/settings_menu/settings_menu.dart
+++ b/dogfooding/lib/widgets/settings_menu/settings_menu.dart
@@ -46,6 +46,7 @@ class SettingsMenu extends StatefulWidget {
     this.onStatsPressed,
     this.onAudioOutputChange,
     this.onAudioInputChange,
+    this.onVideoInputChange,
     super.key,
   });
 
@@ -55,6 +56,7 @@ class SettingsMenu extends StatefulWidget {
   final void Function()? onStatsPressed;
   final void Function(RtcMediaDevice, {bool closeMenu})? onAudioOutputChange;
   final void Function(RtcMediaDevice)? onAudioInputChange;
+  final void Function(RtcMediaDevice)? onVideoInputChange;
 
   @override
   State<SettingsMenu> createState() => _SettingsMenuState();
@@ -71,16 +73,19 @@ class _SettingsMenuState extends State<SettingsMenu> {
   RtcMediaDevice? get _audioOutputDevice =>
       widget.call.state.value.audioOutputDevice;
   var _audioInputs = <RtcMediaDevice>[];
+  var _videoInputs = <RtcMediaDevice>[];
 
   bool _backgroundEffectsSupported = false;
   bool showAudioOutputs = false;
   bool showAudioInputs = false;
+  bool showVideoInputs = false;
   bool showIncomingQuality = false;
   bool showBackgroundEffects = false;
 
   bool get showMainSettings =>
       !showAudioOutputs &&
       !showAudioInputs &&
+      !showVideoInputs &&
       !showIncomingQuality &&
       !showBackgroundEffects;
 
@@ -98,6 +103,12 @@ class _SettingsMenuState extends State<SettingsMenu> {
         _audioInputs = devices
             .where(
               (it) => it.kind == RtcMediaDeviceKind.audioInput,
+            )
+            .toList();
+
+        _videoInputs = devices
+            .where(
+              (it) => it.kind == RtcMediaDeviceKind.videoInput,
             )
             .toList();
 
@@ -130,6 +141,7 @@ class _SettingsMenuState extends State<SettingsMenu> {
         if (showMainSettings) ..._buildMenuItems(),
         if (showAudioOutputs) ..._buildAudioOutputsMenu(),
         if (showAudioInputs) ..._buildAudioInputsMenu(),
+        if (showVideoInputs) ..._buildVideoInputsMenu(),
         if (showIncomingQuality) ..._buildIncomingQualityMenu(),
         if (showBackgroundEffects) ..._buildBackgroundFiltersMenu(),
       ]),
@@ -215,6 +227,16 @@ class _SettingsMenuState extends State<SettingsMenu> {
           onPressed: () {
             setState(() {
               showAudioInputs = true;
+            });
+          },
+        ),
+        const SizedBox(height: 16),
+        StandardActionMenuItem(
+          icon: Icons.camera_alt,
+          label: 'Choose video input',
+          onPressed: () {
+            setState(() {
+              showVideoInputs = true;
             });
           },
         ),
@@ -323,6 +345,41 @@ class _SettingsMenuState extends State<SettingsMenu> {
                 onPressed: () {
                   widget.call.setAudioInputDevice(device);
                   widget.onAudioInputChange?.call(device);
+                },
+              );
+            },
+          )
+          .cast()
+          .insertBetween(const SizedBox(height: 16)),
+    ];
+  }
+
+  List<Widget> _buildVideoInputsMenu() {
+    return [
+      GestureDetector(
+        onTap: () {
+          setState(() {
+            showVideoInputs = false;
+          });
+        },
+        child: const Align(
+          alignment: Alignment.centerLeft,
+          child: Icon(Icons.arrow_back, size: 24),
+        ),
+      ),
+      const SizedBox(height: 16),
+      ..._videoInputs
+          .map(
+            (device) {
+              return StandardActionMenuItem(
+                icon: Icons.camera_alt,
+                label: device.label,
+                color: widget.call.state.value.videoInputDevice?.id == device.id
+                    ? AppColorPalette.appGreen
+                    : null,
+                onPressed: () {
+                  widget.call.setVideoInputDevice(device);
+                  widget.onVideoInputChange?.call(device);
                 },
               );
             },


### PR DESCRIPTION
Related to FLU-156

### 🎯 Goal

Allow to switch video inputs when on desktop

### 🛠 Implementation details

Shows all video inputs, similar to audio inputs.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
