### PR TITLE
fix(llc): callMembers not updating correctly after call session start

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Web] Fixed changing the output audio device during the call.
 - [Android/iOS] Fixed an issue where screen sharing was not stopped correctly when canceled via the system UI on Android or iOS.
 - [iOS] Improved broadcast extension handling — the app now waits for the broadcast picker selection before actually starting screen sharing.
+- Fixed an issue where `callMembers` collection wasn't reflecting the actual members list after starting the call session.
 
 ✅ Added
 - [Web] Added `checkIfAudioOutputChangeSupported()` to the `Call` class to check whether the browser supports changing the audio output device.

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -613,9 +613,15 @@ class Call {
       case StreamCallMissedEvent _:
         return _stateManager.callMetadataChanged(event.metadata);
       case StreamCallSessionEndedEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
+        return _stateManager.callMetadataChanged(
+          event.metadata,
+          updateMembers: false,
+        );
       case StreamCallSessionStartedEvent _:
-        return _stateManager.callMetadataChanged(event.metadata);
+        return _stateManager.callMetadataChanged(
+          event.metadata,
+          updateMembers: false,
+        );
       default:
         break;
     }

--- a/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_coordinator_mixin.dart
@@ -17,10 +17,12 @@ mixin StateCoordinatorMixin on StateNotifier<CallState> {
   void callMetadataChanged(
     CallMetadata callMetadata, {
     Map<String, List<String>>? capabilitiesByRole,
+    bool updateMembers = true,
   }) {
     state = state.copyFromMetadata(
       callMetadata,
       capabilitiesByRole: capabilitiesByRole,
+      updateMembers: updateMembers,
     );
   }
 

--- a/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
+++ b/packages/stream_video/lib/src/call/state/mixins/state_lifecycle_mixin.dart
@@ -111,18 +111,16 @@ mixin StateLifecycleMixin on StateNotifier<CallState> {
   }) {
     _logWithState('lifecycleCallCreated', 'ringing: $ringing');
 
-    state = state
-        .copyFromMetadata(
-          data.metadata,
-        )
-        .copyWith(
-          status: data.toCallStatus(state: state, ringing: ringing),
-          callParticipants: data.metadata.toCallParticipants(state),
-          isRingingFlow: ringing,
-          audioOutputDevice: callConnectOptions.audioOutputDevice,
-          audioInputDevice: callConnectOptions.audioInputDevice,
-          videoInputDevice: callConnectOptions.videoInputDevice,
-        );
+    final newState = state.copyFromMetadata(data.metadata);
+
+    state = newState.copyWith(
+      status: data.toCallStatus(state: newState, ringing: ringing),
+      callParticipants: data.metadata.toCallParticipants(newState),
+      isRingingFlow: ringing,
+      audioOutputDevice: callConnectOptions.audioOutputDevice,
+      audioInputDevice: callConnectOptions.audioInputDevice,
+      videoInputDevice: callConnectOptions.videoInputDevice,
+    );
   }
 
   void lifecycleCallRinging(
@@ -130,16 +128,14 @@ mixin StateLifecycleMixin on StateNotifier<CallState> {
   ) {
     _logWithState('lifecycleCallRinging');
 
-    state = state
-        .copyFromMetadata(
-          data.metadata,
-        )
-        .copyWith(
-          status: data.toCallStatus(state: state),
-          isRingingFlow: data.ringing,
-          ownCapabilities: data.metadata.details.ownCapabilities.toList(),
-          callParticipants: data.metadata.toCallParticipants(state),
-        );
+    final newState = state.copyFromMetadata(data.metadata);
+
+    state = newState.copyWith(
+      status: data.toCallStatus(state: newState),
+      isRingingFlow: data.ringing,
+      ownCapabilities: data.metadata.details.ownCapabilities.toList(),
+      callParticipants: data.metadata.toCallParticipants(newState),
+    );
   }
 
   void lifecycleCallJoining() {
@@ -157,18 +153,16 @@ mixin StateLifecycleMixin on StateNotifier<CallState> {
     final status = state.status.isJoining ? CallStatus.joined() : state.status;
     _logWithState('lifecycleCallJoined', 'newStatus: $status');
 
-    state = state
-        .copyFromMetadata(
-          data.metadata,
-        )
-        .copyWith(
-          status: status,
-          ownCapabilities: data.metadata.details.ownCapabilities.toList(),
-          callParticipants: data.metadata.toCallParticipants(state),
-          audioOutputDevice: callConnectOptions?.audioOutputDevice,
-          audioInputDevice: callConnectOptions?.audioInputDevice,
-          videoInputDevice: callConnectOptions?.videoInputDevice,
-        );
+    final newState = state.copyFromMetadata(data.metadata);
+
+    state = newState.copyWith(
+      status: status,
+      ownCapabilities: data.metadata.details.ownCapabilities.toList(),
+      callParticipants: data.metadata.toCallParticipants(newState),
+      audioOutputDevice: callConnectOptions?.audioOutputDevice,
+      audioInputDevice: callConnectOptions?.audioInputDevice,
+      videoInputDevice: callConnectOptions?.videoInputDevice,
+    );
   }
 
   void lifecycleCallReconnectingFailed() {

--- a/packages/stream_video/lib/src/call_state.dart
+++ b/packages/stream_video/lib/src/call_state.dart
@@ -248,6 +248,7 @@ class CallState extends Equatable {
   CallState copyFromMetadata(
     CallMetadata metadata, {
     Map<String, List<String>>? capabilitiesByRole,
+    bool updateMembers = true,
   }) {
     final capabilities = metadata.details.ownCapabilities.toList();
 
@@ -273,7 +274,7 @@ class CallState extends Equatable {
       liveEndedAt: metadata.session.liveEndedAt,
       timerEndsAt: metadata.session.timerEndsAt,
       capabilitiesByRole: capabilitiesByRole,
-      callMembers: metadata.toCallMembers(),
+      callMembers: updateMembers ? metadata.toCallMembers() : null,
     );
   }
 
@@ -298,6 +299,7 @@ class CallState extends Equatable {
     audioOutputDevice,
     ownCapabilities,
     callParticipants,
+    callMembers,
     capabilitiesByRole,
     createdAt,
     updatedAt,


### PR DESCRIPTION
resolves FLU-308, https://github.com/GetStream/stream-video-flutter/issues/1088

This PR resolves an issue where the `callMembers` collection did not accurately reflect the current list of participants after initiating a call session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed call members list to accurately reflect actual members after starting a call session. The members collection now synchronizes correctly during session lifecycle events, improving data consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->