### PR TITLE
fix(llc): fix for the edge case where the same call id is used for outgoind and incoming call

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -7,6 +7,7 @@
 🐞 Fixed
 * Improved SFU error handling in Call flow and disconnect reason handling. The disconnected call state now accurately reflects the original cause of disconnection.
 * Fixed an issue where rejecting a ringing call by one participant would incorrectly end the call for all other ringing participants.
+* Fixed an edge case where a call with the same CID as an incoming call is also an outgoing call to ensure the same Call instance is used.
 
 ## 0.9.6
 

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -453,6 +453,15 @@ class StreamVideo extends Disposable {
         event.metadata.details.createdBy.id != currentUserId &&
         event.data.ringing) {
       _logger.v(() => '[onCoordinatorEvent] onCallRinging: ${event.data}');
+
+      // In a edge case where call with the same CID as the incoming call is also an outgoing call
+      // we want to use the same Call instance.
+      if (state.outgoingCall.valueOrNull?.callCid.value ==
+          event.data.callCid.value) {
+        _state.incomingCall.value = state.outgoingCall.valueOrNull;
+        return;
+      }
+
       final call = _makeCallFromRinging(data: event.data);
       _state.incomingCall.value = call;
     } else if (event is CoordinatorConnectedEvent) {

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -20,6 +20,7 @@ By (only) using these callbacks the root widgets will use more efficient partial
 🐞 Fixed
 * Improved SFU error handling in Call flow and disconnect reason handling. The disconnected call state now accurately reflects the original cause of disconnection.
 * Fixed an issue where rejecting a ringing call by one participant would incorrectly end the call for all other ringing participants.
+* Fixed an edge case where a call with the same CID as an incoming call is also an outgoing call to ensure the same Call instance is used.
 
 ## 0.9.6
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where calls with the same Call ID appearing as both incoming and outgoing would create duplicate call instances. Now, the same call instance is used in this scenario, improving call handling and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->