### PR TITLE
Update screen share visibility separate from video

### DIFF
--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2772,12 +2772,21 @@ class Call {
     required String sessionId,
     required String userId,
     required ViewportVisibility visibility,
+    required SfuTrackTypeVideo trackType,
   }) async {
     final change = VisibilityChange(
       sessionId: sessionId,
       userId: userId,
       visibility: visibility,
     );
+    if (trackType.isScreenShare) {
+      _stateManager.participantUpdateScreenShareViewportVisibility(
+        sessionId: sessionId,
+        userId: userId,
+        visibility: visibility,
+      );
+      return const Result.success(none);
+    }
 
     final result = await _session?.updateViewportVisibility(change) ??
         Result.error('Session is null');

--- a/packages/stream_video/lib/src/call/state/mixins/state_participant_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_participant_mixin.dart
@@ -53,6 +53,25 @@ mixin StateParticipantMixin on StateNotifier<CallState> {
     );
   }
 
+  void participantUpdateScreenShareViewportVisibility({
+    required String sessionId,
+    required String userId,
+    required ViewportVisibility visibility,
+  }) {
+    state = state.copyWith(
+      callParticipants: state.callParticipants.map((participant) {
+        if (participant.sessionId == sessionId &&
+            participant.userId == userId) {
+          return participant.copyWith(
+            screenShareViewportVisibility: visibility,
+          );
+        }
+
+        return participant;
+      }).toList(),
+    );
+  }
+
   void participantUpdateSubscription({
     required String userId,
     required String sessionId,

--- a/packages/stream_video/lib/src/models/call_participant_state.dart
+++ b/packages/stream_video/lib/src/models/call_participant_state.dart
@@ -34,6 +34,7 @@ class CallParticipantState
     this.pin,
     this.reaction,
     this.viewportVisibility = ViewportVisibility.unknown,
+    this.screenShareViewportVisibility = ViewportVisibility.unknown,
   }) : audioLevels = audioLevels ?? [audioLevel];
 
   /// Internal constructor to be used with copyWith methods
@@ -56,6 +57,7 @@ class CallParticipantState
     required this.pin,
     required this.reaction,
     required this.viewportVisibility,
+    required this.screenShareViewportVisibility,
   });
 
   final String userId;
@@ -81,6 +83,7 @@ class CallParticipantState
   final CallParticipantPin? pin;
   final CallReaction? reaction;
   final ViewportVisibility viewportVisibility;
+  final ViewportVisibility screenShareViewportVisibility;
 
   bool get isPinned => pin != null;
   String get uniqueParticipantKey => '$userId-$sessionId';
@@ -108,6 +111,7 @@ class CallParticipantState
     CallParticipantPin? pin,
     CallReaction? reaction,
     ViewportVisibility? viewportVisibility,
+    ViewportVisibility? screenShareViewportVisibility,
   }) {
     return CallParticipantState._(
       userId: userId ?? this.userId,
@@ -128,6 +132,8 @@ class CallParticipantState
       pin: pin ?? this.pin,
       reaction: reaction ?? this.reaction,
       viewportVisibility: viewportVisibility ?? this.viewportVisibility,
+      screenShareViewportVisibility:
+          screenShareViewportVisibility ?? this.screenShareViewportVisibility,
     );
   }
 
@@ -171,6 +177,7 @@ class CallParticipantState
       pin: participantPin,
       reaction: reaction,
       viewportVisibility: viewportVisibility,
+      screenShareViewportVisibility: screenShareViewportVisibility,
     );
   }
 
@@ -200,6 +207,7 @@ class CallParticipantState
       pin: pin,
       reaction: reaction,
       viewportVisibility: viewportVisibility,
+      screenShareViewportVisibility: screenShareViewportVisibility,
     );
   }
 

--- a/packages/stream_video/lib/src/sfu/data/models/sfu_track_type.dart
+++ b/packages/stream_video/lib/src/sfu/data/models/sfu_track_type.dart
@@ -17,6 +17,8 @@ class SfuTrackType {
   bool get isAudio => this is SfuTrackTypeAudio;
 
   bool get isVideo => this is SfuTrackTypeVideo;
+
+  bool get isScreenShare => this is SfuTrackTypeVideo && this == screenShare;
 }
 
 abstract class SfuTrackTypeAudio extends SfuTrackType {

--- a/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
+++ b/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
@@ -153,7 +153,10 @@ class _StreamVideoRendererState extends State<StreamVideoRenderer> {
     latestVisibilityInfo = info;
     final fraction = info.visibleFraction;
 
-    final prevVisibility = widget.participant.viewportVisibility;
+    final prevVisibility = widget.videoTrackType.isScreenShare
+        ? widget.participant.screenShareViewportVisibility
+        : widget.participant.viewportVisibility;
+
     final visibility = ViewportVisibility.fromVisibleFraction(fraction);
 
     // Update the viewport visibility of the participant.
@@ -162,6 +165,7 @@ class _StreamVideoRendererState extends State<StreamVideoRenderer> {
         sessionId: widget.participant.sessionId,
         userId: widget.participant.userId,
         visibility: visibility,
+        trackType: widget.videoTrackType,
       );
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fixes FLU-210

### 🛠 Implementation details

Participants were jumping, because participant visibility was set to hidden when the screen share track was hidden.


### 🧪 Testing

Easily test before/after by having a call with 2 members and share screen from one of them. When you stop sharing the participant who talks is always put on spot 1 even though both are always visible. After the fix it works normally.


### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation
