### PR TITLE
feat(llc): ringing display name customization

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+✅ Added
+* Added support for customization of display name for ringing notifications by providing `display_name` custom data to the call. See the [documentation](https://getstream.io/video/docs/flutter/advanced/incoming-calls/customization/#display-name-customization) for details.
+
 ## 0.10.0
 
 ✅ Added

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -896,6 +896,8 @@ class StreamVideo extends Disposable {
 
     final createdById = payload['created_by_id'] as String?;
     final createdByName = payload['created_by_display_name'] as String?;
+    final callDisplayName = payload['call_display_name'] as String?;
+
     final hasVideo = payload['video'] as String?;
 
     final type = payload['type'] as String?;
@@ -904,7 +906,7 @@ class StreamVideo extends Disposable {
         manager.showMissedCall(
           uuid: callUUID,
           handle: createdById,
-          nameCaller: createdByName,
+          nameCaller: callDisplayName ?? createdByName,
           callCid: callCid,
         ),
       );
@@ -925,7 +927,7 @@ class StreamVideo extends Disposable {
           manager.showIncomingCall(
             uuid: callUUID,
             handle: createdById,
-            nameCaller: createdByName,
+            nameCaller: callDisplayName ?? createdByName,
             callCid: callCid,
             hasVideo: hasVideo != 'false',
           ),

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+✅ Added
+* Added support for customization of display name for ringing notifications by providing `display_name` custom data to the call. See the [documentation](https://getstream.io/video/docs/flutter/advanced/incoming-calls/customization/#display-name-customization) for details.
+
 ## 0.10.0
 
 🚧 (Android) Picture-in-Picture (PiP) Improvements - Breaking Change

--- a/packages/stream_video_push_notification/CHANGELOG.md
+++ b/packages/stream_video_push_notification/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+✅ Added
+* Added support for customization of display name for ringing notifications by providing `display_name` custom data to the call. See the [documentation](https://getstream.io/video/docs/flutter/advanced/incoming-calls/customization/#display-name-customization) for details.
+
 ## 0.10.0
 * Sync version with `stream_video_flutter` 0.10.0
 

--- a/packages/stream_video_push_notification/ios/Classes/StreamVideoPKDelegateManager.swift
+++ b/packages/stream_video_push_notification/ios/Classes/StreamVideoPKDelegateManager.swift
@@ -79,6 +79,7 @@ public class StreamVideoPKDelegateManager: NSObject, PKPushRegistryDelegate,
 
         let callCid = streamDict?["call_cid"] as? String ?? ""
         let createdByName = streamDict?["created_by_display_name"] as? String
+        let callDisplayName = streamDict?["call_display_name"] as? String
         let createdById = streamDict?["created_by_id"] as? String
         let videoIncluded = streamDict?["video"] as? String
         let videoData = videoIncluded == "false" ? 0 : 1
@@ -93,7 +94,7 @@ public class StreamVideoPKDelegateManager: NSObject, PKPushRegistryDelegate,
         }
 
         data.callKitData.uuid = callUUID
-        data.callKitData.nameCaller = createdByName ?? defaultCallText
+        data.callKitData.nameCaller = callDisplayName ?? createdByName ?? defaultCallText
         data.callKitData.handle = createdById ?? defaultCallText
         data.callKitData.type = videoData
         data.callKitData.extra = ["callCid": callCid]

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
@@ -325,6 +325,7 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
     String? nameCaller,
     bool hasVideo = true,
   }) {
+    // ignore: deprecated_member_use_from_same_package
     final customData = callerCustomizationCallback?.call(
       callCid: callCid,
       callerName: nameCaller,
@@ -352,6 +353,7 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
     String? nameCaller,
     bool hasVideo = true,
   }) {
+    // ignore: deprecated_member_use_from_same_package
     final customData = callerCustomizationCallback?.call(
       callCid: callCid,
       callerName: nameCaller,

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
@@ -33,7 +33,10 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
     required StreamVideoPushProvider iosPushProvider,
     required StreamVideoPushProvider androidPushProvider,
     @Deprecated(
-        "Caller customization is deprecated as it was not fully compatible with iOS (foreground calls only). Use 'display_name' custom field in the call instead. See details: [https://getstream.io/video/docs/flutter/advanced/incoming-calls/customization/#display-name-customization]")
+      "Caller customization is deprecated as it was not fully compatible with iOS "
+      "(foreground calls only). Use 'display_name' custom field in the call instead. "
+      "See details: https://getstream.io/video/docs/flutter/advanced/incoming-calls/customization/#display-name-customization",
+    )
     CallerCustomizationFunction? callerCustomizationCallback,
     @Deprecated(
         'Background handler is no longer needed for terminated state ringing on iOS.')
@@ -222,6 +225,11 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
   final StreamVideoPushProvider iosPushProvider;
   final StreamVideoPushProvider androidPushProvider;
   final StreamVideoPushParams pushParams;
+  @Deprecated(
+    "Caller customization is deprecated as it was not fully compatible with iOS "
+    "(foreground calls only). Use 'display_name' custom field in the call instead. "
+    "See details: https://getstream.io/video/docs/flutter/advanced/incoming-calls/customization/#display-name-customization",
+  )
   final CallerCustomizationFunction? callerCustomizationCallback;
   final bool registerApnDeviceToken;
   late SharedPreferences _sharedPreferences;

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
@@ -32,6 +32,8 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
   static create({
     required StreamVideoPushProvider iosPushProvider,
     required StreamVideoPushProvider androidPushProvider,
+    @Deprecated(
+        "Caller customization is deprecated as it was not fully compatible with iOS (foreground calls only). Use 'display_name' custom field in the call instead. See details: [https://getstream.io/video/docs/flutter/advanced/incoming-calls/customization/#display-name-customization]")
     CallerCustomizationFunction? callerCustomizationCallback,
     @Deprecated(
         'Background handler is no longer needed for terminated state ringing on iOS.')


### PR DESCRIPTION
resolves FLU-188

Added support for customization of display name for ringing notifications by providing `display_name` custom data to the call. 

Docs PR: https://github.com/GetStream/docs-content/pull/434



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the display name shown in ringing and missed call notifications by providing a custom display name field.

* **Bug Fixes**
  * Improved prioritization of the display name in notifications, falling back to default values if not provided.

* **Documentation**
  * Updated changelogs with details about the new display name customization feature and references to relevant documentation.

* **Refactor**
  * Deprecated the previous caller customization callback in favor of the new display name approach, with guidance for migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->