### PR TITLE
fix(llc): fixed wrong camera selection

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+🐞 Fixed
+* Fixed an issue where the default camera selection would occasionally be incorrect even when properly configured.
+
 ## 0.10.0
 
 ✅ Added

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -1524,9 +1524,6 @@ class Call {
     final audioInputs = mediaDevices
         .where((d) => d.kind == RtcMediaDeviceKind.audioInput)
         .toList();
-    final videoInputs = mediaDevices
-        .where((d) => d.kind == RtcMediaDeviceKind.videoInput)
-        .toList();
 
     /// Determines if the speaker should be enabled based on a priority hierarchy of
     /// settings.
@@ -1576,17 +1573,6 @@ class Call {
     final defaultAudioInput = audioInputs
         .firstWhereOrNull((d) => d.label == defaultAudioOutput?.label);
 
-    var defaultVideoInput = videoInputs.firstWhereOrNull(
-      (device) => device.label
-          .toLowerCase()
-          .contains(settings.video.cameraFacing.value.toLowerCase()),
-    );
-
-    // If it's not front or back then take one of the external cameras
-    if (defaultVideoInput == null && videoInputs.length > 2) {
-      defaultVideoInput = videoInputs.last;
-    }
-
     _connectOptions = connectOptions.copyWith(
       camera: TrackOption.fromSetting(
         enabled: settings.video.cameraDefaultOn,
@@ -1596,7 +1582,6 @@ class Call {
       ),
       audioInputDevice: defaultAudioInput,
       audioOutputDevice: defaultAudioOutput,
-      videoInputDevice: defaultVideoInput ?? videoInputs.firstOrNull,
       cameraFacingMode: settings.video.cameraFacing ==
               VideoSettingsRequestCameraFacingEnum.front
           ? FacingMode.user

--- a/packages/stream_video/test/src/call/call_apply_settings_test.dart
+++ b/packages/stream_video/test/src/call/call_apply_settings_test.dart
@@ -318,9 +318,6 @@ void main() {
         // Assert
         expect(result.isSuccess, true);
         expect(call.connectOptions.cameraFacingMode, FacingMode.user);
-
-        final videoInputDevice = call.connectOptions.videoInputDevice;
-        expect(videoInputDevice?.label.toLowerCase(), contains('front'));
       });
 
       test('selects back camera when cameraFacing is back', () async {
@@ -344,9 +341,6 @@ void main() {
         // Assert
         expect(result.isSuccess, true);
         expect(call.connectOptions.cameraFacingMode, FacingMode.environment);
-
-        final videoInputDevice = call.connectOptions.videoInputDevice;
-        expect(videoInputDevice?.label.toLowerCase(), contains('back'));
       });
     });
 


### PR DESCRIPTION
resolves FLU-190

There was redundant logic for selecting camera devices that duplicated the later camera facing option. It could also choose an incorrect camera due to localized labels on iOS. We will need to reimplement the removed code if we want to handle external camera selection by default (from dashboard settings), which we currently do not support.

<img width="430" alt="image" src="https://github.com/user-attachments/assets/58da77de-b8fb-4549-911f-cd3c880d4a2f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the default camera selection was occasionally incorrect, ensuring more reliable camera selection during video calls.

* **Documentation**
  * Updated the changelog to include details of the latest bug fix in an "Unreleased" section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->