### PR TITLE
feat(llc): configuration for reconnect timeouts

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+✅ Added
+* Introduced the `reconnectTimeout` option in `CallPreferences`, allowing you to set the maximum duration the SDK will attempt to reconnect to a call before giving up.
+
+🔄 Changed
+* Deprecated `callRejoinTimeout` in `RetryConfig`, instead added `networkAvailabilityTimeout` to `CallPreferences` to control how long the SDK waits for network connectivity to be restored during reconnection attempts before timing out.
+
 ## 0.10.1
 
 ✅ Added

--- a/packages/stream_video/lib/src/models/call_preferences.dart
+++ b/packages/stream_video/lib/src/models/call_preferences.dart
@@ -1,20 +1,61 @@
 import 'call_client_publish_options.dart';
 
 abstract class CallPreferences {
+  /// The maximum duration to wait when establishing a connection to the call.
+  ///
+  /// If the connection is not established within this timeout, the connection
+  /// attempt will be cancelled.
   Duration get connectTimeout;
+
+  /// The maximum duration to wait when reconnecting to the call.
+  ///
+  /// If the connection is not established within this timeout, the reconnection
+  /// attempt will be cancelled. And the user will disconnect from the call.
+  Duration get reconnectTimeout;
+
+  /// The maximum duration to wait for network availability before timing out.
+  ///
+  /// If the network is not available within this timeout, the call will be
+  /// considered disconnected
+  Duration get networkAvailabilityTimeout;
+
+  /// The duration after which call reactions (like emoji reactions)
+  /// automatically disappear from the UI.
   Duration get reactionAutoDismissTime;
+
+  /// The interval at which call statistics are reported and updated.
+  ///
+  /// This controls how frequently metrics like bandwidth, latency, and
+  /// quality statistics are collected and reported.
   Duration get callStatsReportingInterval;
+
+  /// Whether to automatically drop the call if the user is alone
+  /// in the ringing flow.
+  ///
+  /// When true, if all participants leave the call initiated by ringing,
+  /// the call will be automatically ended.
   bool get dropIfAloneInRingingFlow;
 
+  /// Configuration options for client-side publishing settings.
+  ///
+  /// Manually setting preferred codec can cause call stability/compatibility issues.
+  /// Use with caution.
   ClientPublishOptions? get clientPublishOptions;
 
+  /// The duration in milliseconds that closed captions remain visible
+  /// on screen before being automatically hidden.
   int get closedCaptionsVisibilityDurationMs;
+
+  /// The maximum number of closed caption lines that can be visible
+  /// simultaneously on screen.
   int get closedCaptionsVisibleCaptions;
 }
 
 class DefaultCallPreferences implements CallPreferences {
   DefaultCallPreferences({
     this.connectTimeout = const Duration(seconds: 60),
+    this.reconnectTimeout = Duration.zero,
+    this.networkAvailabilityTimeout = const Duration(minutes: 5),
     this.reactionAutoDismissTime = const Duration(seconds: 5),
     this.callStatsReportingInterval = const Duration(seconds: 2),
     this.dropIfAloneInRingingFlow = true,
@@ -23,24 +64,77 @@ class DefaultCallPreferences implements CallPreferences {
     this.closedCaptionsVisibleCaptions = 2,
   });
 
+  /// The maximum duration to wait when establishing a connection to the call.
+  ///
+  /// If the connection is not established within this timeout, the connection
+  /// attempt will be cancelled.
+  ///
+  /// Defaults to 60 seconds.
   @override
   final Duration connectTimeout;
 
+  /// The maximum amount of time to wait when attempting to reconnect to the call.
+  ///
+  /// If reconnection is not successful within this period, the attempt will be aborted
+  /// and the user will be disconnected from the call.
+  ///
+  /// Defaults to 0 seconds, which means reconnection attempts will continue indefinitely.
+  @override
+  final Duration reconnectTimeout;
+
+  /// The maximum duration to wait for network availability before timing out.
+  ///
+  /// If the network is not available within this timeout, the call will be
+  /// considered disconnected.
+  ///
+  /// Defaults to 5 minutes.
+  @override
+  final Duration networkAvailabilityTimeout;
+
+  /// The duration after which call reactions (like emoji reactions)
+  /// automatically disappear from the UI.
+  ///
+  /// Defaults to 5 seconds.
   @override
   final Duration reactionAutoDismissTime;
 
+  /// The interval at which call statistics are reported and updated.
+  ///
+  /// This controls how frequently metrics like bandwidth, latency, and
+  /// quality statistics are collected and reported.
+  ///
+  /// Defaults to 2 seconds.
   @override
   final Duration callStatsReportingInterval;
 
+  /// Whether to automatically drop the call if the user is alone
+  /// in the ringing flow.
+  ///
+  /// When true, if all participants leave the call initiated by ringing,
+  /// the call will be automatically ended.
+  ///
+  /// Defaults to true.
   @override
   final bool dropIfAloneInRingingFlow;
 
+  /// Configuration options for client-side publishing settings.
+  ///
+  /// Manually setting preferred codec can cause call stability/compatibility issues.
+  /// Use with caution.
   @override
   final ClientPublishOptions? clientPublishOptions;
 
+  /// The duration in milliseconds that closed captions remain visible
+  /// on screen before being automatically hidden.
+  ///
+  /// Defaults to 2700ms (2.7 seconds).
   @override
   final int closedCaptionsVisibilityDurationMs;
 
+  /// The maximum number of closed caption lines that can be visible
+  /// simultaneously on screen.
+  ///
+  /// Defaults to 2 lines.
   @override
   final int closedCaptionsVisibleCaptions;
 }

--- a/packages/stream_video/lib/src/retry/retry_policy.dart
+++ b/packages/stream_video/lib/src/retry/retry_policy.dart
@@ -42,6 +42,7 @@ class RetryConfig with EquatableMixin {
   const RetryConfig({
     this.rpcMaxRetries = _defaultRpcMaxRetries,
     this.maxBackoff = _defaultMaxBackoff,
+    @Deprecated('Use CallPreferences.networkAvailabilityTimeout instead')
     this.callRejoinTimeout = _defaultRejoinTimeout,
   });
 
@@ -49,6 +50,7 @@ class RetryConfig with EquatableMixin {
 
   final Duration maxBackoff;
 
+  @Deprecated('Use CallPreferences.networkAvailabilityTimeout instead')
   final Duration callRejoinTimeout;
 
   @override

--- a/packages/stream_video/test/src/call/call_test.dart
+++ b/packages/stream_video/test/src/call/call_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:stream_video/src/call/state/call_state_notifier.dart';
 import 'package:stream_video/src/errors/video_error.dart';
 import 'package:stream_video/src/webrtc/rtc_manager.dart';
 import 'package:stream_video/stream_video.dart';
@@ -68,6 +69,74 @@ void main() {
       verify(callSession.fastReconnect).called(1);
 
       await internetStatusController.close();
+    });
+
+    test(
+        'should timeout when network is unavailable longer than networkAvailabilityTimeout',
+        () async {
+      final customPreferences = DefaultCallPreferences(
+        networkAvailabilityTimeout: const Duration(milliseconds: 100),
+      );
+
+      final customStateManager = CallStateNotifier(
+        CallState(
+          preferences: customPreferences,
+          currentUserId: defaultUserInfo.id,
+          callCid: defaultCid,
+        ),
+      );
+
+      final internetStatusController =
+          BehaviorSubject<InternetStatus>.seeded(InternetStatus.connected);
+
+      final coordinatorClient = setupMockCoordinatorClient();
+      final callSession = setupMockCallSession();
+
+      // Track when fastReconnect is called during the timeout scenario
+      var fastReconnectCallCount = 0;
+      when(callSession.fastReconnect).thenAnswer((_) {
+        fastReconnectCallCount++;
+        return Future.value(
+          Result.success(
+            (
+              callState: createTestSfuCallState(),
+              fastReconnectDeadline: Duration.zero,
+            ),
+          ),
+        );
+      });
+
+      final call = createTestCall(
+        stateManager: customStateManager,
+        networkMonitor: setupMockInternetConnection(
+          statusStream: internetStatusController,
+        ),
+        coordinatorClient: coordinatorClient,
+        sessionFactory: setupMockSessionFactory(
+          callSession: callSession,
+        ),
+      );
+
+      // First join the call successfully
+      final joinResult = await call.join();
+      expect(joinResult, isA<Result<None>>());
+      expect(joinResult.isSuccess, isTrue);
+
+      // Verify the custom timeout is set in the call state
+      expect(
+        call.state.value.preferences.networkAvailabilityTimeout,
+        const Duration(milliseconds: 100),
+      );
+
+      // Simulate network disconnection to trigger reconnection
+      internetStatusController.add(InternetStatus.disconnected);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(internetStatusController.value, InternetStatus.disconnected);
+      expect(fastReconnectCallCount, 0);
+
+      await internetStatusController.close();
+      customStateManager.dispose();
     });
 
     test('should set audio input device', () async {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for call reconnection and network availability, allowing users to tailor connection behavior.
  * Introduced new preferences for reaction auto-dismiss timing and call statistics reporting interval.

* **Documentation**
  * Enhanced and expanded documentation for call preference options, providing clearer descriptions and default values.

* **Chores**
  * Deprecated an older timeout setting in favor of new, more flexible configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->