### PR TITLE
chore(ui): Picture in Picture improvements

### DIFF
--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 * Added `handleCallInterruptionCallbacks` method to `RtcMediaDeviceNotifier` that provides an option to handle system audio interruption like incoming calls, or other media playing
+* Improved the Picture-in-Picture (PiP) implementation for video calls
+    * (iOS) Shows participant avatar instead of black screen when video track is disabled.
+    * (iOS) Added overlay with participant name, microphone indicator and connection qualit indicator.
+    * (iOS/Android) Added `sort` in `PictureInPictureConfiguration` that enables customization of PiP participant selection.
 
 ## 0.9.5
 

--- a/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
+++ b/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
@@ -55,8 +55,8 @@ final class StreamAVPictureInPictureVideoCallViewController:
         get { contentView.track }
         set {
             contentView.track = newValue
-            // Ensure video content view is visible when track is set
-            contentView.isHidden = false
+            contentView.isHidden = (newValue == nil)
+
             // Bring video content to front when new track is set, then overlay on top
             view.bringSubviewToFront(contentView)
             if let overlayController = overlayHostingController {

--- a/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
+++ b/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
@@ -4,6 +4,7 @@
 
 import AVKit
 import Foundation
+import SwiftUI
 import stream_webrtc_flutter
 
 /// Describes an object that can be used to present picture-in-picture content.
@@ -22,6 +23,13 @@ protocol StreamAVPictureInPictureViewControlling: AnyObject {
 
     /// The layer that renders the incoming frames from WebRTC.
     var displayLayer: CALayer { get }
+
+    /// Removes the current overlay from the picture-in-picture view
+    func removeOverlay()
+
+    /// Updates overlay with participant information
+    func updateParticipantOverlay(
+        name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool)
 }
 
 @available(iOS 15.0, *)
@@ -35,9 +43,26 @@ final class StreamAVPictureInPictureVideoCallViewController:
 
     var onSizeUpdate: ((CGSize) -> Void)?
 
+    // Overlay support
+    private var overlayHostingController: UIHostingController<AnyView>?
+
+    // Track state to avoid unnecessary updates
+    private var currentName: String?
+    private var currentImageUrl: String?
+    private var currentHasVideo: Bool?
+
     var track: RTCVideoTrack? {
         get { contentView.track }
-        set { contentView.track = newValue }
+        set {
+            contentView.track = newValue
+            // Ensure video content view is visible when track is set
+            contentView.isHidden = false
+            // Bring video content to front when new track is set, then overlay on top
+            view.bringSubviewToFront(contentView)
+            if let overlayController = overlayHostingController {
+                view.bringSubviewToFront(overlayController.view)
+            }
+        }
     }
 
     var displayLayer: CALayer { contentView.displayLayer }
@@ -63,6 +88,95 @@ final class StreamAVPictureInPictureVideoCallViewController:
         super.viewDidLayoutSubviews()
         contentView.bounds = view.bounds
         onSizeUpdate?(contentView.bounds.size)
+
+        // Update overlay layout if it exists
+        if let overlayController = overlayHostingController {
+            overlayController.view.frame = view.bounds
+        }
+    }
+
+    // MARK: - Overlay Support
+
+    func removeOverlay() {
+        if let overlayController = overlayHostingController {
+            overlayController.willMove(toParent: nil)
+            overlayController.view.removeFromSuperview()
+            overlayController.removeFromParent()
+            overlayHostingController = nil
+        }
+        currentName = nil
+        currentImageUrl = nil
+        currentHasVideo = nil
+    }
+
+    private func addOverlay<Content: View>(@ViewBuilder content: () -> Content) {
+        let swiftUIView = AnyView(content())
+        let hostingController = UIHostingController(rootView: swiftUIView)
+        overlayHostingController = hostingController
+
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.isUserInteractionEnabled = false  // Allow touch events to pass through
+
+        NSLayoutConstraint.activate([
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        hostingController.didMove(toParent: self)
+    }
+
+    func updateParticipantOverlay(
+        name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool
+    ) {
+        let participantName = name ?? ""
+
+        let needsUpdate =
+            currentName != participantName || currentImageUrl != imageUrl
+            || currentHasVideo != hasVideo
+
+        if needsUpdate || overlayHostingController == nil {
+            removeOverlay()
+            addOverlay {
+                PictureInPictureOverlayView(
+                    name: participantName,
+                    imageUrl: imageUrl,
+                    connectionQuality: connectionQuality,
+                    isMuted: isMuted,
+                    hasVideo: hasVideo
+                )
+            }
+            currentName = participantName
+            currentImageUrl = imageUrl
+            currentHasVideo = hasVideo
+
+            // Ensure proper layering after overlay update
+            if hasVideo {
+                view.bringSubviewToFront(contentView)
+                if let overlayController = overlayHostingController {
+                    view.bringSubviewToFront(overlayController.view)
+                }
+            }
+        } else {
+            // Just update the overlay's data without recreating the view
+            if let controller = overlayHostingController {
+                let updatedView = AnyView(
+                    PictureInPictureOverlayView(
+                        name: participantName,
+                        imageUrl: imageUrl,
+                        connectionQuality: connectionQuality,
+                        isMuted: isMuted,
+                        hasVideo: hasVideo
+                    )
+                )
+                controller.rootView = updatedView
+            }
+        }
     }
 
     // MARK: - Private helpers
@@ -81,5 +195,179 @@ final class StreamAVPictureInPictureVideoCallViewController:
         ])
 
         contentView.bounds = view.bounds
+    }
+}
+
+// MARK: - SwiftUI Overlay Views
+
+@available(iOS 15.0, *)
+struct PictureInPictureOverlayView: View {
+    let name: String
+    let imageUrl: String?
+    let connectionQuality: String
+    let isMuted: Bool
+    let hasVideo: Bool
+
+    var body: some View {
+        ZStack {
+            if !hasVideo {
+                Color.black
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+            if !hasVideo && imageUrl != nil && !imageUrl!.isEmpty {
+                AsyncImage(url: URL(string: imageUrl!)) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Circle()
+                        .fill(Color.blue.opacity(0.8))
+                        .frame(width: 80, height: 80)
+                        .overlay(
+                            Text(getInitials(from: name))
+                                .foregroundColor(.white)
+                                .font(.title2)
+                                .fontWeight(.medium)
+                        )
+                }
+                .frame(width: 80, height: 80)
+                .clipShape(Circle())
+            }
+
+            VStack {
+                Spacer()
+                HStack {
+                    HStack(spacing: 4) {
+                        Text(name)
+                            .foregroundColor(.white)
+                            .multilineTextAlignment(.leading)
+                            .lineLimit(1)
+                            .font(Font.caption)
+                            .minimumScaleFactor(0.7)
+
+                        SoundIndicator(isMuted: isMuted)
+                    }
+                    .padding(.all, 2)
+                    .padding(.horizontal, 4)
+                    .frame(height: 28)
+                    .background(Color.black.opacity(0.6))
+                    .cornerRadius(8)
+
+                    Spacer()
+
+                    // Connection quality indicator on the right
+                    ConnectionQualityIndicator(connectionQuality: connectionQuality)
+                }
+            }
+            // .padding(8)
+        }
+    }
+
+    private func getInitials(from name: String) -> String {
+        let words = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .whitespaces)
+            .filter { !$0.isEmpty }
+
+        if words.isEmpty {
+            return "N/A"
+        } else if words.count == 1 {
+            return String(words[0].prefix(2)).uppercased()
+        } else {
+            let firstInitial = String(words.first?.first ?? Character("?"))
+            let lastInitial = String(words.last?.first ?? Character(""))
+            return "\(firstInitial)\(lastInitial)".uppercased()
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+struct ConnectionQualityIndicator: View {
+
+    private var size: CGFloat = 28
+    private var width: CGFloat = 3
+
+    var connectionQuality: String
+
+    init(connectionQuality: String, size: CGFloat = 28, width: CGFloat = 3) {
+        self.connectionQuality = connectionQuality
+        self.size = size
+        self.width = width
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 2) {
+            ForEach(1..<4, id: \.self) { index in
+                IndicatorPart(
+                    width: width,
+                    height: height(for: index),
+                    color: color(for: index)
+                )
+            }
+        }
+        .frame(width: size, height: size)
+        .padding(4)
+        .background(
+            connectionQuality == "unspecified" ? Color.clear : Color.black.opacity(0.6)
+        )
+        .cornerRadius(8)
+        .accessibility(identifier: "connectionQualityIndicator")
+    }
+
+    private func color(for index: Int) -> Color {
+        switch connectionQuality.lowercased() {
+        case "excellent":
+            return .green
+        case "good":
+            return index == 3 ? Color.white.opacity(0.3) : .green
+        case "poor":
+            return index == 1 ? .red : Color.white.opacity(0.3)
+        default:  // "unspecified"
+            return .gray.opacity(0.8)
+        }
+    }
+
+    private func height(for part: Int) -> CGFloat {
+        switch part {
+        case 1:
+            return width * 2
+        case 2:
+            return width * 3
+        default:
+            return width * 4
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+struct IndicatorPart: View {
+
+    var width: CGFloat
+    var height: CGFloat
+    var color: Color
+
+    var body: some View {
+        RoundedRectangle(cornerSize: .init(width: 2, height: 2))
+            .fill(color)
+            .frame(width: width, height: height)
+    }
+}
+
+public struct SoundIndicator: View {
+
+    let isMuted: Bool
+
+    public init(isMuted: Bool) {
+        self.isMuted = isMuted
+    }
+
+    public var body: some View {
+        (!isMuted ? Image(systemName: "mic.fill") : Image(systemName: "mic.slash.fill"))
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 12, height: 12)
+            .foregroundColor(!isMuted ? .white : Color(red: 1.0, green: 0.216, blue: 0.259))
+            .accessibility(identifier: "participantMic")
+            .accessibilityValue(!isMuted ? "1" : "0")
     }
 }

--- a/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
+++ b/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
@@ -30,6 +30,12 @@ protocol StreamAVPictureInPictureViewControlling: AnyObject {
     /// Updates overlay with participant information
     func updateParticipantOverlay(
         name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool)
+
+    /// Updates overlay with participant information and configuration options
+    func updateParticipantOverlay(
+        name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool,
+        showParticipantName: Bool, showMicrophoneIndicator: Bool,
+        showConnectionQualityIndicator: Bool)
 }
 
 @available(iOS 15.0, *)
@@ -134,6 +140,19 @@ final class StreamAVPictureInPictureVideoCallViewController:
     func updateParticipantOverlay(
         name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool
     ) {
+        updateParticipantOverlay(
+            name: name, imageUrl: imageUrl, connectionQuality: connectionQuality,
+            isMuted: isMuted, hasVideo: hasVideo,
+            showParticipantName: true, showMicrophoneIndicator: true,
+            showConnectionQualityIndicator: true
+        )
+    }
+
+    func updateParticipantOverlay(
+        name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool,
+        showParticipantName: Bool, showMicrophoneIndicator: Bool,
+        showConnectionQualityIndicator: Bool
+    ) {
         let participantName = name ?? ""
 
         let needsUpdate =
@@ -148,7 +167,10 @@ final class StreamAVPictureInPictureVideoCallViewController:
                     imageUrl: imageUrl,
                     connectionQuality: connectionQuality,
                     isMuted: isMuted,
-                    hasVideo: hasVideo
+                    hasVideo: hasVideo,
+                    showParticipantName: showParticipantName,
+                    showMicrophoneIndicator: showMicrophoneIndicator,
+                    showConnectionQualityIndicator: showConnectionQualityIndicator
                 )
             }
             currentName = participantName
@@ -171,7 +193,10 @@ final class StreamAVPictureInPictureVideoCallViewController:
                         imageUrl: imageUrl,
                         connectionQuality: connectionQuality,
                         isMuted: isMuted,
-                        hasVideo: hasVideo
+                        hasVideo: hasVideo,
+                        showParticipantName: showParticipantName,
+                        showMicrophoneIndicator: showMicrophoneIndicator,
+                        showConnectionQualityIndicator: showConnectionQualityIndicator
                     )
                 )
                 controller.rootView = updatedView
@@ -207,6 +232,9 @@ struct PictureInPictureOverlayView: View {
     let connectionQuality: String
     let isMuted: Bool
     let hasVideo: Bool
+    let showParticipantName: Bool
+    let showMicrophoneIndicator: Bool
+    let showConnectionQualityIndicator: Bool
 
     var body: some View {
         ZStack {
@@ -239,25 +267,31 @@ struct PictureInPictureOverlayView: View {
                 Spacer()
                 HStack {
                     HStack(spacing: 4) {
-                        Text(name)
-                            .foregroundColor(.white)
-                            .multilineTextAlignment(.leading)
-                            .lineLimit(1)
-                            .font(Font.caption)
-                            .minimumScaleFactor(0.7)
+                        if showParticipantName {
+                            Text(name)
+                                .foregroundColor(.white)
+                                .multilineTextAlignment(.leading)
+                                .lineLimit(1)
+                                .font(Font.caption)
+                                .minimumScaleFactor(0.7)
+                        }
 
-                        SoundIndicator(isMuted: isMuted)
+                        if showMicrophoneIndicator {
+                            SoundIndicator(isMuted: isMuted)
+                        }
                     }
-                    .padding(.all, 2)
                     .padding(.horizontal, 4)
                     .frame(height: 28)
+                    .padding(4)
                     .background(Color.black.opacity(0.6))
                     .cornerRadius(8)
 
                     Spacer()
 
                     // Connection quality indicator on the right
-                    ConnectionQualityIndicator(connectionQuality: connectionQuality)
+                    if showConnectionQualityIndicator {
+                        ConnectionQualityIndicator(connectionQuality: connectionQuality)
+                    }
                 }
             }
             // .padding(8)

--- a/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
+++ b/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
@@ -243,24 +243,23 @@ struct PictureInPictureOverlayView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
 
-            if !hasVideo && imageUrl != nil && !imageUrl!.isEmpty {
-                AsyncImage(url: URL(string: imageUrl!)) { image in
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                } placeholder: {
-                    Circle()
-                        .fill(Color.blue.opacity(0.8))
-                        .frame(width: 80, height: 80)
-                        .overlay(
-                            Text(getInitials(from: name))
-                                .foregroundColor(.white)
-                                .font(.title2)
-                                .fontWeight(.medium)
-                        )
+            if !hasVideo {
+                if let urlString = imageUrl,
+                    !urlString.isEmpty,
+                    let url = URL(string: urlString)
+                {
+                    AsyncImage(url: url) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    } placeholder: {
+                        avatarPlaceholder
+                    }
+                    .frame(width: 80, height: 80)
+                    .clipShape(Circle())
+                } else {
+                    avatarPlaceholder
                 }
-                .frame(width: 80, height: 80)
-                .clipShape(Circle())
             }
 
             VStack {
@@ -296,6 +295,19 @@ struct PictureInPictureOverlayView: View {
             }
             // .padding(8)
         }
+    }
+
+    @ViewBuilder
+    var avatarPlaceholder: some View {
+        Circle()
+            .fill(Color.blue.opacity(0.8))
+            .frame(width: 80, height: 80)
+            .overlay(
+                Text(getInitials(from: name))
+                    .foregroundColor(.white)
+                    .font(.title2)
+                    .fontWeight(.medium)
+            )
     }
 
     private func getInitials(from name: String) -> String {

--- a/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamPictureInPictureController.swift
+++ b/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamPictureInPictureController.swift
@@ -128,7 +128,9 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
     /// Updates participant information and refreshes overlay
     /// - Note: Only available on iOS 15.0+. Earlier versions will ignore this call.
     public func updateParticipant(
-        name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool
+        name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool,
+        showParticipantName: Bool = true, showMicrophoneIndicator: Bool = true,
+        showConnectionQualityIndicator: Bool = true
     ) {
         guard #available(iOS 15.0, *) else { return }
 
@@ -144,7 +146,10 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
             imageUrl: imageUrl,
             connectionQuality: connectionQuality,
             isMuted: isMuted,
-            hasVideo: hasVideo
+            hasVideo: hasVideo,
+            showParticipantName: showParticipantName,
+            showMicrophoneIndicator: showMicrophoneIndicator,
+            showConnectionQualityIndicator: showConnectionQualityIndicator
         )
     }
 

--- a/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamPictureInPictureController.swift
+++ b/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamPictureInPictureController.swift
@@ -123,6 +123,31 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
     ) {
     }
 
+    // MARK: - Public API
+
+    /// Updates participant information and refreshes overlay
+    /// - Note: Only available on iOS 15.0+. Earlier versions will ignore this call.
+    public func updateParticipant(
+        name: String?, imageUrl: String?, connectionQuality: String, isMuted: Bool, hasVideo: Bool
+    ) {
+        guard #available(iOS 15.0, *) else { return }
+
+        guard
+            let contentViewController = contentViewController
+                as? StreamAVPictureInPictureVideoCallViewController
+        else {
+            return
+        }
+
+        contentViewController.updateParticipantOverlay(
+            name: name,
+            imageUrl: imageUrl,
+            connectionQuality: connectionQuality,
+            isMuted: isMuted,
+            hasVideo: hasVideo
+        )
+    }
+
     // MARK: - Private helpers
 
     private func didUpdate(_ track: RTCVideoTrack?) {

--- a/packages/stream_video_flutter/ios/Classes/StreamVideoFlutterPlugin.swift
+++ b/packages/stream_video_flutter/ios/Classes/StreamVideoFlutterPlugin.swift
@@ -119,9 +119,14 @@ class StreamPictureInPictureNativeView: NSObject, FlutterPlatformView {
 
     private func onMethodCall(call: FlutterMethodCall, result: FlutterResult) {
         switch call.method {
-        case "setTrack":
+        case "updateParticipant":
             let argumentsDictionary = call.arguments as? [String: Any]
             let trackId = argumentsDictionary?["trackId"] as? String
+            let name = argumentsDictionary?["name"] as? String
+            let imageUrl = argumentsDictionary?["imageUrl"] as? String
+            let isAudioEnabled = argumentsDictionary?["isAudioEnabled"] as? Bool ?? false
+            let isVideoEnabled = argumentsDictionary?["isVideoEnabled"] as? Bool ?? false
+            let connectionQuality = argumentsDictionary?["connectionQuality"] as? String
 
             DispatchQueue.main.async {
                 if let unwrappedTrackId = trackId {
@@ -131,10 +136,20 @@ class StreamPictureInPictureNativeView: NSObject, FlutterPlatformView {
                         self.pictureInPictureController?.track = videoTrack
                     }
                 }
+
+                self.pictureInPictureController?.updateParticipant(
+                    name: name ?? "",
+                    imageUrl: imageUrl,
+                    connectionQuality: connectionQuality ?? "",
+                    isMuted: !isAudioEnabled,
+                    hasVideo: isVideoEnabled,
+                )
             }
+            result(nil)
         case "callEnded":
             self.pictureInPictureController?.track = nil
             self.pictureInPictureController?.sourceView = nil
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/packages/stream_video_flutter/ios/Classes/StreamVideoFlutterPlugin.swift
+++ b/packages/stream_video_flutter/ios/Classes/StreamVideoFlutterPlugin.swift
@@ -127,6 +127,11 @@ class StreamPictureInPictureNativeView: NSObject, FlutterPlatformView {
             let isAudioEnabled = argumentsDictionary?["isAudioEnabled"] as? Bool ?? false
             let isVideoEnabled = argumentsDictionary?["isVideoEnabled"] as? Bool ?? false
             let connectionQuality = argumentsDictionary?["connectionQuality"] as? String
+            let showParticipantName = argumentsDictionary?["showParticipantName"] as? Bool ?? true
+            let showMicrophoneIndicator =
+                argumentsDictionary?["showMicrophoneIndicator"] as? Bool ?? true
+            let showConnectionQualityIndicator =
+                argumentsDictionary?["showConnectionQualityIndicator"] as? Bool ?? true
 
             DispatchQueue.main.async {
                 if let unwrappedTrackId = trackId {
@@ -143,6 +148,9 @@ class StreamPictureInPictureNativeView: NSObject, FlutterPlatformView {
                     connectionQuality: connectionQuality ?? "",
                     isMuted: !isAudioEnabled,
                     hasVideo: isVideoEnabled,
+                    showParticipantName: showParticipantName,
+                    showMicrophoneIndicator: showMicrophoneIndicator,
+                    showConnectionQualityIndicator: showConnectionQualityIndicator
                 )
             }
             result(nil)

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
@@ -197,6 +197,8 @@ class _StreamCallContentState extends State<StreamCallContent>
               width: 300,
               child: StreamPictureInPictureUiKitView(
                 call: call,
+                configuration:
+                    widget.pictureInPictureConfiguration.iOSPiPConfiguration,
                 participantSort: widget.pictureInPictureConfiguration.sort,
                 includeLocalParticipantVideo: widget
                     .pictureInPictureConfiguration

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
@@ -200,10 +200,6 @@ class _StreamCallContentState extends State<StreamCallContent>
                 configuration:
                     widget.pictureInPictureConfiguration.iOSPiPConfiguration,
                 participantSort: widget.pictureInPictureConfiguration.sort,
-                includeLocalParticipantVideo: widget
-                    .pictureInPictureConfiguration
-                    .iOSPiPConfiguration
-                    .includeLocalParticipantVideo,
               ),
             ),
           widget.callParticipantsBuilder?.call(

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
@@ -181,6 +181,7 @@ class _StreamCallContentState extends State<StreamCallContent>
             call: call,
             participants: callState.callParticipants,
             layoutMode: ParticipantLayoutMode.pictureInPicture,
+            sort: widget.pictureInPictureConfiguration.sort,
           );
     }
 
@@ -196,6 +197,7 @@ class _StreamCallContentState extends State<StreamCallContent>
               width: 300,
               child: StreamPictureInPictureUiKitView(
                 call: call,
+                participantSort: widget.pictureInPictureConfiguration.sort,
                 includeLocalParticipantVideo: widget
                     .pictureInPictureConfiguration
                     .iOSPiPConfiguration

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/picture_in_picture_configuration.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/picture_in_picture_configuration.dart
@@ -57,7 +57,13 @@ class AndroidPictureInPictureConfiguration {
 class IOSPictureInPictureConfiguration {
   const IOSPictureInPictureConfiguration({
     this.includeLocalParticipantVideo = true,
+    this.showParticipantName = true,
+    this.showMicrophoneIndicator = true,
+    this.showConnectionQualityIndicator = true,
   });
 
   final bool includeLocalParticipantVideo;
+  final bool showParticipantName;
+  final bool showMicrophoneIndicator;
+  final bool showConnectionQualityIndicator;
 }

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/picture_in_picture_configuration.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/picture_in_picture_configuration.dart
@@ -12,6 +12,7 @@ class PictureInPictureConfiguration {
   const PictureInPictureConfiguration({
     this.enablePictureInPicture = false,
     this.disablePictureInPictureWhenScreenSharing = true,
+    this.sort,
     this.androidPiPConfiguration = const AndroidPictureInPictureConfiguration(),
     this.iOSPiPConfiguration = const IOSPictureInPictureConfiguration(),
   });
@@ -21,6 +22,11 @@ class PictureInPictureConfiguration {
 
   /// Whether to disable picture-in-picture mode during screen sharing on the device.
   final bool disablePictureInPictureWhenScreenSharing;
+
+  /// Sorting function for participants in picture-in-picture mode.
+  /// The first participant will be displayed in the PiP view.
+  /// If not provided, the default sorting prioritising speaker / screen sharer will be used.
+  final Comparator<CallParticipantState>? sort;
 
   /// Configuration for picture-in-picture mode on Android.
   final AndroidPictureInPictureConfiguration androidPiPConfiguration;

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
@@ -64,8 +64,8 @@ class _StreamPictureInPictureUiKitViewState
     bool includeLocalParticipantVideo,
   ) async {
     final participants = includeLocalParticipantVideo
-        ? widget.call.state.value.callParticipants
-        : widget.call.state.value.otherParticipants;
+        ? callState.callParticipants
+        : callState.otherParticipants;
 
     final sorted = List<CallParticipantState>.from(participants);
     mergeSort(

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:stream_video/stream_video.dart';
 
+import 'picture_in_picture_configuration.dart';
+
 /// A widget that handles the picture-in-picture mode on iOS.
 /// If you are implementing custom call content widget and want to include PiP support
 /// add this widget to your widget tree.
@@ -37,6 +39,7 @@ class StreamPictureInPictureUiKitView extends StatefulWidget {
   const StreamPictureInPictureUiKitView({
     super.key,
     required this.call,
+    required this.configuration,
     this.includeLocalParticipantVideo = true,
     this.participantSort,
   });
@@ -44,6 +47,7 @@ class StreamPictureInPictureUiKitView extends StatefulWidget {
   final Call call;
   final bool includeLocalParticipantVideo;
   final Comparator<CallParticipantState>? participantSort;
+  final IOSPictureInPictureConfiguration configuration;
 
   @override
   State<StreamPictureInPictureUiKitView> createState() =>
@@ -94,6 +98,11 @@ class _StreamPictureInPictureUiKitViewState
           'isVideoEnabled':
               participant.isVideoEnabled || participant.isScreenShareEnabled,
           'connectionQuality': participant.connectionQuality.name,
+          'showParticipantName': widget.configuration.showParticipantName,
+          'showMicrophoneIndicator':
+              widget.configuration.showMicrophoneIndicator,
+          'showConnectionQualityIndicator':
+              widget.configuration.showConnectionQualityIndicator,
         },
       );
     }

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
@@ -40,12 +40,10 @@ class StreamPictureInPictureUiKitView extends StatefulWidget {
     super.key,
     required this.call,
     required this.configuration,
-    this.includeLocalParticipantVideo = true,
     this.participantSort,
   });
 
   final Call call;
-  final bool includeLocalParticipantVideo;
   final Comparator<CallParticipantState>? participantSort;
   final IOSPictureInPictureConfiguration configuration;
 
@@ -121,7 +119,7 @@ class _StreamPictureInPictureUiKitViewState
         (callState) {
           _handleCallState(
             callState,
-            widget.includeLocalParticipantVideo &&
+            widget.configuration.includeLocalParticipantVideo &&
                 widget.call.state.value.iOSMultitaskingCameraAccessEnabled,
           );
         },

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
@@ -67,17 +67,18 @@ class _StreamPictureInPictureUiKitViewState
         ? widget.call.state.value.callParticipants
         : widget.call.state.value.otherParticipants;
 
+    final sorted = List<CallParticipantState>.from(participants);
     mergeSort(
-      participants,
+      sorted,
       compare: widget.participantSort ?? CallParticipantSortingPresets.speaker,
     );
 
-    if (participants.isNotEmpty) {
-      final participant = participants.first;
+    if (sorted.isNotEmpty) {
+      final participant = sorted.first;
 
       final videoTrack = widget.call.getTrack(
-        participants.first.trackIdPrefix,
-        participants.first.isScreenShareEnabled
+        participant.trackIdPrefix,
+        participant.isScreenShareEnabled
             ? SfuTrackType.screenShare
             : SfuTrackType.video,
       );


### PR DESCRIPTION
resolves FLU-161

Enhanced the Picture in Picture experience on iOS. Now, when a video isn't available, we display the participant's avatar instead of a black screen. We've also made the microphone and connection quality indicators visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a participant overlay to the picture-in-picture video call view on iOS, displaying participant name, profile image, connection quality, and mute status.
  - Introduced support for custom participant sorting in picture-in-picture mode, allowing control over which participant is shown.
- **Refactor**
  - Streamlined call state handling for the picture-in-picture UI, improving update efficiency and overlay responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->