### PR TITLE
chore(llc): noise cancellation enum rename

### DIFF
--- a/dogfooding/lib/widgets/settings_menu/noise_cancellation_menu_item.dart
+++ b/dogfooding/lib/widgets/settings_menu/noise_cancellation_menu_item.dart
@@ -25,7 +25,7 @@ class _NoiseCancellationMenuItemState extends State<NoiseCancellationMenuItem> {
 
           if (callState == null ||
               callState.settings.audio.noiseCancellation?.mode ==
-                  NoiceCancellationSettingsMode.disabled) {
+                  NoiseCancellationSettingsMode.disabled) {
             return const SizedBox.shrink();
           }
 

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -14,7 +14,7 @@ Each call now owns an isolated native `PeerConnectionFactory`. This fixes cross-
 - Added safety nets and recovery for cases where the publisher connection fails to establish after a reconnection (e.g. the SFU answer is lost or ICE stays in the `new` state).
 - Fixed sibling-call audio capture being silently broken when another concurrently active call ended (e.g. a 1:1 ringing call ending alongside a running livestream, or a previous ringing call ending before a new one was accepted).
 - Fixed a sibling call's audio breaking when a ringing 1:1 call ended via `dropIfAloneInRingingFlow` (the remote party hung up first). `Call.end()` and `Call.leave()` now share a single `_disconnect` cleanup path.
-- Made the audio processor teardown in `Call._clear` multi-call aware. The audio processor is owned by `StreamVideo` rather than by an individual `Call`, so disabling it during one call's teardown silently dropped noise cancellation on any other still-active call. `_clear` now stops the global processor only when no other active call is configured to use `NoiceCancellationSettingsMode.autoOn`.
+- Made the audio processor teardown in `Call._clear` multi-call aware. The audio processor is owned by `StreamVideo` rather than by an individual `Call`, so disabling it during one call's teardown silently dropped noise cancellation on any other still-active call. `_clear` now stops the global processor only when no other active call is configured to use `NoiseCancellationSettingsMode.autoOn`.
 - Fixed noise cancellation breaking on iOS after the rejoin reconnection flow.
 - Fixed a potential iOS crash on call end when noise cancellation was active.
 

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -1547,7 +1547,7 @@ class Call {
 
     if (_streamVideo.isAudioProcessorConfigured() &&
         joinResult.data.metadata.settings.audio.noiseCancellation?.mode ==
-            NoiceCancellationSettingsMode.autoOn) {
+            NoiseCancellationSettingsMode.autoOn) {
       // AutoOn will enable noise cancellation if the device has sufficient processing power
       unawaited(
         startAudioProcessing(
@@ -2326,15 +2326,15 @@ class Call {
     // Call, so stopping it on this call's teardown would silently drop noise
     // cancellation on any other still-active call that also wants it. Only
     // stop the global processor when no other active call is configured for
-    // NoiceCancellationSettingsMode.autoOn.
+    // NoiseCancellationSettingsMode.autoOn.
     if (state.value.settings.audio.noiseCancellation?.mode ==
-        NoiceCancellationSettingsMode.autoOn) {
+        NoiseCancellationSettingsMode.autoOn) {
       final anotherCallWantsAutoOn = _streamVideo.state.activeCalls.value.any(
         (other) =>
             other.callCid != callCid &&
             other.state.value.status is! CallStatusDisconnected &&
             other.state.value.settings.audio.noiseCancellation?.mode ==
-                NoiceCancellationSettingsMode.autoOn,
+                NoiseCancellationSettingsMode.autoOn,
       );
       if (!anotherCallWantsAutoOn) {
         unawaited(

--- a/packages/stream_video/lib/src/models/call_settings.dart
+++ b/packages/stream_video/lib/src/models/call_settings.dart
@@ -1296,6 +1296,7 @@ enum RecordingType {
   }
 }
 
+@Deprecated('Use NoiseCancellationSettingsMode instead.')
 typedef NoiceCancellationSettingsMode = NoiseCancellationSettingsMode;
 
 enum NoiseCancellationSettingsMode {

--- a/packages/stream_video/lib/src/models/call_settings.dart
+++ b/packages/stream_video/lib/src/models/call_settings.dart
@@ -474,10 +474,10 @@ class StreamTranscriptionSettings extends AbstractSettings {
 
 class StreamNoiceCancellingSettings extends AbstractSettings {
   const StreamNoiceCancellingSettings({
-    this.mode = NoiceCancellationSettingsMode.disabled,
+    this.mode = NoiseCancellationSettingsMode.disabled,
   });
 
-  final NoiceCancellationSettingsMode mode;
+  final NoiseCancellationSettingsMode mode;
 
   @override
   List<Object?> get props => [mode];
@@ -1295,6 +1295,8 @@ enum RecordingType {
     }
   }
 }
+
+typedef NoiseCancellationSettingsMode = NoiceCancellationSettingsMode;
 
 enum NoiceCancellationSettingsMode {
   available,

--- a/packages/stream_video/lib/src/models/call_settings.dart
+++ b/packages/stream_video/lib/src/models/call_settings.dart
@@ -1296,9 +1296,9 @@ enum RecordingType {
   }
 }
 
-typedef NoiseCancellationSettingsMode = NoiceCancellationSettingsMode;
+typedef NoiceCancellationSettingsMode = NoiseCancellationSettingsMode;
 
-enum NoiceCancellationSettingsMode {
+enum NoiseCancellationSettingsMode {
   available,
   disabled,
   autoOn;
@@ -1308,11 +1308,11 @@ enum NoiceCancellationSettingsMode {
 
   NoiseCancellationSettingsModeEnum toOpenDto() {
     switch (this) {
-      case NoiceCancellationSettingsMode.available:
+      case NoiseCancellationSettingsMode.available:
         return NoiseCancellationSettingsModeEnum.available;
-      case NoiceCancellationSettingsMode.disabled:
+      case NoiseCancellationSettingsMode.disabled:
         return NoiseCancellationSettingsModeEnum.disabled;
-      case NoiceCancellationSettingsMode.autoOn:
+      case NoiseCancellationSettingsMode.autoOn:
         return NoiseCancellationSettingsModeEnum.autoOn;
     }
   }

--- a/packages/stream_video/test/src/call/call_audio_processing_test.dart
+++ b/packages/stream_video/test/src/call/call_audio_processing_test.dart
@@ -448,7 +448,7 @@ void main() {
           const autoOnSettings = CallSettings(
             audio: StreamAudioSettings(
               noiseCancellation: StreamNoiceCancellingSettings(
-                mode: NoiceCancellationSettingsMode.autoOn,
+                mode: NoiseCancellationSettingsMode.autoOn,
               ),
             ),
           );
@@ -538,7 +538,7 @@ void main() {
           const availableSettings = CallSettings(
             audio: StreamAudioSettings(
               noiseCancellation: StreamNoiceCancellingSettings(
-                mode: NoiceCancellationSettingsMode.available,
+                mode: NoiseCancellationSettingsMode.available,
               ),
             ),
           );
@@ -582,7 +582,7 @@ void main() {
           const autoOnSettings = CallSettings(
             audio: StreamAudioSettings(
               noiseCancellation: StreamNoiceCancellingSettings(
-                mode: NoiceCancellationSettingsMode.autoOn,
+                mode: NoiseCancellationSettingsMode.autoOn,
               ),
             ),
           );
@@ -758,7 +758,7 @@ void main() {
           const autoOnSettings = CallSettings(
             audio: StreamAudioSettings(
               noiseCancellation: StreamNoiceCancellingSettings(
-                mode: NoiceCancellationSettingsMode.autoOn,
+                mode: NoiseCancellationSettingsMode.autoOn,
               ),
             ),
           );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected noise-cancellation mode naming to ensure auto-on behavior works reliably during call start and teardown.

* **Tests**
  * Updated audio-processing tests to use the corrected noise-cancellation mode values.

* **Documentation**
  * Clarified CHANGELOG entry to reflect the accurate noise-cancellation mode names and related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->