### PR TITLE
fix(llc):  Fixed coordinator API token refresh

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Upcoming
 
+### Fixed
+* Fixed coordinator REST API calls failing permanently when the JWT token expires.
+
 ### 🔄 Changed
 * Regenerated OpenAPI models to match the latest backend schema.
 * Fixed broadcasting status updates not being wired through to call state.

--- a/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
+++ b/packages/stream_video/lib/src/coordinator/retry/coordinator_client_retry.dart
@@ -18,6 +18,7 @@ import '../../models/user_info.dart';
 import '../../retry/retry_manager.dart';
 import '../../retry/retry_policy.dart';
 import '../../shared_emitter.dart';
+import '../../token/token_manager.dart';
 import '../../utils/none.dart';
 import '../../utils/result.dart';
 import '../coordinator_client.dart';
@@ -28,8 +29,12 @@ class CoordinatorClientRetry extends CoordinatorClient {
   CoordinatorClientRetry({
     required CoordinatorClient delegate,
     required RetryPolicy retryPolicy,
+    TokenManager? tokenManager,
   }) : _delegate = delegate,
-       _retryManager = RpcRetryManager(retryPolicy);
+       _retryManager = RpcRetryManager(
+         retryPolicy,
+         tokenManager: tokenManager,
+       );
 
   final CoordinatorClient _delegate;
   final RpcRetryManager _retryManager;

--- a/packages/stream_video/lib/src/retry/retry_manager.dart
+++ b/packages/stream_video/lib/src/retry/retry_manager.dart
@@ -84,6 +84,7 @@ class RpcRetryManager {
 
     final statusCode = cause.code;
     if (statusCode >= 400 && statusCode < 500) {
+      // 401 Unauthorized, 408 Request Timeout, 429 Too Many Requests
       return statusCode == 401 || statusCode == 408 || statusCode == 429;
     }
 

--- a/packages/stream_video/lib/src/retry/retry_manager.dart
+++ b/packages/stream_video/lib/src/retry/retry_manager.dart
@@ -71,8 +71,9 @@ class RpcRetryManager {
   }
 
   /// Returns false for permanent client errors (4xx except 401/408/429)
-  /// that should not be retried. 401 is retryable because the auth-retry
-  /// logic above handles it with a token refresh.
+  /// that should not be retried.
+  /// 401 (Unauthorized) is retryable because the auth-retry logic above handles it with a token refresh.
+  /// 408 (Request Timeout) and 429 (Too Many Requests) are retryable because they are temporary errors.
   bool _isRetryable(Result<dynamic> result) {
     if (result is! Failure) return true;
 
@@ -84,7 +85,6 @@ class RpcRetryManager {
 
     final statusCode = cause.code;
     if (statusCode >= 400 && statusCode < 500) {
-      // 401 Unauthorized, 408 Request Timeout, 429 Too Many Requests
       return statusCode == 401 || statusCode == 408 || statusCode == 429;
     }
 

--- a/packages/stream_video/lib/src/retry/retry_manager.dart
+++ b/packages/stream_video/lib/src/retry/retry_manager.dart
@@ -70,7 +70,7 @@ class RpcRetryManager {
     return cause.code == 401;
   }
 
-  /// Returns false for permanent client errors (4xx except 401 and 429)
+  /// Returns false for permanent client errors (4xx except 401/408/429)
   /// that should not be retried. 401 is retryable because the auth-retry
   /// logic above handles it with a token refresh.
   bool _isRetryable(Result<dynamic> result) {
@@ -84,7 +84,7 @@ class RpcRetryManager {
 
     final statusCode = cause.code;
     if (statusCode >= 400 && statusCode < 500) {
-      return statusCode == 401 || statusCode == 429;
+      return statusCode == 401 || statusCode == 408 || statusCode == 429;
     }
 
     return true;

--- a/packages/stream_video/lib/src/retry/retry_manager.dart
+++ b/packages/stream_video/lib/src/retry/retry_manager.dart
@@ -41,10 +41,10 @@ class RpcRetryManager {
       // On 401, refresh the token once and retry immediately.
       if (result.isFailure && !authRefreshed && _isAuthError(result)) {
         if (tokenManager != null) {
+          authRefreshed = true;
           final refreshResult = await tokenManager!.refreshToken();
           if (refreshResult.isSuccess) {
             // Prevent infinite loop of retries if the token refresh provides invalid token.
-            authRefreshed = true;
             continue;
           }
         }

--- a/packages/stream_video/lib/src/retry/retry_manager.dart
+++ b/packages/stream_video/lib/src/retry/retry_manager.dart
@@ -1,5 +1,6 @@
 import '../../open_api/video/coordinator/api.dart';
 import '../errors/video_error.dart';
+import '../token/token_manager.dart';
 import '../utils/result.dart';
 import 'retry_policy.dart';
 
@@ -11,9 +12,13 @@ typedef OnFailure<T> =
     );
 
 class RpcRetryManager {
-  const RpcRetryManager(this.policy);
+  const RpcRetryManager(
+    this.policy, {
+    this.tokenManager,
+  });
 
   final RetryPolicy policy;
+  final TokenManager? tokenManager;
 
   Future<Result<T>> execute<T>(
     Delegate<T> delegate, [
@@ -21,6 +26,8 @@ class RpcRetryManager {
   ]) async {
     late Result<T> result;
     var retryAttempt = 0;
+    var authRefreshed = false;
+
     do {
       final delay = policy.backoff(retryAttempt);
       if (retryAttempt > 0 && result is Failure) {
@@ -30,6 +37,19 @@ class RpcRetryManager {
         delay,
         delegate,
       );
+
+      // On 401, refresh the token once and retry immediately.
+      if (result.isFailure && !authRefreshed && _isAuthError(result)) {
+        if (tokenManager != null) {
+          final refreshResult = await tokenManager!.refreshToken();
+          if (refreshResult.isSuccess) {
+            // Prevent infinite loop of retries if the token refresh provides invalid token.
+            authRefreshed = true;
+            continue;
+          }
+        }
+      }
+
       retryAttempt++;
     } while (result.isFailure &&
         retryAttempt < policy.config.rpcMaxRetries &&
@@ -38,8 +58,21 @@ class RpcRetryManager {
     return result;
   }
 
-  /// Returns false for permanent client errors (4xx except 408/429)
-  /// that should not be retried.
+  bool _isAuthError(Result<dynamic> result) {
+    if (result is! Failure) return false;
+
+    final error = result.error;
+    if (error is! VideoErrorWithCause) return false;
+
+    final cause = error.cause;
+    if (cause is! ApiException) return false;
+
+    return cause.code == 401;
+  }
+
+  /// Returns false for permanent client errors (4xx except 401 and 429)
+  /// that should not be retried. 401 is retryable because the auth-retry
+  /// logic above handles it with a token refresh.
   bool _isRetryable(Result<dynamic> result) {
     if (result is! Failure) return true;
 
@@ -51,8 +84,7 @@ class RpcRetryManager {
 
     final statusCode = cause.code;
     if (statusCode >= 400 && statusCode < 500) {
-      // 408 Request Timeout and 429 Too Many Requests are retryable
-      return statusCode == 408 || statusCode == 429;
+      return statusCode == 401 || statusCode == 429;
     }
 
     return true;

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -1268,6 +1268,7 @@ CoordinatorClient buildCoordinatorClient({
   streamLog.i(_tag, () => '[buildCoordinatorClient] apiKey: $apiKey');
   return CoordinatorClientRetry(
     retryPolicy: retryPolicy,
+    tokenManager: tokenManager,
     delegate: CoordinatorClientOpenApi(
       apiKey: apiKey,
       tokenManager: tokenManager,

--- a/packages/stream_video/test/src/retry/rpc_retry_manager_test.dart
+++ b/packages/stream_video/test/src/retry/rpc_retry_manager_test.dart
@@ -54,7 +54,7 @@ void main() {
       final result = await manager.execute(() async {
         callCount++;
         if (callCount == 1) {
-          return _httpError(401, 'Unauthorized');
+          return _httpError<String>(401, 'Unauthorized');
         }
         return const Result.success('ok');
       });
@@ -65,8 +65,6 @@ void main() {
     });
 
     test('retries only once on repeated 401', () async {
-      var callCount = 0;
-
       when(() => tokenManager.refreshToken()).thenAnswer(
         (_) async => Result.success(_token),
       );
@@ -77,8 +75,7 @@ void main() {
       );
 
       final result = await manager.execute(() async {
-        callCount++;
-        return _httpError(401, 'Unauthorized');
+        return _httpError<String>(401, 'Unauthorized');
       });
 
       expect(result.isFailure, isTrue);
@@ -97,7 +94,7 @@ void main() {
 
       final result = await manager.execute(() async {
         callCount++;
-        return _httpError(403, 'Forbidden');
+        return _httpError<String>(403, 'Forbidden');
       });
 
       expect(result.isFailure, isTrue);
@@ -108,11 +105,11 @@ void main() {
     test('does not attempt refresh without tokenManager', () async {
       var callCount = 0;
 
-      final manager = RpcRetryManager(_noDelayPolicy);
+      const manager = RpcRetryManager(_noDelayPolicy);
 
       final result = await manager.execute(() async {
         callCount++;
-        return _httpError(401, 'Unauthorized');
+        return _httpError<String>(401, 'Unauthorized');
       });
 
       expect(result.isFailure, isTrue);
@@ -128,7 +125,7 @@ void main() {
         (_) async => Result.success(_token),
       );
 
-      final policy = const RetryPolicy(
+      const policy = RetryPolicy(
         config: RetryConfig(rpcMaxRetries: 2),
         backoff: _zeroBackoff,
       );
@@ -143,8 +140,8 @@ void main() {
       // 3rd → success (retry slot 2)
       final result = await manager.execute(() async {
         callCount++;
-        if (callCount == 1) return _httpError(401);
-        if (callCount == 2) return _httpError(500);
+        if (callCount == 1) return _httpError<String>(401);
+        if (callCount == 2) return _httpError<String>(500);
         return const Result.success('ok');
       });
 
@@ -163,7 +160,10 @@ void main() {
 
       final result = await manager.execute(() async {
         callCount++;
-        if (callCount < 3) return _httpError(503, 'Service Unavailable');
+        if (callCount < 3) {
+          return _httpError<String>(503, 'Service Unavailable');
+        }
+
         return const Result.success('ok');
       });
 

--- a/packages/stream_video/test/src/retry/rpc_retry_manager_test.dart
+++ b/packages/stream_video/test/src/retry/rpc_retry_manager_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_video/open_api/video/coordinator/api.dart';
+import 'package:stream_video/src/errors/video_error.dart';
+import 'package:stream_video/src/retry/retry_manager.dart';
+import 'package:stream_video/src/retry/retry_policy.dart';
+import 'package:stream_video/src/token/token.dart';
+import 'package:stream_video/src/token/token_manager.dart';
+import 'package:stream_video/src/utils/result.dart';
+
+class MockTokenManager extends Mock implements TokenManager {}
+
+/// A [RetryPolicy] with no backoff delay for fast tests.
+const _noDelayPolicy = RetryPolicy(
+  config: RetryConfig(rpcMaxRetries: 3),
+  backoff: _zeroBackoff,
+);
+
+Duration _zeroBackoff(RetryConfig config, int retryAttempt) => Duration.zero;
+
+/// Helper to create a [Result.failure] wrapping an [ApiException] with the
+/// given [statusCode].
+Result<T> _httpError<T>(int statusCode, [String message = '']) {
+  return Result.failure(
+    VideoErrorWithCause(
+      message: message,
+      cause: ApiException(statusCode, message),
+    ),
+  );
+}
+
+final _token = UserToken.anonymous();
+
+void main() {
+  group('RpcRetryManager auth retry', () {
+    late MockTokenManager tokenManager;
+
+    setUp(() {
+      tokenManager = MockTokenManager();
+    });
+
+    test('refreshes token and retries on 401', () async {
+      var callCount = 0;
+
+      when(() => tokenManager.refreshToken()).thenAnswer(
+        (_) async => Result.success(_token),
+      );
+
+      final manager = RpcRetryManager(
+        _noDelayPolicy,
+        tokenManager: tokenManager,
+      );
+
+      final result = await manager.execute(() async {
+        callCount++;
+        if (callCount == 1) {
+          return _httpError(401, 'Unauthorized');
+        }
+        return const Result.success('ok');
+      });
+
+      expect(result.isSuccess, isTrue);
+      expect(callCount, 2);
+      verify(() => tokenManager.refreshToken()).called(1);
+    });
+
+    test('retries only once on repeated 401', () async {
+      var callCount = 0;
+
+      when(() => tokenManager.refreshToken()).thenAnswer(
+        (_) async => Result.success(_token),
+      );
+
+      final manager = RpcRetryManager(
+        _noDelayPolicy,
+        tokenManager: tokenManager,
+      );
+
+      final result = await manager.execute(() async {
+        callCount++;
+        return _httpError(401, 'Unauthorized');
+      });
+
+      expect(result.isFailure, isTrue);
+      // 1st call → 401 → refresh → 2nd call → 401 → no more auth retries
+      // then normal retries continue up to rpcMaxRetries
+      verify(() => tokenManager.refreshToken()).called(1);
+    });
+
+    test('does not refresh token on non-401 4xx errors', () async {
+      var callCount = 0;
+
+      final manager = RpcRetryManager(
+        _noDelayPolicy,
+        tokenManager: tokenManager,
+      );
+
+      final result = await manager.execute(() async {
+        callCount++;
+        return _httpError(403, 'Forbidden');
+      });
+
+      expect(result.isFailure, isTrue);
+      expect(callCount, 1); // 403 is not retryable, fails immediately
+      verifyNever(() => tokenManager.refreshToken());
+    });
+
+    test('does not attempt refresh without tokenManager', () async {
+      var callCount = 0;
+
+      final manager = RpcRetryManager(_noDelayPolicy);
+
+      final result = await manager.execute(() async {
+        callCount++;
+        return _httpError(401, 'Unauthorized');
+      });
+
+      expect(result.isFailure, isTrue);
+      // 401 is retryable but no tokenManager to refresh — retries with same
+      // stale token up to rpcMaxRetries
+      expect(callCount, 3);
+    });
+
+    test('auth retry does not consume a regular retry slot', () async {
+      var callCount = 0;
+
+      when(() => tokenManager.refreshToken()).thenAnswer(
+        (_) async => Result.success(_token),
+      );
+
+      final policy = const RetryPolicy(
+        config: RetryConfig(rpcMaxRetries: 2),
+        backoff: _zeroBackoff,
+      );
+
+      final manager = RpcRetryManager(
+        policy,
+        tokenManager: tokenManager,
+      );
+
+      // 1st → 401 (auth retry, doesn't count)
+      // 2nd → 500 (retry slot 1)
+      // 3rd → success (retry slot 2)
+      final result = await manager.execute(() async {
+        callCount++;
+        if (callCount == 1) return _httpError(401);
+        if (callCount == 2) return _httpError(500);
+        return const Result.success('ok');
+      });
+
+      expect(result.isSuccess, isTrue);
+      expect(callCount, 3);
+      verify(() => tokenManager.refreshToken()).called(1);
+    });
+
+    test('retries 5xx errors normally without token refresh', () async {
+      var callCount = 0;
+
+      final manager = RpcRetryManager(
+        _noDelayPolicy,
+        tokenManager: tokenManager,
+      );
+
+      final result = await manager.execute(() async {
+        callCount++;
+        if (callCount < 3) return _httpError(503, 'Service Unavailable');
+        return const Result.success('ok');
+      });
+
+      expect(result.isSuccess, isTrue);
+      expect(callCount, 3);
+      verifyNever(() => tokenManager.refreshToken());
+    });
+  });
+}


### PR DESCRIPTION
When the coordinator JWT expired, REST API calls failed permanently. This issue rarely surfaced in practice because the coordinator WebSocket independently handles token expiry. However, the issue could affect users when the app resumes after a long background period (OS killed the WS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Coordinator REST API calls no longer fail permanently when JWT token expires. The system now automatically detects expired authentication and refreshes the token before retrying the request.

## Tests
* Added comprehensive test coverage for authentication retry behavior and token refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->