### PR TITLE
fix(llc, samples): to run video on windows

### DIFF
--- a/dogfooding/linux/flutter/generated_plugin_registrant.cc
+++ b/dogfooding/linux/flutter/generated_plugin_registrant.cc
@@ -13,7 +13,6 @@
 #include <record_linux/record_linux_plugin.h>
 #include <stream_webrtc_flutter/flutter_web_r_t_c_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
-#include <volume_controller/volume_controller_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) desktop_drop_registrar =
@@ -37,7 +36,4 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
-  g_autoptr(FlPluginRegistrar) volume_controller_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "VolumeControllerPlugin");
-  volume_controller_plugin_register_with_registrar(volume_controller_registrar);
 }

--- a/dogfooding/linux/flutter/generated_plugins.cmake
+++ b/dogfooding/linux/flutter/generated_plugins.cmake
@@ -10,7 +10,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   record_linux
   stream_webrtc_flutter
   url_launcher_linux
-  volume_controller
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/dogfooding/windows/flutter/CMakeLists.txt
+++ b/dogfooding/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/dogfooding/windows/flutter/generated_plugins.cmake
+++ b/dogfooding/windows/flutter/generated_plugins.cmake
@@ -14,11 +14,11 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_video
   permission_handler_windows
   record_windows
+  screen_brightness_windows
   share_plus
   stream_webrtc_flutter
   thumblr_windows
   url_launcher_windows
-  volume_controller
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/melos.yaml
+++ b/melos.yaml
@@ -22,7 +22,7 @@ command:
       device_info_plus: ">=10.1.2 <12.0.0"
       share_plus: ^11.0.0
       stream_chat_flutter: ^9.8.0
-      stream_webrtc_flutter: ^1.0.9
+      stream_webrtc_flutter: ^1.0.10
       stream_video: ^0.10.1
       stream_video_flutter: ^0.10.1
       stream_video_noise_cancellation: ^0.10.1

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fixed an issue where the last reaction was removed too fast when a user sends multiple reactions quickly after each other.
 * Fixed an issue where toggling camera enabled quickly could cause AVCaptureMultiCamSession to crash
 * Fixed an issue where the default camera selection would occasionally be incorrect even when properly configured.
-* Boolean type of `DtlsSrtpKeyAgreement`.
+* Fixed `DtlsSrtpKeyAgreement` audio constraint parameter mapping
 
 ## 0.10.0
 

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed an issue where the last reaction was removed too fast when a user sends multiple reactions quickly after each other.
 * Fixed an issue where toggling camera enabled quickly could cause AVCaptureMultiCamSession to crash
 * Fixed an issue where the default camera selection would occasionally be incorrect even when properly configured.
+* Boolean type of `DtlsSrtpKeyAgreement`.
 
 ## 0.10.0
 

--- a/packages/stream_video/lib/src/webrtc/media/audio_constraints.dart
+++ b/packages/stream_video/lib/src/webrtc/media/audio_constraints.dart
@@ -53,7 +53,7 @@ class AudioConstraints extends MediaConstraints {
         {'googAutoGainControl': autoGainControl},
         {'googHighpassFilter': highPassFilter},
         {'googTypingNoiseDetection': typingNoiseDetection},
-        {'DtlsSrtpKeyAgreement': 'true'},
+        {'DtlsSrtpKeyAgreement': true},
       ];
     }
 

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   rxdart: ^0.28.0
   sdp_transform: ^0.3.2
   state_notifier: ^1.0.0
-  stream_webrtc_flutter: ^1.0.9
+  stream_webrtc_flutter: ^1.0.10
   synchronized: ^3.1.0
   system_info2: ^4.0.0
   tart: ^0.5.1

--- a/packages/stream_video_flutter/example/pubspec.yaml
+++ b/packages/stream_video_flutter/example/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   stream_video: ^0.10.1
   stream_video_flutter: ^0.10.1
   stream_video_push_notification: ^0.10.1
-  stream_webrtc_flutter: ^1.0.9
+  stream_webrtc_flutter: ^1.0.10
 
 dependency_overrides:
   stream_video:

--- a/packages/stream_video_flutter/pubspec.yaml
+++ b/packages/stream_video_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   rate_limiter: ^1.0.0
   stream_video: ^0.10.1
-  stream_webrtc_flutter: ^1.0.9
+  stream_webrtc_flutter: ^1.0.10
   visibility_detector: ^0.4.0+2
 
 dev_dependencies:

--- a/packages/stream_video_noise_cancellation/pubspec.yaml
+++ b/packages/stream_video_noise_cancellation/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
   stream_video: ^0.10.1
-  stream_webrtc_flutter: ^1.0.9
+  stream_webrtc_flutter: ^1.0.10
 
 dev_dependencies:
   flutter_test:

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   stream_video: ^0.10.1
   uuid: ^4.2.1
   shared_preferences: ^2.3.2
-  stream_webrtc_flutter: ^1.0.9
+  stream_webrtc_flutter: ^1.0.10
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
### 🎯 Goal

Run dogfooding on windows.

Related PR: https://github.com/GetStream/webrtc-flutter/pull/37

### 🛠 Implementation details

Mostly automated changes, the only real change is in audio_constraints.dart
```dart
{'DtlsSrtpKeyAgreement': true},
```

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by updating the audio constraints configuration for secure media connections.

* **Chores**
  * Removed the volume controller plugin from Linux and Windows platforms.
  * Added the screen brightness plugin for Windows.
  * Enhanced Windows build configuration to support dynamic platform specification.
  * Updated dependency versions for stream_webrtc_flutter across multiple packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->