### PR TITLE
fix(samples): Pin gorouter to last version before 15.2

### DIFF
--- a/dogfooding/pubspec.yaml
+++ b/dogfooding/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter_rating_stars: ^1.1.0
   flutter_svg: ^2.0.7
   get_it: ^7.7.0
-  go_router: ^15.1.0
+  go_router: 15.1.3 # Go router 15.2.0 breaks with Type-safe routes 
   google_fonts: ^5.1.0
   google_sign_in: ^6.2.1
   http: ^1.2.2


### PR DESCRIPTION
### 🎯 Goal

Make latest build on web run again

### 🛠 Implementation details

Go router 15.2.0 has type safe routes: https://pub.dev/documentation/go_router/latest/topics/Type-safe%20routes-topic.html

We can probably fix it by rebuilding the paths with go_router_builder 3 (see [changelog](https://pub.dev/packages/go_router/changelog#1520)), but quickest solution for now is just to pin it to an older version. 

### 🎨 UI Changes

No UI changes

### 🧪 Testing

Run it locally, should run as before.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of an internal dependency to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->