### PR TITLE
fix(llc): toggling camera quickly fix

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+🐞 Fixed
+- Fixed an issue where toggling camera enabled quickly could cause AVCaptureMultiCamSession to crash
+
 ## 0.10.0
 
 ✅ Added

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -257,6 +257,7 @@ class Call {
   late final _callJoinLock = Lock();
   late final _callReconnectLock = Lock();
   late final _callClosedCaptionsLock = Lock();
+  late final _multitaskingCameraLock = Lock();
 
   final CoordinatorClient _coordinatorClient;
   final StreamVideo _streamVideo;
@@ -2330,21 +2331,23 @@ class Call {
   }
 
   Future<Result<bool>> setMultitaskingCameraAccessEnabled(bool enabled) async {
-    if (CurrentPlatform.isIos) {
-      try {
-        final result =
-            await rtc.Helper.enableIOSMultitaskingCameraAccess(enabled);
-        return Result.success(result);
-      } catch (error, stackTrace) {
-        _logger.e(() => 'Failed to set multitasking camera access: $error');
-        return Result.error(
-          'Failed to set multitasking camera access',
-          stackTrace,
-        );
+    return _multitaskingCameraLock.synchronized(() async {
+      if (CurrentPlatform.isIos) {
+        try {
+          final result =
+              await rtc.Helper.enableIOSMultitaskingCameraAccess(enabled);
+          return Result.success(result);
+        } catch (error, stackTrace) {
+          _logger.e(() => 'Failed to set multitasking camera access: $error');
+          return Result.error(
+            'Failed to set multitasking camera access',
+            stackTrace,
+          );
+        }
       }
-    }
 
-    return const Result.success(false);
+      return const Result.success(false);
+    });
   }
 
   Future<Result<None>> setZoom({

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+🐞 Fixed
+- Fixed an issue where toggling camera enabled quickly could cause AVCaptureMultiCamSession to crash
+
 ## 0.10.0
 
 🚧 (Android) Picture-in-Picture (PiP) Improvements - Breaking Change


### PR DESCRIPTION
Quickly toggling the camera on or off might cause AVCaptureMultiCamSession to crash. This PR resolves the issue by adding a lock around the method that calls it.

```
*** Terminating app due to uncaught exception 'NSGenericException', reason: '*** -[AVCaptureMultiCamSession startRunning] startRunning may not be called between calls to beginConfiguration and commitConfiguration'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash issue on iOS that could occur when rapidly toggling the camera enabled state during multitasking, improving app stability.  
* **Improvements**
  * Enhanced multitasking camera access handling on iOS with improved synchronization for smoother and safer camera usage.  
* **Tests**
  * Added tests to ensure reliable and race-condition-free handling of concurrent camera enable/disable requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->