### PR TITLE
fix(llc): deprecate precacheGenericSdps instead of removing it

### DIFF
--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -132,6 +132,10 @@ class StreamVideo extends Disposable {
     TokenLoader? tokenLoader,
     OnTokenUpdated? onTokenUpdated,
     PNManagerProvider? pushNotificationManagerProvider,
+    @Deprecated(
+      'No longer used, SDPs are now generated lazily per call. This parameter is a no-op and will be removed in a future major release.',
+    )
+    bool precacheGenericSdps = true,
   }) {
     final instance = StreamVideo._(
       apiKey,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The `precacheGenericSdps` parameter in `StreamVideo.create()` is now deprecated and marked for removal in a future major release. Users should remove this parameter from their code to prepare for the upcoming change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->