### PR TITLE
fix(llc): guard null intent action in TransparentActivity

### DIFF
--- a/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/TransparentActivity.kt
+++ b/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/TransparentActivity.kt
@@ -32,11 +32,20 @@ class TransparentActivity : Activity() {
 
         val data = intent.getBundleExtra("data")
 
-        val broadcastIntent = IncomingCallBroadcastReceiver.getIntent(this, intent.action!!, data)
+        // The system can recreate this activity (e.g. process death / restore
+        // from recents) with a null action. Without an action there is nothing
+        // to dispatch, so finish instead of crashing on a non-null assertion.
+        val action = intent.action ?: run {
+            finish()
+            overridePendingTransition(0, 0)
+            return
+        }
+
+        val broadcastIntent = IncomingCallBroadcastReceiver.getIntent(this, action, data)
         broadcastIntent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
         sendBroadcast(broadcastIntent)
 
-        val activityIntent = AppUtils.getAppIntent(this, intent.action, data)
+        val activityIntent = AppUtils.getAppIntent(this, action, data)
         startActivity(activityIntent)
 
         finish()


### PR DESCRIPTION
## Summary

Fixes a `NullPointerException` crash in `TransparentActivity.onCreate` when the activity is created with a `null` intent action.

[`TransparentActivity.kt:35`](https://github.com/GetStream/stream-video-flutter/blob/main/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/TransparentActivity.kt#L35) uses a non-null assertion on `intent.action`:

```kotlin
val broadcastIntent = IncomingCallBroadcastReceiver.getIntent(this, intent.action!!, data)
```

The plugin's own `getIntent(...)` always sets the action, so the happy path is safe. But the Android framework can **recreate** the activity with no action — e.g. after process death / restore from recents, or a system relaunch (the activity carries `FLAG_ACTIVITY_NO_HISTORY`). When that happens `intent.action` is `null` and `!!` throws, crashing the app before the Flutter engine is involved (so it can't be caught from Dart).

## Change

Guard the null action instead of asserting. When there's no action there's nothing to dispatch, so the activity just finishes — same teardown as the normal path.

## Crash (production Crashlytics, 1.4.0)

```
Caused by java.lang.NullPointerException:
       at io.getstream.video.flutter.stream_video_push_notification.TransparentActivity.onCreate(TransparentActivity.kt:35)
       at android.app.Activity.performCreate(Activity.java:7994)
```

Closes #1255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the push notification system that could occur when the app was restored from the background or recovered from a process restart. This enhancement improves overall stability and reliability of push notifications during critical app lifecycle transitions and various edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->