### PR TITLE
fix(ui): fixed ios PiP remote participant issue

### DIFF
--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 🐞 Fixed
 * (iOS) Fixed Picture-in-Picture (PiP) issue where remote participants joining during active PiP mode would not have their video tracks displayed properly.
+* (iOS) Fixed a visual issue where the Picture-in-Picture view displayed an empty container when participant name and microphone indicator settings were disabled.
 
 ## 0.10.0
 

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.1
+
+🐞 Fixed
+* (iOS) Fixed Picture-in-Picture (PiP) issue where remote participants joining during active PiP mode would not have their video tracks displayed properly.
+
 ## 0.10.0
 
 🚧 (Android) Picture-in-Picture (PiP) Improvements - Breaking Change

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.1
+## Unreleased
 
 🐞 Fixed
 * (iOS) Fixed Picture-in-Picture (PiP) issue where remote participants joining during active PiP mode would not have their video tracks displayed properly.

--- a/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
+++ b/packages/stream_video_flutter/ios/Classes/PictureInPicture/StreamAVPictureInPictureVideoCallViewController.swift
@@ -265,25 +265,27 @@ struct PictureInPictureOverlayView: View {
             VStack {
                 Spacer()
                 HStack {
-                    HStack(spacing: 4) {
-                        if showParticipantName {
-                            Text(name)
-                                .foregroundColor(.white)
-                                .multilineTextAlignment(.leading)
-                                .lineLimit(1)
-                                .font(Font.caption)
-                                .minimumScaleFactor(0.7)
-                        }
+                    if showParticipantName || showMicrophoneIndicator {
+                        HStack(spacing: 4) {
+                            if showParticipantName {
+                                Text(name)
+                                    .foregroundColor(.white)
+                                    .multilineTextAlignment(.leading)
+                                    .lineLimit(1)
+                                    .font(Font.caption)
+                                    .minimumScaleFactor(0.7)
+                            }
 
-                        if showMicrophoneIndicator {
-                            SoundIndicator(isMuted: isMuted)
+                            if showMicrophoneIndicator {
+                                SoundIndicator(isMuted: isMuted)
+                            }
                         }
+                        .padding(.horizontal, 4)
+                        .frame(height: 28)
+                        .padding(4)
+                        .background(Color.black.opacity(0.6))
+                        .cornerRadius(8)
                     }
-                    .padding(.horizontal, 4)
-                    .frame(height: 28)
-                    .padding(4)
-                    .background(Color.black.opacity(0.6))
-                    .cornerRadius(8)
 
                     Spacer()
 

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
@@ -85,7 +85,8 @@ class _StreamPictureInPictureUiKitViewState
             : SfuTrackType.video,
       );
 
-      if (videoTrack == null && participant.isVideoEnabled) {
+      if (videoTrack == null &&
+          (participant.isVideoEnabled || participant.isScreenShareEnabled)) {
         // If the video track is not available, we need to update the subscription
         // to ensure that the participant's video is displayed correctly.
         await widget.call.updateSubscription(

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
@@ -85,6 +85,22 @@ class _StreamPictureInPictureUiKitViewState
             : SfuTrackType.video,
       );
 
+      if (videoTrack == null && participant.isVideoEnabled) {
+        // If the video track is not available, we need to update the subscription
+        // to ensure that the participant's video is displayed correctly.
+        await widget.call.updateSubscription(
+          userId: participant.userId,
+          sessionId: participant.sessionId,
+          trackIdPrefix: participant.trackIdPrefix,
+          trackType: participant.isScreenShareEnabled
+              ? SfuTrackType.screenShare
+              : SfuTrackType.video,
+          videoDimension: RtcVideoDimensionPresets.h360_169,
+        );
+
+        return;
+      }
+
       await _channel.invokeMethod(
         'updateParticipant',
         {
@@ -93,8 +109,8 @@ class _StreamPictureInPictureUiKitViewState
               participant.name.isEmpty ? participant.userId : participant.name,
           'imageUrl': participant.image,
           'isAudioEnabled': participant.isAudioEnabled,
-          'isVideoEnabled':
-              participant.isVideoEnabled || participant.isScreenShareEnabled,
+          'isVideoEnabled': videoTrack != null &&
+              (participant.isVideoEnabled || participant.isScreenShareEnabled),
           'connectionQuality': participant.connectionQuality.name,
           'showParticipantName': widget.configuration.showParticipantName,
           'showMicrophoneIndicator':


### PR DESCRIPTION
part of FLU-173
resolves FLU-175

When a remote participant joins the call while PiP mode is active, we don't subscribe to their video track because VideoRenderer wasn't aware of it. This PR fixed that by subscribing to the video track if necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue on iOS where remote participants joining during an active Picture-in-Picture session would not have their video tracks displayed correctly.
  * Improved Picture-in-Picture UI to hide participant name and microphone indicators when not needed, removing unnecessary background and padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->