### PR TITLE
feat(ui): Allow video filters to be set before video track is created

### DIFF
--- a/dogfooding/lib/app/app_content.dart
+++ b/dogfooding/lib/app/app_content.dart
@@ -154,6 +154,7 @@ class _StreamDogFoodingAppContentState
             final extra = (
               call: call,
               connectOptions: null,
+              effectsManager: null,
             );
 
             _router.push(CallRoute($extra: extra).location, extra: extra);
@@ -179,6 +180,7 @@ class _StreamDogFoodingAppContentState
             final extra = (
               call: callToJoin,
               connectOptions: null,
+              effectsManager: null,
             );
 
             _router.push(CallRoute($extra: extra).location, extra: extra);
@@ -193,6 +195,7 @@ class _StreamDogFoodingAppContentState
         final extra = (
           call: call,
           connectOptions: null,
+          effectsManager: null,
         );
 
         _router.push(CallRoute($extra: extra).location, extra: extra);

--- a/dogfooding/lib/router/routes.dart
+++ b/dogfooding/lib/router/routes.dart
@@ -45,12 +45,13 @@ class LobbyRoute extends GoRouteData {
   Widget build(BuildContext context, GoRouterState state) {
     return LobbyScreen(
       call: $extra,
-      onJoinCallPressed: (connectOptions) {
+      onJoinCallPressed: (connectOptions, effectsManager) {
         // Navigate to the call screen.
         CallRoute(
           $extra: (
             call: $extra,
             connectOptions: connectOptions,
+            effectsManager: effectsManager,
           ),
         ).replace(context);
       },
@@ -79,6 +80,7 @@ class CallRoute extends GoRouteData {
   final ({
     Call call,
     CallConnectOptions? connectOptions,
+    StreamVideoEffectsManager? effectsManager,
   }) $extra;
 
   @override
@@ -86,6 +88,7 @@ class CallRoute extends GoRouteData {
     return CallScreen(
       call: $extra.call,
       connectOptions: $extra.connectOptions,
+      videoEffectsManager: $extra.effectsManager,
     );
   }
 }

--- a/dogfooding/lib/router/routes.g.dart
+++ b/dogfooding/lib/router/routes.g.dart
@@ -124,8 +124,11 @@ RouteBase get $callRoute => GoRouteData.$route(
 
 extension $CallRouteExtension on CallRoute {
   static CallRoute _fromState(GoRouterState state) => CallRoute(
-        $extra:
-            state.extra as ({Call call, CallConnectOptions? connectOptions}),
+        $extra: state.extra as ({
+          Call call,
+          CallConnectOptions? connectOptions,
+          StreamVideoEffectsManager? effectsManager
+        }),
       );
 
   String get location => GoRouteData.$location(

--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -31,10 +31,12 @@ class CallScreen extends StatefulWidget {
     super.key,
     required this.call,
     this.connectOptions,
+    this.videoEffectsManager,
   });
 
   final Call call;
   final CallConnectOptions? connectOptions;
+  final StreamVideoEffectsManager? videoEffectsManager;
 
   @override
   State<CallScreen> createState() => _CallScreenState();
@@ -42,7 +44,8 @@ class CallScreen extends StatefulWidget {
 
 class _CallScreenState extends State<CallScreen> {
   late final _userChatRepo = locator.get<UserChatRepository>();
-  late final _videoEffectsManager = StreamVideoEffectsManager(widget.call);
+  late final _videoEffectsManager =
+      widget.videoEffectsManager ?? StreamVideoEffectsManager(widget.call);
 
   Channel? _channel;
   ParticipantLayoutMode _currentLayoutMode = ParticipantLayoutMode.grid;
@@ -58,6 +61,7 @@ class _CallScreenState extends State<CallScreen> {
   void dispose() {
     widget.call.leave();
     _userChatRepo.disconnectUser();
+    _videoEffectsManager.dispose();
     super.dispose();
   }
 

--- a/dogfooding/lib/screens/home_screen.dart
+++ b/dogfooding/lib/screens/home_screen.dart
@@ -116,6 +116,7 @@ class _HomeScreenState extends State<HomeScreen> {
               CallRoute($extra: (
                 call: _call!,
                 connectOptions: null,
+                effectsManager: null,
               )).push(context);
             } else {
               LobbyRoute($extra: _call!).push(context);

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+🐞 Fixed
+* Fixed an issue where video filters were cleared after toggling the camera.
+
+✅ Added
+* Added support for setting video filters before the video track is created by listening for local participant state changes and applying the filters once the video is enabled.
+* Added support for setting video filters on a specific video track before the local participant is available — useful for scenarios like lobby previews with a temporary video track.
+
 ## 0.10.1
 
 🐞 Fixed

--- a/packages/stream_video_flutter/lib/src/call_screen/lobby_video.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/lobby_video.dart
@@ -18,6 +18,7 @@ class StreamLobbyVideo extends StatefulWidget {
     this.onMicrophoneTrackSet,
     this.onCameraTrackSet,
     this.streamVideo,
+    this.additionalActionsBuilder,
   });
 
   /// Represents a call.
@@ -31,6 +32,8 @@ class StreamLobbyVideo extends StatefulWidget {
 
   final FutureOr<void> Function(RtcLocalAudioTrack?)? onMicrophoneTrackSet;
   final FutureOr<void> Function(RtcLocalCameraTrack?)? onCameraTrackSet;
+
+  final List<Widget> Function(BuildContext, Call)? additionalActionsBuilder;
 
   /// An instance of [StreamVideo].
   ///
@@ -188,6 +191,8 @@ class _StreamLobbyVideoState extends State<StreamLobbyVideo> {
                     cameraEnabled ? null : theme.optionOffBackgroundColor,
                 onPressed: toggleCamera,
               ),
+              if (widget.additionalActionsBuilder != null)
+                ...widget.additionalActionsBuilder!(context, widget.call),
             ],
           ),
         ],

--- a/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/lobby_view.dart
@@ -70,34 +70,6 @@ class _StreamLobbyViewState extends State<StreamLobbyView> {
 
   bool get hasMicrophoneEnabled => _microphoneTrack != null;
 
-  Future<void> toggleCamera() async {
-    if (hasCameraEnabled) {
-      await _cameraTrack?.stop();
-      return setState(() => _cameraTrack = null);
-    }
-
-    try {
-      final cameraTrack = await RtcLocalTrack.camera();
-      return setState(() => _cameraTrack = cameraTrack);
-    } catch (e) {
-      _logger.w(() => 'Error creating camera track: $e');
-    }
-  }
-
-  Future<void> toggleMicrophone() async {
-    if (hasMicrophoneEnabled) {
-      await _microphoneTrack?.stop();
-      return setState(() => _microphoneTrack = null);
-    }
-
-    try {
-      final microphoneTrack = await RtcLocalTrack.audio();
-      return setState(() => _microphoneTrack = microphoneTrack);
-    } catch (e) {
-      _logger.w(() => 'Error creating microphone track: $e');
-    }
-  }
-
   void onJoinCallPressed() {
     var options = const CallConnectOptions();
 

--- a/packages/stream_video_flutter/lib/src/video_effects/video_effects_manager.dart
+++ b/packages/stream_video_flutter/lib/src/video_effects/video_effects_manager.dart
@@ -99,6 +99,8 @@ class StreamVideoEffectsManager {
     List<String> names, {
     RtcLocalTrack? track,
   }) async {
+    _appliedVideoEffects = names;
+
     await _localVideoTrackSubscription?.cancel();
     _localVideoTrackSubscription =
         call.partialState((s) => s.localParticipant?.isVideoEnabled).listen(
@@ -112,8 +114,6 @@ class StreamVideoEffectsManager {
         }
       },
     );
-
-    _appliedVideoEffects = names;
 
     final trackId = track != null ? track.mediaTrack.id : await _getTrackId();
     if (trackId == null) {
@@ -156,6 +156,9 @@ class StreamVideoEffectsManager {
       return;
     }
 
+    _appliedVideoEffects = [];
+    await _localVideoTrackSubscription?.cancel();
+
     final trackId = track != null ? track.mediaTrack.id : await _getTrackId();
     if (trackId == null) {
       return;
@@ -165,9 +168,6 @@ class StreamVideoEffectsManager {
       trackId,
       names: [],
     );
-
-    _appliedVideoEffects = [];
-    await _localVideoTrackSubscription?.cancel();
   }
 
   Future<String?> _getTrackId() async {

--- a/packages/stream_video_flutter/lib/src/video_effects/video_effects_manager.dart
+++ b/packages/stream_video_flutter/lib/src/video_effects/video_effects_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:stream_video/stream_video.dart';
 import 'package:stream_webrtc_flutter/stream_webrtc_flutter.dart' as rtc;
@@ -29,6 +31,7 @@ class StreamVideoEffectsManager {
 
   final _logger = taggedLogger(tag: _tag);
   List<String>? _appliedVideoEffects;
+  StreamSubscription<bool?>? _localVideoTrackSubscription;
 
   /// Checks if the background effect is supported on the current device.
   Future<bool> isSupported() async {
@@ -43,24 +46,30 @@ class StreamVideoEffectsManager {
 
   /// Applies a background blur filter to the local participant video stream.
   /// The [blurIntensity] parameter specifies the intensity of the blur effect.
-  Future<void> applyBackgroundBlurFilter(BlurIntensity blurIntensity) async {
+  Future<void> applyBackgroundBlurFilter(
+    BlurIntensity blurIntensity, {
+    RtcLocalTrack? track,
+  }) async {
     if (!(await isSupported())) {
       return;
     }
 
     await ensureBlurEffectRegistered();
-    await applyVideoEffects([blurIntensity.name]);
+    await applyVideoEffects([blurIntensity.name], track: track);
   }
 
   /// Applies a background image filter to the local participant video stream.
   /// The [imageUrl] parameter specifies the path to the image asset file or an URL to the image.
-  Future<void> applyBackgroundImageFilter(String imageUrl) async {
+  Future<void> applyBackgroundImageFilter(
+    String imageUrl, {
+    RtcLocalTrack? track,
+  }) async {
     if (!(await isSupported())) {
       return;
     }
 
     await ensureImageEffectRegistered(imageUrl);
-    await applyVideoEffects(['VirtualBackground-$imageUrl']);
+    await applyVideoEffects(['VirtualBackground-$imageUrl'], track: track);
   }
 
   /// Applies a custom effect to the local participant video stream.
@@ -86,9 +95,32 @@ class StreamVideoEffectsManager {
   /// Applies a list of video effects to the local participant video stream.
   /// The [names] parameter specifies the list of effect names.
   /// Make sure to register the effect processors before applying the effects.
-  Future<void> applyVideoEffects(List<String> names) async {
-    final trackId = await _getTrackId();
+  Future<void> applyVideoEffects(
+    List<String> names, {
+    RtcLocalTrack? track,
+  }) async {
+    await _localVideoTrackSubscription?.cancel();
+    _localVideoTrackSubscription =
+        call.partialState((s) => s.localParticipant?.isVideoEnabled).listen(
+      (enabled) async {
+        final trackId = await _getTrackId();
+        if (trackId != null) {
+          await rtc.setVideoEffects(
+            trackId,
+            names: names,
+          );
+        }
+      },
+    );
+
+    _appliedVideoEffects = names;
+
+    final trackId = track != null ? track.mediaTrack.id : await _getTrackId();
     if (trackId == null) {
+      _logger.w(
+        () =>
+            'Could not apply video effects, could not find video track for localParticipant. Effects will be applied when the track is available.',
+      );
       return;
     }
 
@@ -96,7 +128,6 @@ class StreamVideoEffectsManager {
       trackId,
       names: names,
     );
-    _appliedVideoEffects = names;
   }
 
   /// Ensures that the blur effect processor is registered.
@@ -118,12 +149,14 @@ class StreamVideoEffectsManager {
   }
 
   /// Disables all video filters applied to the local participant video stream.
-  Future<void> disableAllFilters() async {
+  Future<void> disableAllFilters({
+    RtcLocalTrack? track,
+  }) async {
     if (!(await isSupported())) {
       return;
     }
 
-    final trackId = await _getTrackId();
+    final trackId = track != null ? track.mediaTrack.id : await _getTrackId();
     if (trackId == null) {
       return;
     }
@@ -132,13 +165,15 @@ class StreamVideoEffectsManager {
       trackId,
       names: [],
     );
+
     _appliedVideoEffects = [];
+    await _localVideoTrackSubscription?.cancel();
   }
 
   Future<String?> _getTrackId() async {
     final trackPrefix = call.state.value.localParticipant?.trackIdPrefix;
     if (trackPrefix == null) {
-      _logger.e(
+      _logger.d(
         () =>
             'Could not apply background image filter, trackPrefix is null for localParticipant',
       );
@@ -149,7 +184,7 @@ class StreamVideoEffectsManager {
     final trackId = track?.mediaTrack.id;
 
     if (trackId == null) {
-      _logger.e(
+      _logger.d(
         () =>
             'Could not apply background image filter, could not find video track for localParticipant',
       );
@@ -157,5 +192,10 @@ class StreamVideoEffectsManager {
     }
 
     return trackId;
+  }
+
+  Future<void> dispose() async {
+    await _localVideoTrackSubscription?.cancel();
+    _localVideoTrackSubscription = null;
   }
 }


### PR DESCRIPTION
resolves FLU-209

**Summary**
This PR improves the handling of video filters in various lifecycle states of the video track and local participant.

**Changes:**
- Enables setting video filters before the video track is created by listening for local participant state changes and applying the filters once the video is enabled.
- Fixes an issue where video filters were cleared after toggling the camera.
- Adds support for setting video filters on a specific video track before the local participant is available — useful for scenarios like lobby previews with a temporary video track.


https://github.com/user-attachments/assets/5f442f4a-0aff-4381-b75d-787a8268fcbb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for applying video effects (such as background blur and image filters) to specific video tracks, including during lobby preview before a call starts.
  * Introduced a toggle button in the lobby allowing users to enable or disable background blur before joining a call.
  * Video effects now persist and are automatically reapplied if the video track changes or is toggled.
  * Added ability to inject additional action buttons into the lobby video control bar.

* **Improvements**
  * Enhanced resource management by ensuring video effects managers are properly disposed of when no longer needed.
  * The call screen and lobby now seamlessly pass and manage video effects settings throughout the join and call experience.
  * Improved handling of video effects application by targeting specific video tracks and subscribing to track state changes.

* **Bug Fixes**
  * Fixed an issue where video filters were cleared after toggling the camera.

* **Removals**
  * Removed camera and microphone toggle logic from the lobby view component.

* **Documentation**
  * Updated changelog to reflect new features and bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->