### PR TITLE
fix(ui): ios pip dismiss when call end fix

### DIFF
--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcoming
+
+### 🐞 Fixed
+* Fixed iOS Picture-in-Picture window not dismissing when the call ends during PiP mode.
+
 ## 1.3.1
 
 ### 🐞 Fixed

--- a/packages/stream_video_flutter/ios/stream_video_flutter/Sources/stream_video_flutter/PictureInPicture/StreamPictureInPictureController.swift
+++ b/packages/stream_video_flutter/ios/stream_video_flutter/Sources/stream_video_flutter/PictureInPicture/StreamPictureInPictureController.swift
@@ -89,6 +89,11 @@ final class StreamPictureInPictureController: NSObject, AVPictureInPictureContro
             name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
+    deinit {
+        pictureInPictureController?.stopPictureInPicture()
+        NotificationCenter.default.removeObserver(self)
+    }
+
     // MARK: - AVPictureInPictureControllerDelegate
 
     func pictureInPictureController(

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
@@ -307,6 +307,9 @@ class _StreamPictureInPictureUiKitViewState
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _subscriptions.cancelAll();
+    try {
+      _channel.invokeMethod('callEnded');
+    } catch (_) {}
     super.dispose();
   }
 

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/picture_in_picture/stream_picture_in_picture_ui_kit_view.dart
@@ -307,9 +307,11 @@ class _StreamPictureInPictureUiKitViewState
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _subscriptions.cancelAll();
-    try {
-      _channel.invokeMethod('callEnded');
-    } catch (_) {}
+    unawaited(
+      _channel.invokeMethod('callEnded').catchError((_) {
+        // Best-effort cleanup; intentionally ignored.
+      }),
+    );
     super.dispose();
   }
 


### PR DESCRIPTION
fixes #1197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iOS Picture-in-Picture now reliably dismisses when a call ends while in PiP mode.
  * Improved teardown to notify the native layer that the call has ended, preventing lingering PiP state.
  * Added lifecycle cleanup to stop any active PiP sessions and remove observers to avoid resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->