### PR TITLE
fix(samples): Handle null result with qr code scanner

### DIFF
--- a/dogfooding/lib/screens/home_screen.dart
+++ b/dogfooding/lib/screens/home_screen.dart
@@ -418,7 +418,7 @@ class _JoinForm extends StatelessWidget {
         onPressed: () async {
           final result = await QrCodeScanner.scan(context);
 
-          if (context.mounted) {
+          if (context.mounted && result != null) {
             _handleJoinUrl(context, result);
           }
         },

--- a/dogfooding/lib/screens/qr_code_scanner.dart
+++ b/dogfooding/lib/screens/qr_code_scanner.dart
@@ -13,12 +13,12 @@ class QrCodeScanner extends StatefulWidget {
   @override
   State<QrCodeScanner> createState() => _QrCodeScannerState();
 
-  static Future<String> scan(BuildContext context) async {
+  static Future<String?> scan(BuildContext context) async {
     final result = await Navigator.push(
       context,
       MaterialPageRoute<String>(builder: (_) => const QrCodeScanner()),
     );
-    return result!;
+    return result;
   }
 }
 


### PR DESCRIPTION
### 🎯 Goal

Fix crash for qr scanning

### 🛠 Implementation details

When you cancel scanning result can be `null`, resulting in an error: "Null check operator used on a null value"
Now we're just not doing anything if we get a `null` result.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR code scanning by preventing errors when no QR code is scanned or the scan is cancelled.
  * Enhanced stability of the join process by ensuring actions are only taken when a valid scan result is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->