### PR TITLE
fix(ui): fix diagnostic content dispose

### DIFF
--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### 🐞 Fixed
+* Fixed `CallDiagnosticsContent` throwing `failed to call super.dispose` when the widget was disposed while awaiting stats subscription cancellation.
+
 ## 1.3.1
 
 ### 🐞 Fixed

--- a/packages/stream_video_flutter/lib/src/call_screen/call_diagnostics_content/call_diagnostics_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_diagnostics_content/call_diagnostics_content.dart
@@ -53,8 +53,9 @@ class _CallDiagnosticsContentState extends State<CallDiagnosticsContent> {
   }
 
   @override
-  Future<void> dispose() async {
-    await _subscription?.cancel();
+  void dispose() {
+    _subscription?.cancel();
+    _subscription = null;
     super.dispose();
   }
 


### PR DESCRIPTION
fixes #1194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the call diagnostics widget could throw a "failed to call super.dispose" error when the widget was disposed while background cleanup operations were still in progress. The widget now properly handles the disposal lifecycle without throwing errors in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->