### PR TITLE
fix(ui): Add null check and default config in CircleTransform

### DIFF
--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -9,6 +9,9 @@
 🔄 Dependency updates
 * Updated `flutter_callkit_incoming` dependency to the latests (2.5.5) version. That version contains Android 14 compatibility fixes for ringing notifications and lock screen handling.
 
+🐞 Fixed
+* (Android) CircleTransform Argument type mismatch on Bitmap.Config?
+
 ## 0.10.1
 
 🐞 Fixed

--- a/packages/stream_video_flutter/android/src/main/kotlin/io/getstream/video/flutter/stream_video_flutter/service/notification/image/CircleTransform.kt
+++ b/packages/stream_video_flutter/android/src/main/kotlin/io/getstream/video/flutter/stream_video_flutter/service/notification/image/CircleTransform.kt
@@ -16,7 +16,8 @@ class CircleTransform : Transformation {
         if (squaredBitmap != source) {
             source.recycle()
         }
-        val bitmap = Bitmap.createBitmap(size, size, source.config)
+        val config = source.config ?: Bitmap.Config.ARGB_8888
+        val bitmap = Bitmap.createBitmap(size, size, config)
         val canvas = Canvas(bitmap)
         val paint = Paint()
         val shader = BitmapShader(


### PR DESCRIPTION
### 🎯 Goal

Fixes #1039

### 🛠 Implementation details

Even though config is annotated with `@NonNull`, apparently it can be null (see also the docs). This adds a fallback to default config.

<img width="823" height="226" alt="image" src="https://github.com/user-attachments/assets/520a9cb9-c5f5-40c7-aa37-a431424270d8" />

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling to prevent potential errors when processing images with missing configuration data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->