### PR TITLE
fix(llc): Leave call when failing to join

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -738,7 +738,7 @@ class Call {
 
         final error = (joinedResult as Failure).error;
         await leave(reason: DisconnectReason.failure(error));
-        return result;
+        return joinedResult;
       }
 
       _credentials = joinedResult.data;

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -719,7 +719,6 @@ class Call {
         _logger.e(() => '[join] waiting failed: $result');
 
         await reject(reason: CallRejectReason.timeout());
-        _stateManager.lifecycleCallTimeout();
 
         return result;
       }
@@ -738,7 +737,7 @@ class Call {
         _logger.e(() => '[join] coordinator joining failed: $joinedResult');
 
         final error = (joinedResult as Failure).error;
-        _stateManager.lifecycleCallConnectFailed(error: error);
+        await leave(reason: DisconnectReason.failure(error));
         return result;
       }
 
@@ -794,7 +793,7 @@ class Call {
           _logger.e(() => '[join] sfu session start failed: $sessionResult');
 
           final error = (sessionResult as Failure).error;
-          _stateManager.lifecycleCallConnectFailed(error: error);
+          await leave(reason: DisconnectReason.failure(error));
           return sessionResult;
         }
       } else {
@@ -1420,6 +1419,10 @@ class Call {
   /// - [reason]: optional reason for leaving the call
   Future<Result<None>> leave({DisconnectReason? reason}) async {
     try {
+      if (_leaveCallTriggered) {
+        _logger.w(() => '[leave] rejected (already leaving call)');
+        return const Result.success(none);
+      }
       _leaveCallTriggered = true;
 
       final state = this.state.value;

--- a/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
@@ -192,18 +192,6 @@ mixin StateLifecycleMixin on StateNotifier<CallState> {
     );
   }
 
-  void lifecycleCallTimeout() {
-    _logger.e(() => '[lifecycleCallTimeout] state: $state');
-    lifecycleCallDisconnected(reason: const DisconnectReason.timeout());
-  }
-
-  void lifecycleCallConnectFailed({
-    required VideoError error,
-  }) {
-    _logger.e(() => '[lifecycleCallConnectFailed] state: $state');
-    lifecycleCallDisconnected(reason: DisconnectReason.failure(error));
-  }
-
   void lifecycleCallConnecting({
     required int attempt,
     SfuReconnectionStrategy? strategy,


### PR DESCRIPTION
### 🎯 Goal

Currently the sdk doesn't leave a call when a join fails, meaning that the call stays part of active calls.

### 🛠 Implementation details

This leaves the call when joining fails.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when joining or leaving calls by enhancing error handling and preventing duplicate leave attempts.

* **Refactor**
  * Streamlined internal logic for handling call failures and connection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->