### PR TITLE
fix(llc): Fix TranscriptionSettingsResponse.fromJson null handling

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Upcoming
 
+### 🐞 Fixed
+* Fixed `TranscriptionSettingsResponse.fromJson` crashing with a null check error when the backend returns an empty string for the `language` field.
+
 ### ✅ Added
 * Support server-side pinning on participant join. When the SFU sends `isPinned: true` on a `ParticipantJoined` event, the participant is now automatically pinned.
 * Added `hintHighScaleLivestreamPublisher` parameter to `Call.join()` to allow marking the participant as publishing to a large audience.

--- a/packages/stream_video/lib/open_api/video/coordinator/model/transcription_settings_response.dart
+++ b/packages/stream_video/lib/open_api/video/coordinator/model/transcription_settings_response.dart
@@ -113,8 +113,10 @@ class TranscriptionSettingsResponse {
         closedCaptionMode:
             TranscriptionSettingsResponseClosedCaptionModeEnum.fromJson(
                 json[r'closed_caption_mode'])!,
+        //MANUAL_EDIT: default value added since sometimes language came as an empty string
         language: TranscriptionSettingsResponseLanguageEnum.fromJson(
-            json[r'language'])!,
+                json[r'language']) ??
+            TranscriptionSettingsResponseLanguageEnum.auto,
         mode: TranscriptionSettingsResponseModeEnum.fromJson(json[r'mode'])!,
         speechSegmentConfig:
             SpeechSegmentConfig.fromJson(json[r'speech_segment_config']),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when transcription settings received an empty or null language value from the backend. The app now gracefully handles this scenario with a sensible default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->