### PR TITLE
fix(llc): catch stats reporting exceptions

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+🐞 Fixed
+* Handled SFU stats reporting failures gracefully
+
 ## 0.10.2
 
 ✅ Added


### PR DESCRIPTION
Sometimes sending the stats report to SFU might fail if the Call is in certain states. For example, it might not be possible to collect stats from PeerConnection when it's already disconnected. We shouldn't throw exceptions in that case, but rather handle it gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of SFU call statistics reporting — failures are now caught and handled without disrupting calls.
  * RTC stats collection is now optional, respects settings, and safely rolls back trace data if sending fails.

* **Documentation**
  * Added an Unreleased section to the changelog describing the SFU stats reporting fix and RTC stats option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->