### PR TITLE
fix(llc): fix update permission event handling

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -494,7 +494,12 @@ class Call {
       case StreamCallMemberRemovedEvent _:
         return _stateManager.coordinatorCallMemberRemoved(event);
       case StreamCallMemberUpdatedEvent _:
-        return _stateManager.coordinatorCallMemberUpdated(event);
+        return _stateManager.coordinatorCallMemberUpdated(event.members);
+      case StreamCallMemberUpdatedPermissionEvent _:
+        return _stateManager.coordinatorCallMemberUpdated(
+          event.updatedMembers,
+          capabilitiesByRole: event.capabilitiesByRole,
+        );
       case StreamCallUserBlockedEvent _:
         return _stateManager.coordinatorCallUserBlocked(event);
       case StreamCallUserUnblockedEvent _:

--- a/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
@@ -163,6 +163,13 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
   void coordinatorCallPermissionsUpdated(
     StreamCallPermissionsUpdatedEvent event,
   ) {
+    if (event.user.id != state.currentUserId) {
+      _logger.i(
+        () => '[coordinatorCallPermissionsUpdated] rejected (not current user)',
+      );
+      return;
+    }
+
     final status = state.status;
     if (status is! CallStatusActive) {
       _logger.w(
@@ -483,12 +490,13 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
   }
 
   void coordinatorCallMemberUpdated(
-    StreamCallMemberUpdatedEvent event,
-  ) {
+    List<CallMember> members, {
+    Map<String, List<String>>? capabilitiesByRole,
+  }) {
     state = state.copyWith(
       callMembers: state.callMembers.map((member) {
         final updatedMember =
-            event.members.firstWhereOrNull((m) => m.userId == member.userId);
+            members.firstWhereOrNull((m) => m.userId == member.userId);
         if (updatedMember != null) {
           return member.copyWith(
             roles: updatedMember.roles,
@@ -498,6 +506,7 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
           return member;
         }
       }).toList(),
+      capabilitiesByRole: capabilitiesByRole,
     );
   }
 


### PR DESCRIPTION
### 🎯 Goal

Fix for updating permission event handling. OwnCapabilities should be updated only if the event targets the current user. Additionally, handling of member permission update events has been added.