### PR TITLE
feat(llc): added mirror participant video method

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2503,6 +2503,20 @@ class Call {
     return result;
   }
 
+  Result<None> setParticipantMirrorVideo({
+    required String sessionId,
+    required String userId,
+    required bool mirrorVideo,
+  }) {
+    _stateManager.participantMirrorVideo(
+      sessionId: sessionId,
+      userId: userId,
+      mirrorVideo: mirrorVideo,
+    );
+
+    return const Result.success(none);
+  }
+
   @Deprecated('Use setParticipantPinnedLocally instead')
   Future<Result<None>> setParticipantPinned({
     required String sessionId,

--- a/packages/stream_video/lib/src/call/state/mixins/state_participant_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_participant_mixin.dart
@@ -143,6 +143,32 @@ mixin StateParticipantMixin on StateNotifier<CallState> {
     );
   }
 
+  void participantMirrorVideo({
+    required String sessionId,
+    required String userId,
+    required bool mirrorVideo,
+  }) {
+    state = state.copyWith(
+      callParticipants: state.callParticipants.map((participant) {
+        if (participant.sessionId == sessionId &&
+            participant.userId == userId) {
+          final trackState = participant.publishedTracks[SfuTrackType.video];
+          if (trackState is RemoteTrackState) {
+            return participant.copyWith(
+              publishedTracks: {
+                ...participant.publishedTracks,
+                SfuTrackType.video: trackState.copyWith(
+                  mirrorVideo: mirrorVideo,
+                ),
+              },
+            );
+          }
+        }
+        return participant;
+      }).toList(),
+    );
+  }
+
   void participantUpdateCameraPosition({
     required CameraPosition cameraPosition,
   }) {

--- a/packages/stream_video/lib/src/models/call_track_state.dart
+++ b/packages/stream_video/lib/src/models/call_track_state.dart
@@ -113,6 +113,7 @@ class RemoteTrackState extends TrackState {
     required super.muted,
     this.subscribed = false,
     this.received = false,
+    this.mirrorVideo = false,
     this.audioSinkDevice,
     this.videoDimension,
   });
@@ -120,6 +121,9 @@ class RemoteTrackState extends TrackState {
   final bool subscribed;
   final bool received;
   final RtcVideoDimension? videoDimension;
+
+  /// Whether the video should be mirrored.
+  final bool mirrorVideo;
 
   /// The sinkId of the audio output device to use
   /// in case it is an audio track.
@@ -130,6 +134,7 @@ class RemoteTrackState extends TrackState {
         subscribed,
         received,
         muted,
+        mirrorVideo,
         audioSinkDevice,
         videoDimension,
       ];
@@ -140,6 +145,7 @@ class RemoteTrackState extends TrackState {
       if (subscribed) 'subscribed',
       if (received) 'received',
       if (muted) 'muted',
+      if (mirrorVideo) 'mirrorVideo',
       if (audioSinkDevice != null) 'audioSinkDevice($audioSinkDevice)',
       if (videoDimension != null)
         'videoDimension(width: ${videoDimension!.width}, height: ${videoDimension!.height})',
@@ -159,6 +165,7 @@ class RemoteTrackState extends TrackState {
     bool? subscribed,
     bool? received,
     bool? muted,
+    bool? mirrorVideo,
     RtcMediaDevice? audioSinkDevice,
     RtcVideoDimension? videoDimension,
   }) {
@@ -166,6 +173,7 @@ class RemoteTrackState extends TrackState {
       subscribed: subscribed ?? this.subscribed,
       received: received ?? this.received,
       muted: muted ?? this.muted,
+      mirrorVideo: mirrorVideo ?? this.mirrorVideo,
       audioSinkDevice: audioSinkDevice ?? this.audioSinkDevice,
       videoDimension: videoDimension ?? this.videoDimension,
     );

--- a/packages/stream_video/test/src/call/call_state_notifier_test.dart
+++ b/packages/stream_video/test/src/call/call_state_notifier_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_video/src/call/state/call_state_notifier.dart';
+import 'package:stream_video/stream_video.dart';
+
+void main() {
+  group('CallStateNotifier participantMirrorVideo tests', () {
+    late CallStateNotifier stateNotifier;
+    late CallState initialState;
+
+    setUp(() {
+      final targetParticipant = CallParticipantState(
+        userId: 'target-user',
+        sessionId: 'target-session',
+        name: 'Target Participant',
+        roles: const [],
+        custom: const {},
+        trackIdPrefix: 'target-track',
+        publishedTracks: {
+          SfuTrackType.video: TrackState.remote(
+            subscribed: true,
+            received: true,
+          ),
+        },
+      );
+
+      final otherParticipant = CallParticipantState(
+        userId: 'other-user',
+        sessionId: 'other-session',
+        name: 'Other Participant',
+        image: '',
+        roles: const [],
+        custom: const {},
+        trackIdPrefix: 'other-track',
+        publishedTracks: {
+          SfuTrackType.video: TrackState.remote(
+            subscribed: true,
+            received: true,
+          ),
+        },
+      );
+
+      initialState = CallState(
+        callCid: StreamCallCid.from(
+          type: StreamCallType.defaultType(),
+          id: 'test-call',
+        ),
+        currentUserId: 'current-user',
+        preferences: DefaultCallPreferences(),
+      ).copyWith(
+        callParticipants: [targetParticipant, otherParticipant],
+      );
+
+      stateNotifier = CallStateNotifier(initialState);
+    });
+
+    tearDown(() {
+      stateNotifier.dispose();
+    });
+
+    test('participantMirrorVideo updates target participant video track', () {
+      final stateBefore = stateNotifier.state;
+      expect(stateBefore.callParticipants.length, 2);
+
+      final targetParticipantBefore = stateBefore.callParticipants.firstWhere(
+        (p) => p.sessionId == 'target-session',
+      );
+      final targetVideoTrackBefore = targetParticipantBefore
+          .publishedTracks[SfuTrackType.video]! as RemoteTrackState;
+      expect(targetVideoTrackBefore.mirrorVideo, false);
+
+      final otherParticipantBefore = stateBefore.callParticipants.firstWhere(
+        (p) => p.sessionId == 'other-session',
+      );
+      final otherVideoTrackBefore = otherParticipantBefore
+          .publishedTracks[SfuTrackType.video]! as RemoteTrackState;
+      expect(otherVideoTrackBefore.mirrorVideo, false);
+
+      stateNotifier.participantMirrorVideo(
+        sessionId: 'target-session',
+        userId: 'target-user',
+        mirrorVideo: true,
+      );
+
+      final stateAfter = stateNotifier.state;
+      expect(stateAfter.callParticipants.length, 2);
+
+      final targetParticipantAfter = stateAfter.callParticipants.firstWhere(
+        (p) => p.sessionId == 'target-session',
+      );
+      final targetVideoTrackAfter = targetParticipantAfter
+          .publishedTracks[SfuTrackType.video]! as RemoteTrackState;
+      expect(targetVideoTrackAfter.mirrorVideo, true);
+
+      // Other participant should remain unchanged
+      final otherParticipantAfter = stateAfter.callParticipants.firstWhere(
+        (p) => p.sessionId == 'other-session',
+      );
+      final otherVideoTrackAfter = otherParticipantAfter
+          .publishedTracks[SfuTrackType.video]! as RemoteTrackState;
+      expect(otherVideoTrackAfter.mirrorVideo, false);
+
+      // Verify other properties remain unchanged
+      expect(targetVideoTrackAfter.muted, targetVideoTrackBefore.muted);
+      expect(
+        targetVideoTrackAfter.subscribed,
+        targetVideoTrackBefore.subscribed,
+      );
+      expect(targetVideoTrackAfter.received, targetVideoTrackBefore.received);
+    });
+
+    test('participantMirrorVideo ignores participants without video tracks',
+        () {
+      // Arrange - Create state with participant that has no video track
+      final participantWithoutVideo = CallParticipantState(
+        userId: 'no-video-user',
+        sessionId: 'no-video-session',
+        name: 'Audio Only Participant',
+        image: '',
+        roles: const [],
+        custom: const {},
+        trackIdPrefix: 'no-video-track',
+        publishedTracks: {
+          SfuTrackType.audio: TrackState.remote(), // Only audio track
+        },
+      );
+
+      final stateWithAudioOnly = initialState.copyWith(
+        callParticipants: [
+          ...initialState.callParticipants,
+          participantWithoutVideo
+        ],
+      );
+      stateNotifier.state = stateWithAudioOnly;
+
+      stateNotifier.participantMirrorVideo(
+        sessionId: 'no-video-session',
+        userId: 'no-video-user',
+        mirrorVideo: true,
+      );
+
+      final stateAfter = stateNotifier.state;
+      final participantAfter = stateAfter.callParticipants.firstWhere(
+        (p) => p.sessionId == 'no-video-session',
+      );
+
+      expect(
+        participantAfter.publishedTracks.containsKey(SfuTrackType.video),
+        false,
+      );
+      expect(
+        participantAfter.publishedTracks[SfuTrackType.audio],
+        isA<RemoteTrackState>(),
+      );
+    });
+
+    test('participantMirrorVideo only affects RemoteTrackState', () {
+      // Arrange - Create participant with LocalTrackState
+      final localParticipant = CallParticipantState(
+        userId: 'local-user',
+        sessionId: 'local-session',
+        name: 'Local Participant',
+        roles: const [],
+        custom: const {},
+        isLocal: true,
+        trackIdPrefix: 'local-track',
+        publishedTracks: {
+          SfuTrackType.video: TrackState.local(), // Local track
+        },
+      );
+
+      final stateWithLocal = initialState.copyWith(
+        callParticipants: [...initialState.callParticipants, localParticipant],
+      );
+      stateNotifier.state = stateWithLocal;
+
+      final localTrackBefore = stateWithLocal.callParticipants
+          .firstWhere((p) => p.isLocal)
+          .publishedTracks[SfuTrackType.video]! as LocalTrackState;
+
+      stateNotifier.participantMirrorVideo(
+        sessionId: 'local-session',
+        userId: 'local-user',
+        mirrorVideo: true,
+      );
+
+      // Assert - Local track should remain unchanged (no mirrorVideo property)
+      final stateAfter = stateNotifier.state;
+      final localTrackAfter = stateAfter.callParticipants
+          .firstWhere((p) => p.sessionId == 'local-session')
+          .publishedTracks[SfuTrackType.video]! as LocalTrackState;
+
+      expect(localTrackAfter.muted, localTrackBefore.muted);
+      expect(localTrackAfter.sourceDevice, localTrackBefore.sourceDevice);
+      expect(localTrackAfter.cameraPosition, localTrackBefore.cameraPosition);
+    });
+  });
+}

--- a/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
+++ b/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
@@ -124,7 +124,8 @@ class _StreamVideoRendererState extends State<StreamVideoRenderer> {
       return widget.placeholderBuilder.call(context);
     }
 
-    var mirror = widget.participant.isLocal;
+    var mirror = (trackState is RemoteTrackState && trackState.mirrorVideo) ||
+        widget.participant.isLocal;
 
     if (videoTrack is RtcLocalScreenShareTrack) {
       mirror = false;


### PR DESCRIPTION
### 🎯 Goal

We want to enable the option to mirror the video track of a remote participant.

### 🛠 Implementation details

Added `setParticipantMirrorVideo()` method to `Call` class.