### PR TITLE
chore: remove speech recognition from dogfooding

### DIFF
--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -46,39 +46,19 @@ class _CallScreenState extends State<CallScreen> {
   late final _userChatRepo = locator.get<UserChatRepository>();
   late final _videoEffectsManager =
       widget.videoEffectsManager ?? StreamVideoEffectsManager(widget.call);
-  late StreamSubscription<SpeakingWhileMutedState> _speechSubscription;
 
   Channel? _channel;
   ParticipantLayoutMode _currentLayoutMode = ParticipantLayoutMode.grid;
   bool _moreMenuVisible = false;
-  late SpeakingWhileMutedRecognition _speakingWhileMutedRecognition;
 
   @override
   void initState() {
     super.initState();
     _connectChatChannel();
-    _speakingWhileMutedRecognition =
-        SpeakingWhileMutedRecognition(call: widget.call);
-    _speechSubscription = _speakingWhileMutedRecognition.stream.listen((state) {
-      final context = this.context;
-      if (state.isSpeakingWhileMuted && context.mounted) {
-        final colorTheme = StreamVideoTheme.of(context).colorTheme;
-
-        ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-          SnackBar(
-            content: const Text('You are speaking while muted'),
-            behavior: SnackBarBehavior.floating,
-            backgroundColor: colorTheme.accentPrimary,
-          ),
-        );
-      }
-    });
   }
 
   @override
   void dispose() {
-    _speechSubscription.cancel();
-    _speakingWhileMutedRecognition.dispose();
     widget.call.leave();
     _userChatRepo.disconnectUser();
     _videoEffectsManager.dispose();


### PR DESCRIPTION
Speech recognition is not yet production-ready ready so we shouldn't use it in our dogfooding app, which is often used by customers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Changes
  - Removed the speaking-while-muted notification on the call screen; you will no longer see a SnackBar alert when talking while muted.
  - Reduced on-screen interruptions during calls for a cleaner experience.
  - Mute functionality remains unchanged; only the notification has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->