### PR TITLE
chore(llc): bump stream_webrtc version

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -22,7 +22,7 @@ command:
       device_info_plus: ">=10.1.2 <12.0.0"
       share_plus: ^11.0.0
       stream_chat_flutter: ^9.8.0
-      stream_webrtc_flutter: ^1.0.7
+      stream_webrtc_flutter: ^1.0.9
 
 scripts:
   postclean:

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   rxdart: ^0.28.0
   sdp_transform: ^0.3.2
   state_notifier: ^1.0.0
-  stream_webrtc_flutter: ^1.0.7
+  stream_webrtc_flutter: ^1.0.9
   synchronized: ^3.1.0
   system_info2: ^4.0.0
   tart: ^0.5.1

--- a/packages/stream_video_flutter/example/pubspec.yaml
+++ b/packages/stream_video_flutter/example/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   stream_video: ^0.9.6
   stream_video_flutter: ^0.9.6
   stream_video_push_notification: ^0.9.6
-  stream_webrtc_flutter: ^1.0.7
+  stream_webrtc_flutter: ^1.0.9
 
 dependency_overrides:
   stream_video:

--- a/packages/stream_video_flutter/pubspec.yaml
+++ b/packages/stream_video_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   rate_limiter: ^1.0.0
   stream_video: ^0.9.6
-  stream_webrtc_flutter: ^1.0.7
+  stream_webrtc_flutter: ^1.0.9
   visibility_detector: ^0.4.0+2
 
 dev_dependencies:

--- a/packages/stream_video_noise_cancellation/pubspec.yaml
+++ b/packages/stream_video_noise_cancellation/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
   stream_video: ^0.9.6
-  stream_webrtc_flutter: ^1.0.7
+  stream_webrtc_flutter: ^1.0.9
 
 dev_dependencies:
   flutter_test:

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   stream_video: ^0.9.6
   uuid: ^4.2.1
   shared_preferences: ^2.3.2
-  stream_webrtc_flutter: ^1.0.7
+  stream_webrtc_flutter: ^1.0.9
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version of the `stream_webrtc_flutter` dependency from `^1.0.7` to `^1.0.9` across multiple packages and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->