### PR TITLE
fix(llc): ringing rejection fix when calling multiple devices

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 🐞 Fixed
 * Improved SFU error handling in Call flow and disconnect reason handling. The disconnected call state now accurately reflects the original cause of disconnection.
+* Fixed an issue where rejecting a ringing call by one participant would incorrectly end the call for all other ringing participants.
 
 ## 0.9.6
 

--- a/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
@@ -92,9 +92,10 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
     }).toList();
 
     if (state.createdByMe) {
-      final everyoneElseRejected = state.callMembers
-          .where((m) => m.userId != state.currentUserId)
-          .every((m) => rejectedBy.keys.contains(m.userId));
+      final everyoneElseRejected = state.otherParticipants.isEmpty &&
+          state.callMembers
+              .where((m) => m.userId != state.currentUserId)
+              .every((m) => rejectedBy.keys.contains(m.userId));
 
       if (everyoneElseRejected) {
         _logger.d(

--- a/packages/stream_video/lib/src/core/client_state.dart
+++ b/packages/stream_video/lib/src/core/client_state.dart
@@ -116,6 +116,7 @@ class MutableClientState implements ClientState {
   @override
   Future<void> removeActiveCall(Call call) async {
     if (!options.allowMultipleActiveCalls &&
+        activeCall.hasValue &&
         activeCall.value?.callCid == call.callCid) {
       activeCall.value = null;
     }

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -19,6 +19,7 @@ By (only) using these callbacks the root widgets will use more efficient partial
 
 🐞 Fixed
 * Improved SFU error handling in Call flow and disconnect reason handling. The disconnected call state now accurately reflects the original cause of disconnection.
+* Fixed an issue where rejecting a ringing call by one participant would incorrectly end the call for all other ringing participants.
 
 ## 0.9.6
 


### PR DESCRIPTION
When handling the call rejected event, we didn't consider participants who already joined the call. As a result, we could accidentally end the call when the last ringing device rejects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where rejecting a ringing call by one participant would incorrectly end the call for all other participants. Now, rejecting a call only affects the participant who rejected, allowing others to continue ringing.
  * Improved call state handling to prevent potential errors when removing active calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->