### PR TITLE
chore(repo): distribute ci fix

### DIFF
--- a/.github/actions/pana/action.yml
+++ b/.github/actions/pana/action.yml
@@ -24,34 +24,25 @@ runs:
     - name: Temporary Override Local Dependencies
       shell: bash
       run: |
-        # Add dependency_overrides to use local paths instead of pub.dev versions
-        # This preserves the original YAML formatting by appending to files
-
-        # --- stream_video_flutter ---
-        cat >> packages/stream_video_flutter/pubspec.yaml << 'PUBSPEC_EOF'
-
+        cat > packages/stream_video_flutter/pubspec_overrides.yaml << 'EOF'
         dependency_overrides:
           stream_video:
             path: ../stream_video
-        PUBSPEC_EOF
+        EOF
 
-        # --- stream_video_push_notification ---
-        cat >> packages/stream_video_push_notification/pubspec.yaml << 'PUBSPEC_EOF'
-
+        cat > packages/stream_video_push_notification/pubspec_overrides.yaml << 'EOF'
         dependency_overrides:
           stream_video:
             path: ../stream_video
           stream_video_flutter:
             path: ../stream_video_flutter
-        PUBSPEC_EOF
+        EOF
 
-        # --- stream_video_noise_cancellation ---
-        cat >> packages/stream_video_noise_cancellation/pubspec.yaml << 'PUBSPEC_EOF'
-
+        cat > packages/stream_video_noise_cancellation/pubspec_overrides.yaml << 'EOF'
         dependency_overrides:
           stream_video:
             path: ../stream_video
-        PUBSPEC_EOF
+        EOF
 
     - name: Install Flutter
       uses: subosito/flutter-action@v2

--- a/.github/actions/pana/action.yml
+++ b/.github/actions/pana/action.yml
@@ -22,27 +22,14 @@ runs:
   using: "composite"
   steps:
     - name: Temporary Override Local Dependencies
-      shell: bash
-      run: |
-        cat > packages/stream_video_flutter/pubspec_overrides.yaml << 'EOF'
-        dependency_overrides:
-          stream_video:
-            path: ../stream_video
-        EOF
-
-        cat > packages/stream_video_push_notification/pubspec_overrides.yaml << 'EOF'
-        dependency_overrides:
-          stream_video:
-            path: ../stream_video
-          stream_video_flutter:
-            path: ../stream_video_flutter
-        EOF
-
-        cat > packages/stream_video_noise_cancellation/pubspec_overrides.yaml << 'EOF'
-        dependency_overrides:
-          stream_video:
-            path: ../stream_video
-        EOF
+      uses: mikefarah/yq@master
+      with:
+        cmd: |
+          yq eval '.dependencies.stream_video = {"path": "../stream_video"}' -i packages/stream_video_flutter/pubspec.yaml
+          yq eval '.dependencies.stream_video = {"path": "../stream_video"}' -i packages/stream_video_push_notification/pubspec.yaml
+          yq eval '.dependencies.stream_video_flutter = {"path": "../stream_video_flutter"}' -i packages/stream_video_push_notification/pubspec.yaml
+          yq eval '.dependencies.stream_video = {"path": "../stream_video"}' -i packages/stream_video_noise_cancellation/pubspec.yaml
+          yq eval '.dependencies.stream_video = {"path": "../stream_video"}' -i packages/stream_video_filters/pubspec.yaml
 
     - name: Install Flutter
       uses: subosito/flutter-action@v2

--- a/.github/actions/pana/action.yml
+++ b/.github/actions/pana/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Temporary Override Local Dependencies
-      uses: mikefarah/yq@master
+      uses: mikefarah/yq@v4.53.2
       with:
         cmd: |
           yq eval '.dependencies.stream_video = {"path": "../stream_video"}' -i packages/stream_video_flutter/pubspec.yaml

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -59,6 +59,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: '26.3'
 

--- a/.github/workflows/ios_pods_spm.yaml
+++ b/.github/workflows/ios_pods_spm.yaml
@@ -15,9 +15,9 @@ jobs:
       - name: 🧰 Setup Checkout
         uses: actions/checkout@v6
 
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: '26.3'
+          xcode-version: "26.3"
 
       - name: 🛠️ Setup Flutter
         uses: subosito/flutter-action@v2

--- a/dogfooding/android/gradle.properties
+++ b/dogfooding/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dlint.nullness.ignore-deprecated=true
+org.gradle.jvmargs=-Xms1024m -Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dlint.nullness.ignore-deprecated=true
 android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false

--- a/dogfooding/pubspec.yaml
+++ b/dogfooding/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   collection: ^1.19.1
   crypto: ^3.0.6
   cupertino_icons: ^1.0.8
-  device_info_plus: ^12.1.0
+  device_info_plus: ">=12.1.0 <14.0.0"
   envied: ^1.2.1
   firebase_auth: ^6.0.2
   firebase_core: ^4.1.0
@@ -56,10 +56,6 @@ dependency_overrides:
     path: ../packages/stream_video_push_notification
   stream_video_screen_sharing:
     path: ../packages/stream_video_screen_sharing
-  stream_webrtc_flutter:
-    git:
-      url: https://github.com/GetStream/webrtc-flutter.git
-      ref: e8678886871fb08aa6646aef870a2560d49199ea
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/melos.yaml
+++ b/melos.yaml
@@ -22,7 +22,7 @@ command:
     # Dependencies used in the project.
     dependencies:
       dart_webrtc: ^1.5.3+hotfix.2
-      device_info_plus: ^12.1.0
+      device_info_plus: ">=12.1.0 <14.0.0"
       share_plus: ^11.0.0
       stream_chat_flutter: ^9.17.0
       stream_webrtc_flutter: ^3.0.0

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   collection: ^1.19.1
   connectivity_plus: ^7.0.0
   dart_webrtc: ^1.5.3+hotfix.2
-  device_info_plus: ^12.1.0
+  device_info_plus: ">=12.1.0 <14.0.0"
   equatable: ^2.0.7
   fixnum: ^1.1.1
   flutter:
@@ -26,7 +26,7 @@ dependencies:
   intl: ">=0.18.1 <=0.21.0"
   jose: ^0.3.4
   meta: ^1.16.0
-  package_info_plus: ^9.0.0
+  package_info_plus: ">=9.0.0 <11.0.0"
   protobuf: ^6.0.0
   rxdart: ^0.28.0
   sdp_transform: ^0.3.2
@@ -39,7 +39,7 @@ dependencies:
   uuid: ^4.5.1
   web: ^1.0.0
   web_socket_channel: ^3.0.3
-  webrtc_interface: ^1.1.1
+  webrtc_interface: ^1.5.1
 
 dev_dependencies:
   fake_async: ^1.3.1

--- a/packages/stream_video_flutter/example/pubspec.yaml
+++ b/packages/stream_video_flutter/example/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   cupertino_icons: ^1.0.5
-  device_info_plus: ^12.1.0
+  device_info_plus: ">=12.1.0 <14.0.0"
   envied: ^1.2.1
   firebase_core: ^4.1.0
   firebase_messaging: ^16.0.1

--- a/packages/stream_video_push_notification/pubspec.yaml
+++ b/packages/stream_video_push_notification/pubspec.yaml
@@ -26,12 +26,6 @@ dependencies:
   stream_webrtc_flutter: ^3.0.0
   uuid: ^4.5.1
 
-dependency_overrides:
-  stream_webrtc_flutter:
-    git:
-      url: https://github.com/GetStream/webrtc-flutter.git
-      ref: e8678886871fb08aa6646aef870a2560d49199ea
-
 dev_dependencies:
   build_runner: ^2.9.0
   flutter_lints: ^2.0.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * iOS builds now pin a specific Xcode version to stabilize macOS CI runs.
  * Increased Android build JVM heap to improve build reliability.
  * CI dependency handling made more robust (safer in-place edits instead of appending).
  * Broadened and updated dependency version ranges and removed a forced dependency override to simplify resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->