### PR TITLE
fix(llc): Reset reaction timer on new reaction

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+🐞 Fixed
+* Fixed an issue where the last reaction was removed too fast when a user sends multiple reactions quickly after each other.
+
 ## 0.10.0
 
 ✅ Added


### PR DESCRIPTION
### 🎯 Goal

Fix reactions

### 🛠 Implementation details

Currently old timer is triggered even when there is a new reaction already. This cancels the old timer if there is any before creating a new one.

Implementation is now more similar to the `_captionsTimers`.

### 🎨 UI Changes

No relevant UI changes

### 🧪 Testing

I've tested it by quickly triggering reactions on old app and new app. In the old app after a couple of seconds all reactions are quickly removed, new app last one stays for couple of seconds.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of call reactions to prevent premature removal when users send multiple reactions quickly.
  * Enhanced reliability in managing reaction timers to ensure accurate reaction resets per user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->