### PR TITLE
fix(ui): ensure proper cleanup when app terminated

### DIFF
--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### 🐞 Fixed
 * [Android] Fixed WebSocket/WebRTC connections persisting after app is killed from recents. Foreground services now properly terminate and leave calls when the app task is removed.
-* [Android] Fixed Picture-in-Picture flickering between camera and screen share by scoping renderer keys, preventing visibility-detector dropping subscriptions.
 
 ## 1.2.1
 

--- a/packages/stream_video_flutter/lib/src/call_participants/call_participant.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participant.dart
@@ -29,7 +29,6 @@ class StreamCallParticipant extends StatelessWidget {
     super.key,
     required this.call,
     required this.participant,
-    this.rendererScopePrefix,
     this.videoFit,
     this.backgroundColor,
     this.borderRadius,
@@ -122,9 +121,6 @@ class StreamCallParticipant extends StatelessWidget {
   /// Callback that is called when the size of the participant widget changes.
   final ValueSetter<Size>? onSizeChanged;
 
-  /// Optional prefix to scope renderer keys (e.g. PiP vs main view).
-  final String? rendererScopePrefix;
-
   @override
   Widget build(BuildContext context) {
     final theme = StreamCallParticipantTheme.of(context);
@@ -198,10 +194,6 @@ class StreamCallParticipant extends StatelessWidget {
               return Stack(
                 children: [
                   StreamVideoRenderer(
-                    key: ValueKey(
-                      '${rendererScopePrefix != null ? '$rendererScopePrefix-' : ''}${participant.uniqueParticipantKey}-video',
-                    ),
-                    rendererScopePrefix: rendererScopePrefix,
                     call: call,
                     participant: participant,
                     videoTrackType: SfuTrackType.video,

--- a/packages/stream_video_flutter/lib/src/call_participants/livestream_hosts.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/livestream_hosts.dart
@@ -57,10 +57,8 @@ class StreamLivestreamHosts extends StatefulWidget {
     CallParticipantState host,
   ) {
     return StreamCallParticipant(
-      key: ValueKey(
-        '${host.uniqueParticipantKey} - livehost',
-      ),
-      rendererScopePrefix: 'livehost',
+      // We use the sessionId as the key to map the state to the participant.
+      key: Key(host.uniqueParticipantKey),
       call: call,
       participant: host,
     );
@@ -99,7 +97,7 @@ class _StreamLivestreamHostsState extends State<StreamLivestreamHosts>
   Widget _buildScreenShareContent(CallParticipantState host) {
     return widget.screenShareContentBuilder?.call(context, widget.call, host) ??
         ScreenShareContent(
-          key: ValueKey('${host.uniqueParticipantKey} - livehost'),
+          key: ValueKey('${host.uniqueParticipantKey} - screenShareContent'),
           call: widget.call,
           participant: host,
         );

--- a/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
@@ -38,10 +38,7 @@ class ScreenShareCallParticipantsContent extends StatelessWidget {
     CallParticipantState participant,
   ) {
     return StreamCallParticipant(
-      key: ValueKey(
-        '${participant.uniqueParticipantKey} - screenshare',
-      ),
-      rendererScopePrefix: 'screenshare',
+      key: ValueKey(participant.uniqueParticipantKey),
       call: call,
       participant: participant,
     );
@@ -121,7 +118,6 @@ class ScreenShareContent extends StatefulWidget {
     super.key,
     required this.call,
     required this.participant,
-    this.rendererScopePrefix,
     this.backgroundColor = const Color(0xFF272A30),
     this.borderRadius = const BorderRadius.all(Radius.circular(8)),
   });
@@ -131,9 +127,6 @@ class ScreenShareContent extends StatefulWidget {
 
   /// The participant that shares their screen.
   final CallParticipantState participant;
-
-  /// Optional prefix to scope renderer keys (e.g. PiP vs main view).
-  final String? rendererScopePrefix;
 
   /// The background color for the video.
   final Color backgroundColor;
@@ -178,10 +171,6 @@ class _ScreenShareContentState extends State<ScreenShareContent> {
                 }
               },
               child: StreamVideoRenderer(
-                key: ValueKey(
-                  '${widget.rendererScopePrefix ?? ''}${widget.participant.uniqueParticipantKey}-screen-share',
-                ),
-                rendererScopePrefix: widget.rendererScopePrefix,
                 call: widget.call,
                 participant: widget.participant,
                 videoFit: VideoFit.contain,

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/android_pip_overlay.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/android_pip_overlay.dart
@@ -96,18 +96,15 @@ class _AndroidPipOverlayState extends State<AndroidPipOverlay>
       if (shouldShowScreenShare) {
         pipBody = ScreenShareContent(
           key: ValueKey(
-            '${pipParticipant.uniqueParticipantKey} - pip',
+            '${pipParticipant.uniqueParticipantKey} - screenShareContent',
           ),
-          rendererScopePrefix: 'pip',
           call: widget.call,
           participant: pipParticipant,
         );
       } else {
         pipBody = StreamCallParticipant(
-          key: ValueKey(
-            '${pipParticipant.uniqueParticipantKey} - pip',
-          ),
-          rendererScopePrefix: 'pip',
+          // We use the sessionId as the key to map the state to the participant.
+          key: Key(pipParticipant.uniqueParticipantKey),
           call: widget.call,
           participant: pipParticipant,
         );

--- a/packages/stream_video_flutter/lib/src/livestream/livestream_content.dart
+++ b/packages/stream_video_flutter/lib/src/livestream/livestream_content.dart
@@ -205,15 +205,12 @@ class _LivestreamContentState extends State<LivestreamContent> {
 
   CallParticipantBuilder get _defaultParticipantBuilder =>
       (context, call, participant) => StreamCallParticipant(
-        key: ValueKey(
-          '${participant.uniqueParticipantKey} - livecontent',
-        ),
-        rendererScopePrefix: 'livecontent',
         call: call,
         participant: participant,
         backgroundColor: StreamVideoTheme.of(
           context,
         ).colorTheme.livestreamBackground,
+        key: ValueKey(participant.uniqueParticipantKey),
         showConnectionQualityIndicator: false,
         showParticipantLabel: false,
         showSpeakerBorder: false,
@@ -235,9 +232,6 @@ class _LivestreamContentState extends State<LivestreamContent> {
         callParticipantBuilder: _defaultParticipantBuilder,
         screenShareContentBuilder: (context, call, participant) =>
             ScreenShareContent(
-              key: ValueKey(
-                '${participant.uniqueParticipantKey} - livecontent',
-              ),
               call: call,
               participant: participant,
               backgroundColor: StreamVideoTheme.of(

--- a/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
+++ b/packages/stream_video_flutter/lib/src/renderer/video_renderer.dart
@@ -19,7 +19,6 @@ class StreamVideoRenderer extends StatefulWidget {
     this.videoFit = VideoFit.cover,
     this.onSizeChanged,
     this.persistTrackIfNotVisible = false,
-    this.rendererScopePrefix,
   });
 
   /// Represents a call.
@@ -44,9 +43,6 @@ class StreamVideoRenderer extends StatefulWidget {
   /// This is useful for screen sharing, where the track should be persisted even when not visible.
   /// Defaults to false.
   final bool persistTrackIfNotVisible;
-
-  /// Optional prefix to scope renderer keys (e.g. PiP vs main view).
-  final String? rendererScopePrefix;
 
   @override
   State<StreamVideoRenderer> createState() => _StreamVideoRendererState();
@@ -109,7 +105,7 @@ class _StreamVideoRendererState extends State<StreamVideoRenderer> {
 
     return VisibilityDetector(
       key: Key(
-        '${widget.rendererScopePrefix ?? ''}${widget.participant.uniqueParticipantKey}${widget.videoTrackType}-visibility',
+        '${widget.participant.uniqueParticipantKey}${widget.videoTrackType}',
       ),
       onVisibilityChanged: (info) =>
           _onVisibilityChanged(info, widget.participant.userId),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket and WebRTC connections no longer persist after the app is killed from recents
  * Improved cleanup of foreground services when the app task is removed
  * Enhanced resource cleanup during service termination to ensure graceful shutdown

* **Improvements**
  * Picture-in-Picture error handling has been improved with better logging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->