### PR TITLE
feat(llc): Make sure the audio input device is set even when the user joins muted

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 🐞 Fixed
 * Fixed an issue where the last reaction was removed too fast when a user sends multiple reactions quickly after each other.
-* Fixed an issue where toggling camera enabled quickly could cause AVCaptureMultiCamSession to crash
+* Fixed an issue where toggling camera enabled quickly could cause AVCaptureMultiCamSession to crash.
 * Fixed an issue where the default camera selection would occasionally be incorrect even when properly configured.
+* Fixed an issue where changing the audio input device while muted from the start of a call would not apply the new device when unmuting. The selected device will now be correctly set upon unmuting.
 
 ## 0.10.0
 

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2545,7 +2545,8 @@ class Call {
       _stateManager.participantSetAudioInputDevice(device: device);
       return const Result.success(none);
     } else {
-      if (result case VideoErrorWithCause(cause: TrackMissingException())) {
+      if (result.getErrorOrNull()
+          case VideoErrorWithCause(cause: TrackMissingException())) {
         // If the track is null, it most probably means that the user
         // joined the call muted and the audio track was not created.
         // We will set the audio input device when the user unmutes.

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2545,7 +2545,7 @@ class Call {
       _stateManager.participantSetAudioInputDevice(device: device);
       return const Result.success(none);
     } else {
-      if (result.getErrorOrNull()?.message == 'Track is null') {
+      if (result case VideoErrorWithCause(cause: TrackMissingException())) {
         // If the track is null, it most probably means that the user
         // joined the call muted and the audio track was not created.
         // We will set the audio input device when the user unmutes.

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2539,7 +2539,7 @@ class Call {
     final result = await _session?.setAudioInputDevice(device) ??
         Result.error('Session is null');
 
-    _connectOptions = connectOptions.copyWith(audioInputDevice: device);
+    _connectOptions = _connectOptions.copyWith(audioInputDevice: device);
 
     if (result.isSuccess) {
       _stateManager.participantSetAudioInputDevice(device: device);

--- a/packages/stream_video/lib/src/webrtc/rtc_manager.dart
+++ b/packages/stream_video/lib/src/webrtc/rtc_manager.dart
@@ -1053,7 +1053,7 @@ extension RtcManagerTrackHelper on RtcManager {
   }) async {
     final track = getPublisherTrackByType(SfuTrackType.audio);
     if (track == null) {
-      _logger.w(() => '[setMicrophoneDeviceId] rejected (track is null)');
+      _logger.d(() => '[setMicrophoneDeviceId] rejected (track is null)');
       return Result.error('Track is null');
     }
 

--- a/packages/stream_video/lib/src/webrtc/rtc_manager.dart
+++ b/packages/stream_video/lib/src/webrtc/rtc_manager.dart
@@ -1054,7 +1054,10 @@ extension RtcManagerTrackHelper on RtcManager {
     final track = getPublisherTrackByType(SfuTrackType.audio);
     if (track == null) {
       _logger.d(() => '[setMicrophoneDeviceId] rejected (track is null)');
-      return Result.error('Track is null');
+      return Result.errorWithCause(
+        'Track is null',
+        TrackMissingException(trackType: SfuTrackType.audio),
+      );
     }
 
     if (track is! RtcLocalAudioTrack) {
@@ -1336,5 +1339,15 @@ extension on RtcLocalTrack<VideoConstraints> {
       }
     }
     return dimension;
+  }
+}
+
+class TrackMissingException implements Exception {
+  TrackMissingException({required this.trackType});
+  final SfuTrackType trackType;
+
+  @override
+  String toString() {
+    return 'TrackMissingException: Track with type "$trackType" is missing.';
   }
 }

--- a/packages/stream_video/test/src/call/call_test.dart
+++ b/packages/stream_video/test/src/call/call_test.dart
@@ -15,13 +15,6 @@ void main() {
   setUpAll(() {
     registerMockFallbackValues();
     TestWidgetsFlutterBinding.ensureInitialized();
-
-    registerFallbackValue(const RtcMediaDevice(
-      id: 'fallback-device',
-      label: 'Fallback Device',
-      kind: RtcMediaDeviceKind.audioInput,
-      groupId: 'fallback-group',
-    ));
   });
 
   group('Call', () {

--- a/packages/stream_video/test/src/call/call_test.dart
+++ b/packages/stream_video/test/src/call/call_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:stream_video/src/errors/video_error.dart';
+import 'package:stream_video/src/webrtc/rtc_manager.dart';
 import 'package:stream_video/stream_video.dart';
 
 import '../../test_helpers.dart';
@@ -13,6 +15,13 @@ void main() {
   setUpAll(() {
     registerMockFallbackValues();
     TestWidgetsFlutterBinding.ensureInitialized();
+
+    registerFallbackValue(const RtcMediaDevice(
+      id: 'fallback-device',
+      label: 'Fallback Device',
+      kind: RtcMediaDeviceKind.audioInput,
+      groupId: 'fallback-group',
+    ));
   });
 
   group('Call', () {
@@ -64,6 +73,112 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       verify(callSession.fastReconnect).called(1);
+
+      await internetStatusController.close();
+    });
+
+    test('should set audio input device', () async {
+      final internetStatusController =
+          BehaviorSubject<InternetStatus>.seeded(InternetStatus.connected);
+
+      final coordinatorClient = setupMockCoordinatorClient();
+      final callSession = setupMockCallSession();
+
+      when(() => callSession.setAudioInputDevice(any<RtcMediaDevice>()))
+          .thenAnswer((_) => Future.value(const Result.success(none)));
+
+      final call = createTestCall(
+        networkMonitor: setupMockInternetConnection(
+          statusStream: internetStatusController,
+        ),
+        coordinatorClient: coordinatorClient,
+        sessionFactory: setupMockSessionFactory(
+          callSession: callSession,
+        ),
+      );
+
+      const audioDevice = RtcMediaDevice(
+        id: 'id',
+        label: 'label',
+        kind: RtcMediaDeviceKind.audioInput,
+      );
+
+      await call.join();
+
+      final result = await call.setAudioInputDevice(audioDevice);
+
+      expect(result, isA<Result<None>>());
+      expect(result.isSuccess, isTrue);
+
+      expect(call.connectOptions.audioInputDevice, audioDevice);
+
+      await internetStatusController.close();
+    });
+
+    test(
+        'should set audio input device when track missing, set later when unmute',
+        () async {
+      final internetStatusController =
+          BehaviorSubject<InternetStatus>.seeded(InternetStatus.connected);
+
+      final coordinatorClient = setupMockCoordinatorClient();
+      final callSession = setupMockCallSession();
+      final mockPermissionManager = MockPermissionsManager();
+
+      when(() => mockPermissionManager.hasPermission(CallPermission.sendAudio))
+          .thenAnswer((_) => true);
+
+      final resultArray = <Result<None>>[
+        Result.failure(
+          VideoErrorWithCause(
+            message: '',
+            cause: TrackMissingException(trackType: SfuTrackType.audio),
+          ),
+        ),
+        const Result.success(none),
+      ];
+
+      when(() => callSession.setAudioInputDevice(any<RtcMediaDevice>()))
+          .thenAnswer(
+        (_) => Future.value(resultArray.removeAt(0)),
+      );
+
+      when(() => callSession.setMicrophoneEnabled(any()))
+          .thenAnswer((_) => Future.value(Result.success(MockRtcLocalTrack())));
+
+      final call = createTestCall(
+        permissionManager: mockPermissionManager,
+        networkMonitor: setupMockInternetConnection(
+          statusStream: internetStatusController,
+        ),
+        coordinatorClient: coordinatorClient,
+        sessionFactory: setupMockSessionFactory(
+          callSession: callSession,
+        ),
+      );
+
+      const audioDevice = RtcMediaDevice(
+        id: 'id',
+        label: 'label',
+        kind: RtcMediaDeviceKind.audioInput,
+      );
+
+      await call.join();
+
+      final result = await call.setAudioInputDevice(audioDevice);
+
+      expect(result, isA<Result<None>>());
+      expect(result.isSuccess, isTrue);
+
+      expect(call.connectOptions.audioInputDevice, audioDevice);
+
+      await call.setMicrophoneEnabled(enabled: true);
+
+      verifyInOrder([
+        () => callSession.setAudioInputDevice(audioDevice),
+        () => callSession.setMicrophoneEnabled(true),
+        () => callSession.setAudioInputDevice(audioDevice),
+      ]);
 
       await internetStatusController.close();
     });

--- a/packages/stream_video/test/src/call/call_test_helpers.dart
+++ b/packages/stream_video/test/src/call/call_test_helpers.dart
@@ -36,6 +36,13 @@ const defaultCredentials = CallCredentials(
   ),
 );
 
+const defaultMediaDevice = RtcMediaDevice(
+  id: 'fallback-device',
+  label: 'Fallback Device',
+  kind: RtcMediaDeviceKind.audioInput,
+  groupId: 'fallback-group',
+);
+
 const defaultUserInfo = UserInfo(id: 'testUserId');
 
 void registerMockFallbackValues() {
@@ -51,6 +58,7 @@ void registerMockFallbackValues() {
     StatsOptions(enableRtcStats: false, reportingIntervalMs: 500),
   );
   registerFallbackValue(SfuReconnectionStrategy.fast);
+  registerFallbackValue(defaultMediaDevice);
 }
 
 Call createStubCall({

--- a/packages/stream_video/test/test_helpers.dart
+++ b/packages/stream_video/test/test_helpers.dart
@@ -44,6 +44,8 @@ class MockWebSocketChannel extends Mock implements WebSocketChannel {}
 
 class MockWebSocketSink extends Mock implements WebSocketSink {}
 
+class MockRtcLocalTrack extends Mock implements RtcLocalTrack {}
+
 /// Helper function to create CallDetails for testing
 CallDetails createTestCallDetails({
   required String createdByUserId,

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -3,7 +3,8 @@
 🐞 Fixed
 * (iOS) Fixed Picture-in-Picture (PiP) issue where remote participants joining during active PiP mode would not have their video tracks displayed properly.
 * (iOS) Fixed a visual issue where the Picture-in-Picture view displayed an empty container when participant name and microphone indicator settings were disabled.
-* Fixed an issue where toggling camera enabled quickly could cause AVCaptureMultiCamSession to crash
+* Fixed an issue where toggling camera enabled quickly could cause AVCaptureMultiCamSession to crash.
+* Fixed an issue where changing the audio input device while muted from the start of a call would not apply the new device when unmuting. The selected device will now be correctly set upon unmuting.
 
 ✅ Added
 * Added support for customization of display name for ringing notifications by providing `display_name` custom data to the call. See the [documentation](https://getstream.io/video/docs/flutter/advanced/incoming-calls/customization/#display-name-customization) for details.


### PR DESCRIPTION
resolves FLU-202

When the user joins the call muted, the audio track is not created. It will be created the first time he or she unmutes. If the user wants to set the audio input device during that time, it would fail. We want to make it possible by storing the chosen deviceId and applying the change when the track is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where changing the audio input device while muted at the start of a call did not apply the new device upon unmuting; the selected device is now correctly set when unmuted.
  * Improved error handling for missing audio tracks, ensuring smoother device switching and unmuting behavior.
  * Minor update to changelog formatting for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->