### PR TITLE
fix(llc): pause audio playout when leaving call to release iOS audio session

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Fixed network availability verification during subsequent fast reconnect attempts.
   * Added `reconnectReason` to reconnect details for sfu logs.
   * Fixed race condition where automatic ICE restart could interfere with fast reconnect, causing subscriber video to not recover.
+* Fixed iOS audio session not being released when leaving a call, which prevented other audio packages from using the microphone.
 
 ## 1.2.2
 * Sync version with `stream_video_flutter` 1.2.2

--- a/packages/stream_video/lib/src/webrtc/rtc_manager.dart
+++ b/packages/stream_video/lib/src/webrtc/rtc_manager.dart
@@ -480,6 +480,14 @@ class RtcManager extends Disposable {
     onLocalTrackPublished = null;
     onRemoteTrackReceived = null;
 
+    if (CurrentPlatform.isIos) {
+      try {
+        await RtcMediaDeviceNotifier.instance.pauseAudioPlayout();
+      } catch (e) {
+        _logger.w(() => '[dispose] pauseAudioPlayout failed: $e');
+      }
+    }
+
     await Future.wait([
       if (publisher != null)
         publisher!.dispose().catchError((Object e, StackTrace stk) {


### PR DESCRIPTION
### 🎯 Goal

Fixes #1151 - iOS: Microphone becomes unusable for other audio packages after leaving a call with 2 participants.

When another participant speaks during a call, WebRTC's Audio Device Module (ADM) starts audio playout. When the call ends, the ADM's playout Audio Unit continues to hold a reference to AVAudioSession, blocking other audio packages (like `record`, `flutter_sound`) from accessing the microphone. This results in silent recordings (0.00 amplitude) with no microphone indicator appearing.

### 🛠 Implementation details

Added `pauseAudioPlayout()` call in the `_clear()` method to stop the ADM's audio playout before disposing other resources.

On iOS, `AVAudioSession` is a shared resource that manages both input (microphone) and output (speaker). When remote audio is played, the ADM creates an Audio Unit that holds an active reference to the audio session. Without explicitly stopping this playout via `pauseAudioPlayout()` (which calls `[adm stopPlayout]` on the native side), the Audio Unit continues to "own" the audio session even after the call ends.

The fix ensures the audio output is properly stopped, releasing the audio session so other packages can take over.

### 🎨 UI Changes

_No UI changes - this is an internal audio session management fix._

### 🧪 Testing

**Steps to reproduce the issue (before fix):**
1. Create an app that uses both `stream_video_flutter` and another audio recording package (e.g., `record`)
2. Record audio - verify it works (non-zero amplitude)
3. Join a Stream video call with another participant
4. Have the other participant speak (their audio plays on your device)
5. Leave the call
6. Attempt to record audio again
7. **Before fix:** Recording shows 0.00 amplitude, no microphone indicator

**Steps to verify the fix:**
1. Same setup as above
2. After the fix, recording should work normally after leaving the call (non-zero amplitude, microphone indicator visible)

<details>

<summary>Test patch for verification</summary>

```dart
// In your app, after leaving a Stream call:
import 'package:stream_webrtc_flutter/stream_webrtc_flutter.dart' as rtc;

// Before calling call.leave(), add:
await rtc.Helper.pauseAudioPlayout();

// Then proceed with normal leave flow
await call.leave();


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iOS audio session is now released when leaving a call, allowing other audio apps to access the microphone.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->