### PR TITLE
fix(llc): safety nets and recovery during reconnect

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -9,6 +9,7 @@ Each call now owns an isolated native PeerConnectionFactory — fixes cross-call
 
 ### 🐞 Fixed
 
+- Added safety nets and recovery for cases when the publisher connection doesn't establish after a reconnection (e.g. the SFU answer is lost or ICE stays in `new` state).
 - Fixed sibling-call audio capture being silently broken when another concurrently-active call ended (e.g. a 1:1 ringing call ending alongside a running livestream, or a previous ringing call ending before a new one was accepted).
 - Fixed a sibling call's audio breaking when a ringing 1:1 call ended via `dropIfAloneInRingingFlow` (the remote party hung up first). `Call.end()` and `Call.leave()` now share a single `_disconnect` cleanup path.
 - Made the audio processor teardown in `Call._clear` multi-call aware. The audio processor is owned by `StreamVideo`, not by an individual `Call`, so disabling it on one call's teardown silently dropped noise cancellation on any other still-active call. `_clear` now only stops the global processor when no other active call is configured to use `NoiceCancellationSettingsMode.autoOn`.

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -1351,6 +1351,8 @@ class Call {
           _fastReconnectDeadline;
     }
 
+    _session?.startPublisherConnectionCheck();
+
     // make sure we only track connection timing if we are not calling this method as part of a migration flow
     connectionTimeStopwatch.stop();
     if (!performingMigration) {

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -42,6 +42,7 @@ const _tag = 'SV:CallSession';
 
 const _debounceDuration = Duration(milliseconds: 200);
 const _migrationCompleteEventTimeout = Duration(seconds: 7);
+const _publisherConnectionCheckDelay = Duration(seconds: 15);
 
 class CallSession extends Disposable {
   CallSession({
@@ -128,7 +129,8 @@ class CallSession extends Disposable {
   /// to record the track in its tracking map.
   final void Function(String trackId) onSuspendedAudioTrackRecorded;
 
-  Timer? _peerConnectionCheckTimer;
+  Timer? _publisherConnectionCheckTimer;
+
   bool _isLeavingOrClosed = false;
 
   SharedEmitter<SfuEvent> get events => sfuWS.events;
@@ -442,7 +444,13 @@ class CallSession extends Disposable {
       result;
 
       _logger.d(() => '[fastReconnect] sfu not connected, recreating');
-      await sfuWS.recreate();
+      final wsResult = await sfuWS.recreate();
+      if (wsResult.isFailure) {
+        _logger.w(() => '[fastReconnect] sfu recreate failed: $wsResult');
+        return const Result.failure(
+          VideoError(message: 'SFU WS reconnect failed'),
+        );
+      }
 
       _logger.d(() => '[fastReconnect] sfu connected, sending join request');
       sfuWS.send(
@@ -526,6 +534,47 @@ class CallSession extends Disposable {
     }
   }
 
+  /// Starts a one-shot timer that verifies the publisher's ICE transport
+  /// transitions out of the `new` state within [_publisherConnectionCheckDelay].
+  ///
+  /// If the transport is still `new` after the deadline, the SDP answer was
+  /// likely never received (e.g. network dropped before the SFU could reply)
+  /// and we trigger a reconnection.
+  void startPublisherConnectionCheck() {
+    _publisherConnectionCheckTimer?.cancel();
+
+    _publisherConnectionCheckTimer = Timer(
+      _publisherConnectionCheckDelay,
+      () {
+        if (_isLeavingOrClosed) return;
+
+        final publisher = rtcManager?.publisher;
+        if (publisher == null) return;
+
+        final iceState = publisher.pc.iceConnectionState;
+        if (iceState == rtc.RTCIceConnectionState.RTCIceConnectionStateNew) {
+          _logger.w(
+            () =>
+                '[publisherConnectionCheck] publisher ICE still in "new" '
+                'state after ${_publisherConnectionCheckDelay.inSeconds}s '
+                '— triggering reconnection',
+          );
+          _tracer.trace('publisherConnectionCheck.stalled', {
+            'iceState': iceState.toString(),
+            'timeoutSeconds': _publisherConnectionCheckDelay.inSeconds,
+          });
+          onReconnectionNeeded(publisher, SfuReconnectionStrategy.rejoin);
+        } else {
+          _logger.v(
+            () =>
+                '[publisherConnectionCheck] publisher ICE state: '
+                '$iceState — OK',
+          );
+        }
+      },
+    );
+  }
+
   void leave({String? reason}) {
     _logger.d(() => '[leave] reason: $reason');
     _isLeavingOrClosed = true;
@@ -542,6 +591,8 @@ class CallSession extends Disposable {
     );
     _isLeavingOrClosed = true;
 
+    _publisherConnectionCheckTimer?.cancel();
+
     await _eventsSubscription?.cancel();
     await _networkStatusSubscription?.cancel();
 
@@ -549,7 +600,6 @@ class CallSession extends Disposable {
     statsReporter = null;
 
     _tracer.dispose();
-    _peerConnectionCheckTimer?.cancel();
 
     unawaited(
       sfuWS
@@ -939,6 +989,11 @@ class CallSession extends Disposable {
     if (_isLeavingOrClosed || stateManager.callState.status.isDisconnected) {
       _logger.w(() => '[negotiate] call is disconnected');
       return Result.error('Call is disconnected');
+    }
+
+    if (!sfuWS.isConnected) {
+      _logger.w(() => '[negotiate] skipped — SFU WS not connected');
+      return Result.error('SFU WS is not connected');
     }
 
     await _negotiationLock.synchronized(() async {

--- a/packages/stream_video/lib/src/webrtc/peer_connection.dart
+++ b/packages/stream_video/lib/src/webrtc/peer_connection.dart
@@ -512,8 +512,16 @@ class StreamPeerConnection extends Disposable {
   }
 
   void _onRenegotiationNeeded() {
-    _logger.v(() => '[onRenegotiationNeeded] no args');
+    if (_isReconnecting) {
+      _logger.i(
+        () =>
+            '[onRenegotiationNeeded] suppressed — reconnect in progress for '
+            '$type, will renegotiate explicitly after reconnect',
+      );
+      return;
+    }
 
+    _logger.v(() => '[onRenegotiationNeeded] no args');
     onRenegotiationNeeded?.call(this);
   }
 

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   webrtc_interface: ^1.1.1
 
 dev_dependencies:
+  fake_async: ^1.3.1
   flutter_test:
     sdk: flutter
   mockito: ^5.4.2

--- a/packages/stream_video/test/src/call/session/call_session_reconnect_safety_test.dart
+++ b/packages/stream_video/test/src/call/session/call_session_reconnect_safety_test.dart
@@ -247,24 +247,26 @@ void main() {
   });
 
   group('CallSession.getReconnectDetails', () {
-    test('rejoin includes the current sessionId as previousSessionId',
-        () async {
-      final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
+    test(
+      'rejoin includes the current sessionId as previousSessionId',
+      () async {
+        final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
 
-      final details = await session.getReconnectDetails(
-        SfuReconnectionStrategy.rejoin,
-        reconnectAttempts: 3,
-        reason: 'sfu_socket_failed',
-      );
+        final details = await session.getReconnectDetails(
+          SfuReconnectionStrategy.rejoin,
+          reconnectAttempts: 3,
+          reason: 'sfu_socket_failed',
+        );
 
-      expect(
-        details.strategy,
-        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_REJOIN,
-      );
-      expect(details.previousSessionId, 'test-session');
-      expect(details.reconnectAttempt, 3);
-      expect(details.reason, 'sfu_socket_failed');
-    });
+        expect(
+          details.strategy,
+          WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_REJOIN,
+        );
+        expect(details.previousSessionId, 'test-session');
+        expect(details.reconnectAttempt, 3);
+        expect(details.reason, 'sfu_socket_failed');
+      },
+    );
 
     test('fast leaves previousSessionId unset', () async {
       final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
@@ -285,22 +287,24 @@ void main() {
       );
     });
 
-    test('migrate carries fromSfuId and leaves previousSessionId unset',
-        () async {
-      final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
+    test(
+      'migrate carries fromSfuId and leaves previousSessionId unset',
+      () async {
+        final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
 
-      final details = await session.getReconnectDetails(
-        SfuReconnectionStrategy.migrate,
-        migratingFromSfuId: 'sfu-eu-west-1',
-      );
+        final details = await session.getReconnectDetails(
+          SfuReconnectionStrategy.migrate,
+          migratingFromSfuId: 'sfu-eu-west-1',
+        );
 
-      expect(
-        details.strategy,
-        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_MIGRATE,
-      );
-      expect(details.previousSessionId, isEmpty);
-      expect(details.fromSfuId, 'sfu-eu-west-1');
-    });
+        expect(
+          details.strategy,
+          WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_MIGRATE,
+        );
+        expect(details.previousSessionId, isEmpty);
+        expect(details.fromSfuId, 'sfu-eu-west-1');
+      },
+    );
 
     test('omits announcedTracks when rtcManager is null', () async {
       final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
@@ -352,8 +356,7 @@ void main() {
   });
 
   group('CallSession.close', () {
-    test('clears rtcManager so subsequent track lookups return null',
-        () async {
+    test('clears rtcManager so subsequent track lookups return null', () async {
       final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
       _wirePublisher(
         session,

--- a/packages/stream_video/test/src/call/session/call_session_reconnect_safety_test.dart
+++ b/packages/stream_video/test/src/call/session/call_session_reconnect_safety_test.dart
@@ -1,0 +1,369 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_video/src/call/session/call_session.dart';
+import 'package:stream_video/src/call/session/call_session_config.dart';
+import 'package:stream_video/src/call/stats/tracer.dart';
+import 'package:stream_video/protobuf/video/sfu/models/models.pbenum.dart';
+import 'package:stream_video/src/webrtc/peer_connection.dart';
+import 'package:stream_video/src/webrtc/peer_connection_factory.dart';
+import 'package:stream_video/src/webrtc/rtc_manager.dart';
+import 'package:stream_video/src/webrtc/traced_peer_connection.dart';
+import 'package:stream_video/src/ws/ws.dart';
+import 'package:stream_video/stream_video.dart';
+import 'package:stream_webrtc_flutter/stream_webrtc_flutter.dart' as rtc;
+
+import '../../../test_helpers.dart';
+import '../fixtures/call_test_helpers.dart';
+import '../fixtures/data.dart';
+
+class MockRtcManager extends Mock implements RtcManager {}
+
+class MockTracedStreamPeerConnection extends Mock
+    implements TracedStreamPeerConnection {}
+
+class MockRTCPeerConnection extends Mock implements rtc.RTCPeerConnection {}
+
+MockStreamVideo _buildMockStreamVideo() {
+  final mock = setupMockStreamVideo();
+  when(() => mock.apiKey).thenReturn('test-api-key');
+  return mock;
+}
+
+CallSession _buildTestSession({
+  required void Function(StreamPeerConnection, SfuReconnectionStrategy)
+  onReconnectionNeeded,
+}) {
+  final callCid = SampleCallData.defaultCid;
+  final stateManager = createTestCallStateManager();
+
+  return CallSession(
+    callCid: callCid,
+    sessionSeq: 0,
+    sessionId: 'test-session',
+    config: const CallSessionConfig(
+      sfuName: 'test-sfu',
+      sfuToken: 'test-token',
+      sfuUrl: 'https://test.example.com',
+      sfuWsEndpoint: 'wss://test.example.com/ws',
+      rtcConfig: RTCConfiguration(),
+    ),
+    stateManager: stateManager,
+    dynascaleManager: DynascaleManager(stateManager: stateManager),
+    onReconnectionNeeded: onReconnectionNeeded,
+    onSuspendedAudioTrackRecorded: (_) {},
+    sdpEditor: MockSdpEditor(),
+    networkMonitor: setupMockInternetConnection(),
+    statsOptions: StatsOptions(
+      enableRtcStats: false,
+      reportingIntervalMs: 500,
+    ),
+    streamVideo: _buildMockStreamVideo(),
+    tracer: Tracer(null),
+    pcFactory: StreamPeerConnectionFactory(callCid: callCid),
+  );
+}
+
+({
+  MockRtcManager rtcManager,
+  MockTracedStreamPeerConnection publisher,
+  MockRTCPeerConnection pc,
+})
+_wirePublisher(
+  CallSession session, {
+  required rtc.RTCIceConnectionState iceState,
+}) {
+  final rtcManager = MockRtcManager();
+  final publisher = MockTracedStreamPeerConnection();
+  final pc = MockRTCPeerConnection();
+
+  when(() => rtcManager.publisher).thenReturn(publisher);
+  when(() => publisher.pc).thenReturn(pc);
+  when(() => pc.iceConnectionState).thenReturn(iceState);
+  // close() will dispose the rtcManager — stub so the cast doesn't blow up.
+  when(rtcManager.dispose).thenAnswer((_) async {});
+
+  session.rtcManager = rtcManager;
+  return (rtcManager: rtcManager, publisher: publisher, pc: pc);
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    registerMockFallbackValues();
+  });
+
+  group('CallSession.startPublisherConnectionCheck', () {
+    test(
+      'triggers rejoin via onReconnectionNeeded when ICE is still '
+      '"new" after the delay',
+      () {
+        fakeAsync((async) {
+          final reconnects =
+              <(StreamPeerConnection, SfuReconnectionStrategy)>[];
+          final session = _buildTestSession(
+            onReconnectionNeeded: (pc, strategy) =>
+                reconnects.add((pc, strategy)),
+          );
+          final wires = _wirePublisher(
+            session,
+            iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateNew,
+          );
+
+          session.startPublisherConnectionCheck();
+
+          // Just before the deadline → no callback yet.
+          async.elapse(const Duration(seconds: 14));
+          expect(reconnects, isEmpty);
+
+          // Cross the deadline.
+          async.elapse(const Duration(seconds: 1));
+          expect(reconnects, hasLength(1));
+          expect(reconnects.single.$1, same(wires.publisher));
+          expect(reconnects.single.$2, SfuReconnectionStrategy.rejoin);
+        });
+      },
+    );
+
+    test(
+      'does NOT trigger reconnection when ICE has progressed past "new"',
+      () {
+        fakeAsync((async) {
+          var called = 0;
+          final session = _buildTestSession(
+            onReconnectionNeeded: (_, __) => called++,
+          );
+          _wirePublisher(
+            session,
+            iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateChecking,
+          );
+
+          session.startPublisherConnectionCheck();
+          async.elapse(const Duration(seconds: 16));
+
+          expect(
+            called,
+            0,
+            reason: 'ICE is no longer in "new" — nothing to recover from',
+          );
+        });
+      },
+    );
+
+    test('no-op when publisher is null at deadline', () {
+      fakeAsync((async) {
+        var called = 0;
+        final session = _buildTestSession(
+          onReconnectionNeeded: (_, __) => called++,
+        );
+        final rtcManager = MockRtcManager();
+        when(() => rtcManager.publisher).thenReturn(null);
+        session.rtcManager = rtcManager;
+
+        session.startPublisherConnectionCheck();
+        async.elapse(const Duration(seconds: 16));
+
+        expect(called, 0);
+      });
+    });
+
+    test('no-op when session was closed before the deadline', () {
+      fakeAsync((async) {
+        var called = 0;
+        final session = _buildTestSession(
+          onReconnectionNeeded: (_, __) => called++,
+        );
+        _wirePublisher(
+          session,
+          iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateNew,
+        );
+
+        session.startPublisherConnectionCheck();
+
+        // close() should cancel the pending timer; even if it didn't, the
+        // _isLeavingOrClosed flag set by leave()/close() short-circuits the
+        // callback once it fires.
+        session.leave(reason: 'test');
+        async.elapse(const Duration(seconds: 20));
+
+        expect(called, 0);
+      });
+    });
+
+    test(
+      'calling startPublisherConnectionCheck twice cancels the first timer',
+      () {
+        fakeAsync((async) {
+          var called = 0;
+          final session = _buildTestSession(
+            onReconnectionNeeded: (_, __) => called++,
+          );
+          _wirePublisher(
+            session,
+            iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateNew,
+          );
+
+          session.startPublisherConnectionCheck();
+          async.elapse(const Duration(seconds: 10));
+          // Second call resets the 15s window.
+          session.startPublisherConnectionCheck();
+
+          // 10s after the first call but only 5s after the second — the second
+          // window hasn't elapsed yet, and the first should have been cancelled.
+          async.elapse(const Duration(seconds: 5));
+          expect(called, 0, reason: 'first timer should be cancelled');
+
+          // Cross the second deadline.
+          async.elapse(const Duration(seconds: 11));
+          expect(called, 1, reason: 'second timer should fire exactly once');
+        });
+      },
+    );
+
+    test('close() cancels the pending publisher-check timer', () {
+      fakeAsync((async) {
+        var called = 0;
+        final session = _buildTestSession(
+          onReconnectionNeeded: (_, __) => called++,
+        );
+        _wirePublisher(
+          session,
+          iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateNew,
+        );
+
+        session.startPublisherConnectionCheck();
+
+        // Trigger the timer-cancelling close path. We do not await to keep
+        // FakeAsync deterministic; the synchronous side effect we care about
+        // (Timer.cancel) runs before any await suspension.
+        unawaited(session.close(StreamWebSocketCloseCode.normalClosure));
+        async.elapse(const Duration(seconds: 20));
+
+        expect(called, 0);
+      });
+    });
+  });
+
+  group('CallSession.getReconnectDetails', () {
+    test('rejoin includes the current sessionId as previousSessionId',
+        () async {
+      final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
+
+      final details = await session.getReconnectDetails(
+        SfuReconnectionStrategy.rejoin,
+        reconnectAttempts: 3,
+        reason: 'sfu_socket_failed',
+      );
+
+      expect(
+        details.strategy,
+        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_REJOIN,
+      );
+      expect(details.previousSessionId, 'test-session');
+      expect(details.reconnectAttempt, 3);
+      expect(details.reason, 'sfu_socket_failed');
+    });
+
+    test('fast leaves previousSessionId unset', () async {
+      final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
+
+      final details = await session.getReconnectDetails(
+        SfuReconnectionStrategy.fast,
+      );
+
+      expect(
+        details.strategy,
+        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST,
+      );
+      expect(
+        details.previousSessionId,
+        isEmpty,
+        reason:
+            'fast reconnect reuses the same session — no `previous` to send',
+      );
+    });
+
+    test('migrate carries fromSfuId and leaves previousSessionId unset',
+        () async {
+      final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
+
+      final details = await session.getReconnectDetails(
+        SfuReconnectionStrategy.migrate,
+        migratingFromSfuId: 'sfu-eu-west-1',
+      );
+
+      expect(
+        details.strategy,
+        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_MIGRATE,
+      );
+      expect(details.previousSessionId, isEmpty);
+      expect(details.fromSfuId, 'sfu-eu-west-1');
+    });
+
+    test('omits announcedTracks when rtcManager is null', () async {
+      final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
+
+      final details = await session.getReconnectDetails(
+        SfuReconnectionStrategy.rejoin,
+      );
+
+      // No rtcManager → no announced tracks list; default repeated field
+      // remains empty rather than throwing.
+      expect(details.announcedTracks, isEmpty);
+    });
+  });
+
+  group('CallSession.leave', () {
+    test(
+      'sets the leaving flag so a later publisher-check fire is a no-op',
+      () {
+        fakeAsync((async) {
+          var called = 0;
+          final session = _buildTestSession(
+            onReconnectionNeeded: (_, __) => called++,
+          );
+          _wirePublisher(
+            session,
+            iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateNew,
+          );
+
+          session.startPublisherConnectionCheck();
+          session.leave(reason: 'user_tapped_leave');
+          async.elapse(const Duration(seconds: 20));
+
+          expect(
+            called,
+            0,
+            reason:
+                'leave() flips _isLeavingOrClosed; the timer fires but its '
+                'callback returns early.',
+          );
+        });
+      },
+    );
+
+    test('repeatedly calling leave is safe', () {
+      final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
+      expect(() => session.leave(reason: 'first'), returnsNormally);
+      expect(() => session.leave(reason: 'second'), returnsNormally);
+    });
+  });
+
+  group('CallSession.close', () {
+    test('clears rtcManager so subsequent track lookups return null',
+        () async {
+      final session = _buildTestSession(onReconnectionNeeded: (_, __) {});
+      _wirePublisher(
+        session,
+        iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateConnected,
+      );
+
+      expect(session.rtcManager, isNotNull);
+      await session.close(StreamWebSocketCloseCode.normalClosure);
+
+      expect(session.rtcManager, isNull);
+    });
+  });
+}

--- a/packages/stream_video/test/src/webrtc/peer_connection_renegotiation_test.dart
+++ b/packages/stream_video/test/src/webrtc/peer_connection_renegotiation_test.dart
@@ -1,0 +1,454 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_video/protobuf/video/sfu/signal_rpc/signal.pb.dart'
+    as sfu;
+import 'package:stream_video/src/sfu/sfu_client.dart';
+import 'package:stream_video/src/webrtc/peer_connection.dart';
+import 'package:stream_video/stream_video.dart';
+import 'package:stream_webrtc_flutter/stream_webrtc_flutter.dart' as rtc;
+
+import '../../test_helpers.dart';
+import '../call/fixtures/data.dart';
+
+/// Minimal fake of [rtc.RTCPeerConnection] that captures the callbacks
+/// [StreamPeerConnection] wires up in its constructor. We only override the
+/// setters the wiring touches; everything else falls back to the [Fake] mixin
+/// (which throws if accidentally invoked).
+class _FakeRtcPeerConnection extends Fake implements rtc.RTCPeerConnection {
+  void Function(rtc.MediaStream)? capturedOnAddStream;
+  void Function(rtc.MediaStream)? capturedOnRemoveStream;
+  void Function(rtc.MediaStream, rtc.MediaStreamTrack)? capturedOnAddTrack;
+  void Function(rtc.RTCTrackEvent)? capturedOnTrack;
+  void Function(rtc.MediaStream, rtc.MediaStreamTrack)? capturedOnRemoveTrack;
+  void Function(rtc.RTCIceCandidate)? capturedOnIceCandidate;
+  void Function(rtc.RTCIceConnectionState)? capturedOnIceConnectionState;
+  void Function(rtc.RTCPeerConnectionState)? capturedOnConnectionState;
+  void Function()? capturedOnRenegotiationNeeded;
+
+  @override
+  set onAddStream(void Function(rtc.MediaStream)? cb) =>
+      capturedOnAddStream = cb;
+
+  @override
+  set onRemoveStream(void Function(rtc.MediaStream)? cb) =>
+      capturedOnRemoveStream = cb;
+
+  @override
+  set onAddTrack(void Function(rtc.MediaStream, rtc.MediaStreamTrack)? cb) =>
+      capturedOnAddTrack = cb;
+
+  @override
+  set onTrack(void Function(rtc.RTCTrackEvent)? cb) => capturedOnTrack = cb;
+
+  @override
+  set onRemoveTrack(void Function(rtc.MediaStream, rtc.MediaStreamTrack)? cb) =>
+      capturedOnRemoveTrack = cb;
+
+  @override
+  set onIceCandidate(void Function(rtc.RTCIceCandidate)? cb) =>
+      capturedOnIceCandidate = cb;
+
+  @override
+  set onIceConnectionState(void Function(rtc.RTCIceConnectionState)? cb) =>
+      capturedOnIceConnectionState = cb;
+
+  @override
+  set onConnectionState(void Function(rtc.RTCPeerConnectionState)? cb) =>
+      capturedOnConnectionState = cb;
+
+  @override
+  set onRenegotiationNeeded(void Function()? cb) =>
+      capturedOnRenegotiationNeeded = cb;
+
+  // _dropRtcCallbacks also nulls these — accept the assignment so dispose()
+  // doesn't blow up on un-overridden setters. We don't capture them because
+  // _initRtcCallbacks never wires them in the first place.
+  @override
+  set onIceGatheringState(void Function(rtc.RTCIceGatheringState)? _) {}
+
+  @override
+  set onSignalingState(void Function(rtc.RTCSignalingState)? _) {}
+
+  @override
+  set onDataChannel(void Function(rtc.RTCDataChannel)? _) {}
+
+  int restartIceCallCount = 0;
+  int disposeCallCount = 0;
+
+  @override
+  Future<void> restartIce() async {
+    restartIceCallCount++;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCallCount++;
+  }
+
+  rtc.RTCIceConnectionState? stubbedIceConnectionState;
+
+  @override
+  rtc.RTCIceConnectionState? get iceConnectionState =>
+      stubbedIceConnectionState;
+}
+
+StreamPeerConnection _build({
+  required _FakeRtcPeerConnection pc,
+  required StreamPeerType type,
+  SfuClient? sfuClient,
+}) {
+  return StreamPeerConnection(
+    sfuClient: sfuClient ?? MockSfuClient(),
+    sessionId: 'test-session',
+    callCid: SampleCallData.defaultCid,
+    type: type,
+    pc: pc,
+    sdpEditor: MockSdpEditor(),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    registerFallbackValue(sfu.ICERestartRequest());
+  });
+
+  group('StreamPeerConnection.onRenegotiationNeeded', () {
+    test(
+      'forwards to the public onRenegotiationNeeded callback when not '
+      'reconnecting',
+      () {
+        final pc = _FakeRtcPeerConnection();
+        final sp = _build(pc: pc, type: StreamPeerType.publisher);
+
+        final invocations = <StreamPeerConnection>[];
+        sp.onRenegotiationNeeded = invocations.add;
+
+        // Sanity: the constructor wired the rtc-side callback.
+        expect(pc.capturedOnRenegotiationNeeded, isNotNull);
+
+        pc.capturedOnRenegotiationNeeded!();
+
+        expect(invocations, hasLength(1));
+        expect(invocations.single, same(sp));
+      },
+    );
+
+    test(
+      'suppresses the callback while setReconnecting(true) is in effect',
+      () {
+        final pc = _FakeRtcPeerConnection();
+        final sp = _build(pc: pc, type: StreamPeerType.publisher);
+
+        var calls = 0;
+        sp.onRenegotiationNeeded = (_) => calls++;
+
+        sp.setReconnecting(true);
+
+        pc.capturedOnRenegotiationNeeded!();
+
+        expect(
+          calls,
+          0,
+          reason:
+              'Renegotiation requests during reconnect must be deferred; '
+              'the session will renegotiate explicitly once reconnect '
+              'completes.',
+        );
+      },
+    );
+
+    test(
+      'resumes forwarding after setReconnecting(false)',
+      () {
+        final pc = _FakeRtcPeerConnection();
+        final sp = _build(pc: pc, type: StreamPeerType.publisher);
+
+        var calls = 0;
+        sp.onRenegotiationNeeded = (_) => calls++;
+
+        sp.setReconnecting(true);
+        pc.capturedOnRenegotiationNeeded!();
+        expect(calls, 0);
+
+        sp.setReconnecting(false);
+        pc.capturedOnRenegotiationNeeded!();
+        expect(calls, 1);
+      },
+    );
+
+    test('is a no-op when no public callback is attached', () {
+      final pc = _FakeRtcPeerConnection();
+      _build(pc: pc, type: StreamPeerType.publisher);
+
+      // onRenegotiationNeeded is null by default — must not throw.
+      expect(pc.capturedOnRenegotiationNeeded!, isA<void Function()>());
+      expect(() => pc.capturedOnRenegotiationNeeded!(), returnsNormally);
+    });
+  });
+
+  group('StreamPeerConnection.onConnectionState', () {
+    test(
+      'fires onReconnectionNeeded with rejoin when the peer enters Failed',
+      () {
+        final pc = _FakeRtcPeerConnection();
+        final sp = _build(pc: pc, type: StreamPeerType.publisher);
+
+        final calls = <(StreamPeerConnection, SfuReconnectionStrategy)>[];
+        sp.onReconnectionNeeded = (peer, strategy) =>
+            calls.add((peer, strategy));
+
+        pc.capturedOnConnectionState!(
+          rtc.RTCPeerConnectionState.RTCPeerConnectionStateFailed,
+        );
+
+        expect(calls, hasLength(1));
+        expect(calls.single.$1, same(sp));
+        expect(calls.single.$2, SfuReconnectionStrategy.rejoin);
+      },
+    );
+
+    test('does not fire onReconnectionNeeded for non-Failed states', () {
+      final pc = _FakeRtcPeerConnection();
+      final sp = _build(pc: pc, type: StreamPeerType.publisher);
+
+      var calls = 0;
+      sp.onReconnectionNeeded = (_, __) => calls++;
+
+      [
+        rtc.RTCPeerConnectionState.RTCPeerConnectionStateNew,
+        rtc.RTCPeerConnectionState.RTCPeerConnectionStateConnecting,
+        rtc.RTCPeerConnectionState.RTCPeerConnectionStateConnected,
+        rtc.RTCPeerConnectionState.RTCPeerConnectionStateDisconnected,
+        rtc.RTCPeerConnectionState.RTCPeerConnectionStateClosed,
+      ].forEach(pc.capturedOnConnectionState!);
+
+      expect(calls, 0);
+    });
+  });
+
+  group('StreamPeerConnection ICE-restart on iceConnectionState changes', () {
+    test(
+      'publisher restartIce is called immediately on ICE Failed when not '
+      'reconnecting',
+      () {
+        final pc = _FakeRtcPeerConnection();
+        _build(pc: pc, type: StreamPeerType.publisher);
+
+        pc.capturedOnIceConnectionState!(
+          rtc.RTCIceConnectionState.RTCIceConnectionStateFailed,
+        );
+
+        // restartIce is async-chained through `.then(...)` — the fake's
+        // counter increments synchronously the moment the future is awaited.
+        expect(pc.restartIceCallCount, 1);
+      },
+    );
+
+    test(
+      'subscriber routes ICE-Failed through sfuClient.restartIce, not pc',
+      () async {
+        final pc = _FakeRtcPeerConnection();
+        final sfuClient = MockSfuClient();
+        when(() => sfuClient.restartIce(any())).thenAnswer(
+          (_) async => Result.success(sfu.ICERestartResponse()),
+        );
+
+        _build(
+          pc: pc,
+          type: StreamPeerType.subscriber,
+          sfuClient: sfuClient,
+        );
+
+        pc.capturedOnIceConnectionState!(
+          rtc.RTCIceConnectionState.RTCIceConnectionStateFailed,
+        );
+
+        // Let the restartIce microtasks settle.
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => sfuClient.restartIce(any())).called(1);
+        expect(
+          pc.restartIceCallCount,
+          0,
+          reason: 'subscriber-side restart goes through SFU, not the PC',
+        );
+      },
+    );
+
+    test('publisher restartIce is suppressed during reconnect', () {
+      final pc = _FakeRtcPeerConnection();
+      final sp = _build(pc: pc, type: StreamPeerType.publisher);
+
+      sp.setReconnecting(true);
+      pc.capturedOnIceConnectionState!(
+        rtc.RTCIceConnectionState.RTCIceConnectionStateFailed,
+      );
+
+      expect(
+        pc.restartIceCallCount,
+        0,
+        reason: 'reconnect is owning the recovery flow',
+      );
+    });
+
+    test(
+      'ICE Disconnected schedules a deferred restart that runs after '
+      'iceRestartDelay if the connection is still bad',
+      () {
+        fakeAsync((async) {
+          final pc = _FakeRtcPeerConnection();
+          _build(pc: pc, type: StreamPeerType.publisher);
+
+          pc.stubbedIceConnectionState =
+              rtc.RTCIceConnectionState.RTCIceConnectionStateDisconnected;
+          pc.capturedOnIceConnectionState!(
+            rtc.RTCIceConnectionState.RTCIceConnectionStateDisconnected,
+          );
+
+          // Default iceRestartDelay is 2500ms; before that no restart yet.
+          async.elapse(const Duration(milliseconds: 2000));
+          expect(pc.restartIceCallCount, 0);
+
+          // Cross the deadline — still disconnected, so restartIce fires.
+          async.elapse(const Duration(milliseconds: 600));
+          expect(pc.restartIceCallCount, 1);
+        });
+      },
+    );
+
+    test(
+      'ICE Disconnected → deferred restart is skipped if the peer has '
+      'recovered to Connected before the delay elapses',
+      () {
+        fakeAsync((async) {
+          final pc = _FakeRtcPeerConnection();
+          _build(pc: pc, type: StreamPeerType.publisher);
+
+          pc.stubbedIceConnectionState =
+              rtc.RTCIceConnectionState.RTCIceConnectionStateDisconnected;
+          pc.capturedOnIceConnectionState!(
+            rtc.RTCIceConnectionState.RTCIceConnectionStateDisconnected,
+          );
+
+          // ICE recovers — Connected handler cancels the pending timer.
+          pc.stubbedIceConnectionState =
+              rtc.RTCIceConnectionState.RTCIceConnectionStateConnected;
+          pc.capturedOnIceConnectionState!(
+            rtc.RTCIceConnectionState.RTCIceConnectionStateConnected,
+          );
+
+          async.elapse(const Duration(seconds: 10));
+          expect(pc.restartIceCallCount, 0);
+        });
+      },
+    );
+
+    test(
+      'setReconnecting(true) cancels a pending ICE-Disconnected restart',
+      () {
+        fakeAsync((async) {
+          final pc = _FakeRtcPeerConnection();
+          final sp = _build(pc: pc, type: StreamPeerType.publisher);
+
+          pc.stubbedIceConnectionState =
+              rtc.RTCIceConnectionState.RTCIceConnectionStateDisconnected;
+          pc.capturedOnIceConnectionState!(
+            rtc.RTCIceConnectionState.RTCIceConnectionStateDisconnected,
+          );
+
+          sp.setReconnecting(true);
+
+          async.elapse(const Duration(seconds: 10));
+          expect(pc.restartIceCallCount, 0);
+        });
+      },
+    );
+  });
+
+  group('StreamPeerConnection event forwarding', () {
+    test(
+      'onAddStream forwards to onStreamAdded with the same peer + stream',
+      () {
+        final pc = _FakeRtcPeerConnection();
+        final sp = _build(pc: pc, type: StreamPeerType.publisher);
+        final fakeStream = _FakeMediaStream();
+
+        final received = <(StreamPeerConnection, rtc.MediaStream)>[];
+        sp.onStreamAdded = (peer, stream) => received.add((peer, stream));
+
+        pc.capturedOnAddStream!(fakeStream);
+
+        expect(received, hasLength(1));
+        expect(received.single.$1, same(sp));
+        expect(received.single.$2, same(fakeStream));
+      },
+    );
+
+    test('onTrack forwards to public onTrack', () {
+      final pc = _FakeRtcPeerConnection();
+      final sp = _build(pc: pc, type: StreamPeerType.publisher);
+      final event = _FakeTrackEvent();
+
+      final received = <(StreamPeerConnection, rtc.RTCTrackEvent)>[];
+      sp.onTrack = (peer, e) => received.add((peer, e));
+
+      pc.capturedOnTrack!(event);
+
+      expect(received.single.$1, same(sp));
+      expect(received.single.$2, same(event));
+    });
+
+    test('onIceCandidate forwards to public onIceCandidate', () {
+      final pc = _FakeRtcPeerConnection();
+      final sp = _build(pc: pc, type: StreamPeerType.publisher);
+      final candidate = rtc.RTCIceCandidate('cand', 'mid', 0);
+
+      final received = <(StreamPeerConnection, rtc.RTCIceCandidate)>[];
+      sp.onIceCandidate = (peer, c) => received.add((peer, c));
+
+      pc.capturedOnIceCandidate!(candidate);
+
+      expect(received.single.$1, same(sp));
+      expect(received.single.$2, same(candidate));
+    });
+  });
+
+  group('StreamPeerConnection.dispose', () {
+    test(
+      'drops every rtc-side callback and disposes the underlying pc',
+      () async {
+        final pc = _FakeRtcPeerConnection();
+        final sp = _build(pc: pc, type: StreamPeerType.publisher);
+
+        // Sanity: callbacks were wired by the ctor.
+        expect(pc.capturedOnRenegotiationNeeded, isNotNull);
+
+        await sp.dispose();
+
+        expect(pc.capturedOnAddStream, isNull);
+        expect(pc.capturedOnRemoveStream, isNull);
+        expect(pc.capturedOnAddTrack, isNull);
+        expect(pc.capturedOnTrack, isNull);
+        expect(pc.capturedOnRemoveTrack, isNull);
+        expect(pc.capturedOnIceCandidate, isNull);
+        expect(pc.capturedOnIceConnectionState, isNull);
+        expect(pc.capturedOnConnectionState, isNull);
+        expect(pc.capturedOnRenegotiationNeeded, isNull);
+        expect(
+          pc.disposeCallCount,
+          1,
+          reason: 'StreamPeerConnection.dispose must dispose the underlying pc',
+        );
+      },
+    );
+  });
+}
+
+class _FakeMediaStream extends Fake implements rtc.MediaStream {
+  @override
+  String get id => 'fake-stream-id';
+}
+
+class _FakeTrackEvent extends Fake implements rtc.RTCTrackEvent {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safety nets and recovery for publisher connection failures after reconnection (including lost SFU responses or prolonged ICE `new` state).
  * Triggers publisher connection health checks during join/fast-reconnect flows.
  * Improves websocket reconnection with explicit failure detection and handling.

* **Tests**
  * New tests covering reconnection safety, publisher-check timer behavior, and peer-connection renegotiation/ICE handling.

* **Documentation**
  * Updated changelog with the fix.

* **Chores**
  * Added dev test utility dependency for deterministic async testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-flutter/pull/1237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->