### PR TITLE
fix(ui): modify closed captions and recording options to use partial call state builder

### DIFF
--- a/packages/stream_video_flutter/lib/src/call_controls/controls/toggle_closed_captions_option.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/controls/toggle_closed_captions_option.dart
@@ -40,25 +40,27 @@ class ToggleClosedCaptionsOption extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final enabled = call.state.value.isCaptioning;
-
-    return CallControlOption(
-      icon: enabled
-          ? Icon(enabledClosedCaptionIcon)
-          : Icon(disabledClosedCaptionIcon),
-      iconColor: enabled
-          ? enabledClosedCaptionIconColor
-          : disabledClosedCaptionIconColor,
-      backgroundColor: enabled
-          ? enabledClosedCaptionBackgroundColor
-          : disabledClosedCaptionBackgroundColor,
-      onPressed: () {
-        if (!enabled) {
-          call.startClosedCaptions();
-        } else {
-          call.stopClosedCaptions();
-        }
-      },
+    return PartialCallStateBuilder<bool>(
+      call: call,
+      selector: (state) => state.isCaptioning,
+      builder: (_, enabled) => CallControlOption(
+        icon: enabled
+            ? Icon(enabledClosedCaptionIcon)
+            : Icon(disabledClosedCaptionIcon),
+        iconColor: enabled
+            ? enabledClosedCaptionIconColor
+            : disabledClosedCaptionIconColor,
+        backgroundColor: enabled
+            ? enabledClosedCaptionBackgroundColor
+            : disabledClosedCaptionBackgroundColor,
+        onPressed: () {
+          if (!enabled) {
+            call.startClosedCaptions();
+          } else {
+            call.stopClosedCaptions();
+          }
+        },
+      ),
     );
   }
 }

--- a/packages/stream_video_flutter/lib/src/call_controls/controls/toggle_recording_option.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/controls/toggle_recording_option.dart
@@ -40,23 +40,25 @@ class ToggleRecordingOption extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final enabled = call.state.value.isRecording;
-
-    return CallControlOption(
-      icon: enabled ? Icon(enabledRecordingIcon) : Icon(disabledRecordingIcon),
-      iconColor: enabled
-          ? enabledRecordingIconColor
-          : disabledRecordingIconColor,
-      backgroundColor: enabled
-          ? enabledRecordingBackgroundColor
-          : disabledRecordingBackgroundColor,
-      onPressed: () {
-        if (!enabled) {
-          call.startRecording();
-        } else {
-          call.stopRecording();
-        }
-      },
+    return PartialCallStateBuilder<bool>(
+      call: call,
+      selector: (state) => state.isRecording,
+      builder: (_, enabled) => CallControlOption(
+        icon: enabled ? Icon(enabledRecordingIcon) : Icon(disabledRecordingIcon),
+        iconColor: enabled
+            ? enabledRecordingIconColor
+            : disabledRecordingIconColor,
+        backgroundColor: enabled
+            ? enabledRecordingBackgroundColor
+            : disabledRecordingBackgroundColor,
+        onPressed: () {
+          if (!enabled) {
+            call.startRecording();
+          } else {
+            call.stopRecording();
+          }
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
### 🎯 Goal

Options like the ToggleCameraOption use the partial call state builder. This helps them be reactive to the state of the call. 
The recording option and closed captions option check the state at build. This has the potential to show stale information after some time. The goal of this change is to have both use the partial call state builder to be consistent with the other options and ensure they are reactive

### 🛠 Implementation details

Uses the callstatebuilder to check for recording and closed captions

### 🎨 UI Changes

No UI change.



### 🧪 Testing

Generally use the streamcallcontainer on a call, and have its call controls include a recording/closed captions option.
Change any of those states from a different device and see them also react to the change

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management efficiency for closed captions and recording toggle controls to ensure responsive updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->