### PR TITLE
fix(llc): improve reconnect reliability and fix strategy escalation

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed an issue where ringing a member during an ongoing call could prematurely end the call if they declined.
 - Fixed an issue where a failed call accept attempt left the CallKit call active on iOS.
+- Improved reconnect flow reliability: fixed several issues that could cause reconnection to stall or silently fail, including delayed disconnect detection on broken connections and reconnect strategy hints being dropped while a reconnect was already in progress.
+- Fixed fast reconnect escalating to rejoin after every single failure regardless of attempt count or connection health. Escalation now follows the same backoff and strategy-promotion logic used by all other reconnect modes.
 
 ## 1.4.0
 

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -373,6 +373,7 @@ class Call {
   Duration _fastReconnectDeadline = Duration.zero;
   SfuReconnectionStrategy _reconnectStrategy =
       SfuReconnectionStrategy.unspecified;
+  bool _isRejoinPending = false;
   Future<InternetStatus>? _awaitNetworkAvailableFuture;
   Future<Result<None>>? _awaitMigrationCompleteFuture;
   bool _initialized = false;
@@ -1054,6 +1055,7 @@ class Call {
     int maxJoinRetries = 3,
     String? reconnectReason,
     bool? hintHighScaleLivestreamPublisher,
+    bool disconnectOnMaxRetries = true,
   }) async {
     if (_callJoinLock.locked) {
       _logger.w(() => '[join] rejected (already joining)');
@@ -1138,13 +1140,15 @@ class Call {
         );
       }
 
-      await leave(
-        reason: DisconnectReason.failure(
-          VideoError(
-            message: 'failed to join after $maxJoinRetries attempts',
+      if (disconnectOnMaxRetries) {
+        await leave(
+          reason: DisconnectReason.failure(
+            VideoError(
+              message: 'failed to join after $maxJoinRetries attempts',
+            ),
           ),
-        ),
-      );
+        );
+      }
 
       return Result.error(
         'failed to join after $maxJoinRetries attempts',
@@ -1341,7 +1345,6 @@ class Call {
 
       if (result.isFailure) {
         _logger.e(() => '[join] fast reconnecting failed: $result');
-        _reconnectStrategy = SfuReconnectionStrategy.rejoin;
         return Result.error('fast reconnecting failed');
       }
 
@@ -1848,7 +1851,8 @@ class Call {
     SfuReconnectionStrategy strategy, {
     String? reconnectReason,
   }) async {
-    if (_callJoinLock.inLock) {
+    if (_callJoinLock.locked) {
+      if (strategy == SfuReconnectionStrategy.rejoin) _isRejoinPending = true;
       _logger.w(() => '[_reconnect] skipping reconnect (join in progress)');
       return;
     }
@@ -1859,6 +1863,7 @@ class Call {
     }
 
     if (_callReconnectLock.locked) {
+      if (strategy == SfuReconnectionStrategy.rejoin) _isRejoinPending = true;
       _logger.w(
         () =>
             '[reconnect] rejected $strategy (reconnect in progress: $_reconnectStrategy)',
@@ -1869,6 +1874,7 @@ class Call {
     await _callReconnectLock.synchronized(() async {
       _reconnectAttempts = 0;
       _reconnectStrategy = strategy;
+      _isRejoinPending = false;
 
       final reconnectStartTime = DateTime.now();
       var fastReconnectAttemptsCount = 0;
@@ -1941,26 +1947,63 @@ class Call {
 
           unawaited(_sfuStatsReporter?.sendSfuStats());
 
-          switch (_reconnectStrategy) {
-            case SfuReconnectionStrategy.unspecified:
-            case SfuReconnectionStrategy.disconnect:
-              _logger.v(
-                () => '[reconnect]  No-op strategy $_reconnectStrategy',
-              );
-            case SfuReconnectionStrategy.fast:
-              _logger.v(() => '[reconnect] fast reconnect');
-              await _reconnectFast(reason: reconnectReason);
-            case SfuReconnectionStrategy.rejoin:
-              _logger.v(() => '[reconnect] rejoin');
-              await _reconnectRejoin(reason: reconnectReason);
-            case SfuReconnectionStrategy.migrate:
-              _logger.v(() => '[reconnect] migrate');
-              await _reconnectMigrate(reason: reconnectReason);
-          }
+          // capture BEFORE dispatch — strategy may change inside the helper
+          final wasMigrating =
+              _reconnectStrategy == SfuReconnectionStrategy.migrate;
 
-          _session?.trace('callReconnectSuccess', {
-            'strategy': strategy.name,
-          });
+          final reconnectResult = switch (_reconnectStrategy) {
+            SfuReconnectionStrategy.fast => await _reconnectFast(
+              reason: reconnectReason,
+            ),
+            SfuReconnectionStrategy.rejoin => await _reconnectRejoin(
+              reason: reconnectReason,
+            ),
+            SfuReconnectionStrategy.migrate => await _reconnectMigrate(
+              reason: reconnectReason,
+            ),
+            _ => const Result.success(none),
+          };
+
+          if (reconnectResult.isSuccess) {
+            _session?.trace('callReconnectSuccess', {
+              'strategy': strategy.name,
+            });
+          } else {
+            _logger.w(
+              () =>
+                  '[reconnect] failed: ${reconnectResult.getErrorOrNull()}, '
+                  'strategy: $_reconnectStrategy, attempt: $_reconnectAttempts',
+            );
+
+            final delay = _reconnectStrategy == SfuReconnectionStrategy.fast
+                ? _retryPolicy.backoff(fastReconnectAttemptsCount)
+                : _retryPolicy.backoff(_reconnectAttempts);
+            await Future<void>.delayed(delay);
+
+            final mustPerformRejoin =
+                DateTime.now().difference(reconnectStartTime) >
+                _fastReconnectDeadline;
+
+            // don't immediately switch to the REJOIN strategy, but instead
+            // attempt to reconnect with the FAST strategy a few times first.
+            final hasPendingRejoin = _isRejoinPending;
+            _isRejoinPending = false;
+            final shouldRejoin =
+                hasPendingRejoin ||
+                mustPerformRejoin ||
+                wasMigrating ||
+                fastReconnectAttemptsCount >= 2 ||
+                !(_session?.rtcManager?.publisher?.isHealthy() ?? true) ||
+                !(_session?.rtcManager?.subscriber.isHealthy() ?? true);
+
+            if (!shouldRejoin) {
+              fastReconnectAttemptsCount++;
+            }
+
+            _reconnectStrategy = shouldRejoin
+                ? SfuReconnectionStrategy.rejoin
+                : SfuReconnectionStrategy.fast;
+          }
         } catch (error) {
           switch (error) {
             case OpenApiError() when error.apiError.unrecoverable ?? false:
@@ -1975,49 +2018,10 @@ class Call {
 
               return;
             default:
-              _logger.w(
+              _logger.e(
                 () =>
-                    '[reconnect] reconnect failed, error: $error, strategy: $_reconnectStrategy, attempt: $_reconnectAttempts. Attempting with Rejoin strategy',
+                    '[reconnect] unexpected error: $error, strategy: $_reconnectStrategy, attempt: $_reconnectAttempts',
               );
-
-              if (_reconnectStrategy == SfuReconnectionStrategy.fast) {
-                await Future<void>.delayed(
-                  _retryPolicy.backoff(fastReconnectAttemptsCount),
-                );
-              } else {
-                await Future<void>.delayed(
-                  _retryPolicy.backoff(_reconnectAttempts),
-                );
-              }
-
-              final wasMigrating =
-                  _reconnectStrategy == SfuReconnectionStrategy.migrate;
-
-              final mustPerformRejoin =
-                  DateTime.now().difference(reconnectStartTime) >
-                  _fastReconnectDeadline;
-
-              // don't immediately switch to the REJOIN strategy, but instead attempt
-              // to reconnect with the FAST strategy for a few times before switching.
-              // in some cases, we immediately switch to the REJOIN strategy.
-              final shouldRejoin =
-                  mustPerformRejoin ||
-                  wasMigrating || // if we were migrating, but the migration failed
-                  fastReconnectAttemptsCount >= 2 || // after 3 failed attempts
-                  !(_session?.rtcManager?.publisher?.isHealthy() ??
-                      true) || // if the publisher is not healthy
-                  !(_session?.rtcManager?.subscriber.isHealthy() ??
-                      true); // if the subscriber is not healthy
-
-              if (!shouldRejoin) {
-                fastReconnectAttemptsCount++;
-              }
-
-              final nextStrategy = shouldRejoin
-                  ? SfuReconnectionStrategy.rejoin
-                  : SfuReconnectionStrategy.fast;
-
-              _reconnectStrategy = nextStrategy;
           }
         }
       } while (state.value.status is! CallStatusConnected &&
@@ -2029,28 +2033,34 @@ class Call {
     });
   }
 
-  Future<void> _reconnectFast({String? reason}) async {
+  Future<Result<None>> _reconnectFast({String? reason}) async {
     _reconnectStrategy = SfuReconnectionStrategy.fast;
-    await _join(reconnectReason: reason);
+    return _join(
+      reconnectReason: reason,
+      maxJoinRetries: 1,
+      disconnectOnMaxRetries: false,
+    );
   }
 
-  Future<void> _reconnectRejoin({String? reason}) async {
+  Future<Result<None>> _reconnectRejoin({String? reason}) async {
     _reconnectAttempts++;
     _reconnectStrategy = SfuReconnectionStrategy.rejoin;
-    await _join(reconnectReason: reason);
+    return _join(reconnectReason: reason, disconnectOnMaxRetries: false);
   }
 
-  Future<void> _reconnectMigrate({String? reason}) async {
+  Future<Result<None>> _reconnectMigrate({String? reason}) async {
     final migrateTimeStopwatch = Stopwatch()..start();
 
     _reconnectAttempts++;
     _reconnectStrategy = SfuReconnectionStrategy.migrate;
-    final joinResult = await _join(reconnectReason: reason);
+    final joinResult = await _join(
+      reconnectReason: reason,
+      disconnectOnMaxRetries: false,
+    );
 
     if (joinResult.isFailure) {
       _logger.e(() => '[reconnectMigrate] join failed: $joinResult');
-      _reconnectStrategy = SfuReconnectionStrategy.rejoin;
-      return;
+      return joinResult;
     }
 
     await _previousSession?.close(StreamWebSocketCloseCode.disposeOldSocket);
@@ -2058,31 +2068,28 @@ class Call {
     final migrationResult = await _awaitMigrationCompleteFuture;
     if (migrationResult == null) {
       _logger.e(() => '[reconnectMigrate] migration failed');
-      _reconnectStrategy = SfuReconnectionStrategy.rejoin;
-      return;
+      return Result.error('migration failed');
     }
 
-    migrationResult.fold(
+    return migrationResult.fold<Result<None>>(
       success: (_) {
         _stateManager.lifecycleCallConnected();
+        migrateTimeStopwatch.stop();
+        unawaited(
+          _sfuStatsReporter?.sendSfuStats(
+            connectionTimeMs: migrateTimeStopwatch.elapsedMilliseconds,
+            reconnectionStrategy: _reconnectStrategy,
+          ),
+        );
+        return const Result.success(none);
       },
       failure: (_) {
         _logger.e(
           () => '[reconnectMigrate] migration did not complete correctly',
         );
-        _reconnectStrategy = SfuReconnectionStrategy.rejoin;
+        return Result.error('migration did not complete correctly');
       },
     );
-
-    if (migrationResult.isSuccess) {
-      migrateTimeStopwatch.stop();
-      unawaited(
-        _sfuStatsReporter?.sendSfuStats(
-          connectionTimeMs: migrateTimeStopwatch.elapsedMilliseconds,
-          reconnectionStrategy: _reconnectStrategy,
-        ),
-      );
-    }
   }
 
   /// Waits until the network becomes available **and** stays connected for
@@ -2173,6 +2180,10 @@ class Call {
                 '${stabilityWindow.inSeconds}s',
           );
           return InternetStatus.connected;
+        } catch (_) {
+          // Stream closed or unexpected error — treat as disconnected so the
+          // reconnect loop exits rather than spinning on a dead stream.
+          return InternetStatus.disconnected;
         }
       }
     } finally {

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -884,8 +884,11 @@ class CallSession extends Disposable {
       // After marking ICE restart, explicitly trigger renegotiation to create
       // a new offer with fresh ICE credentials and send it to the SFU.
       // pc.restartIce() only sets a flag; we must create and send the offer.
+      //
+      // Use unawaited so we don't hold _sfuEventsLock during the SetPublisher
+      // HTTP call.
       _logger.i(() => '[onIceRestart] triggering publisher renegotiation');
-      await _onRenegotiationNeeded(publisher);
+      unawaited(_onRenegotiationNeeded(publisher));
     } else if (peerType == StreamPeerType.subscriber) {
       final subscriber = rtcManager?.subscriber;
       if (subscriber == null) {

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -888,7 +888,23 @@ class CallSession extends Disposable {
       // Use unawaited so we don't hold _sfuEventsLock during the SetPublisher
       // HTTP call.
       _logger.i(() => '[onIceRestart] triggering publisher renegotiation');
-      unawaited(_onRenegotiationNeeded(publisher));
+      unawaited(
+        _onRenegotiationNeeded(publisher)
+            .then((result) {
+              if (result.isFailure) {
+                _logger.w(
+                  () =>
+                      '[onIceRestart] publisher renegotiation failed: '
+                      '${result.getErrorOrNull()}',
+                );
+              }
+            })
+            .catchError((Object e, StackTrace stk) {
+              _logger.e(
+                () => '[onIceRestart] publisher renegotiation error: $e\n$stk',
+              );
+            }),
+      );
     } else if (peerType == StreamPeerType.subscriber) {
       final subscriber = rtcManager?.subscriber;
       if (subscriber == null) {

--- a/packages/stream_video/lib/src/sfu/sfu_client.dart
+++ b/packages/stream_video/lib/src/sfu/sfu_client.dart
@@ -27,6 +27,8 @@ class SfuClient {
     String prefix = '',
     ClientHooks? hooks,
     List<Interceptor> interceptors = const [],
+    this.rpcTimeout = const Duration(seconds: 10),
+    this.rpcMaxRetries = 3,
   }) : _client = signal_twirp.SignalServerProtobufClient(
          baseUrl,
          prefix,
@@ -42,6 +44,8 @@ class SfuClient {
 
   final int sessionSeq;
   final String sfuToken;
+  final Duration rpcTimeout;
+  final int rpcMaxRetries;
 
   int _retryInterval(int numberOfFailures) {
     // try to reconnect in 0.25-5 seconds (random to spread out the load from failures)
@@ -52,23 +56,21 @@ class SfuClient {
 
   Future<Result<T>> _executeWithRetry<T extends GeneratedMessage>({
     required Future<T> Function() call,
-    int maxRetries = 3,
-    Duration timeout = const Duration(seconds: 10),
   }) async {
     var attempt = 0;
     dynamic dynamicResponse;
 
-    while (attempt < maxRetries) {
+    while (attempt < rpcMaxRetries) {
       try {
         final response = await call().timeout(
-          timeout,
+          rpcTimeout,
           onTimeout: () {
             _logger.w(
               () =>
                   '[_executeWithRetry] SFU HTTP call timed out after '
-                  '${timeout.inSeconds}s',
+                  '${rpcTimeout.inSeconds}s',
             );
-            throw TimeoutException('SFU HTTP call timed out', timeout);
+            throw TimeoutException('SFU HTTP call timed out', rpcTimeout);
           },
         );
 
@@ -80,7 +82,7 @@ class SfuClient {
 
           if (error.shouldRetry) {
             attempt++;
-            if (attempt < maxRetries) {
+            if (attempt < rpcMaxRetries) {
               await Future<void>.delayed(
                 Duration(milliseconds: _retryInterval(attempt)),
               );
@@ -93,15 +95,15 @@ class SfuClient {
         }
 
         return Result.success(response);
-      } on TimeoutException {
+      } on TimeoutException catch (e, stk) {
         attempt++;
-        if (attempt < maxRetries) {
+        if (attempt < rpcMaxRetries) {
           await Future<void>.delayed(
             Duration(milliseconds: _retryInterval(attempt)),
           );
           continue;
         }
-        rethrow;
+        return Result.failure(VideoErrors.compose(e, stk));
       }
     }
 

--- a/packages/stream_video/lib/src/sfu/sfu_client.dart
+++ b/packages/stream_video/lib/src/sfu/sfu_client.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_dynamic_calls
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:protobuf/protobuf.dart';
@@ -52,12 +53,19 @@ class SfuClient {
   Future<Result<T>> _executeWithRetry<T extends GeneratedMessage>({
     required Future<T> Function() call,
     int maxRetries = 3,
+    Duration timeout = const Duration(seconds: 10),
   }) async {
     var attempt = 0;
     dynamic dynamicResponse;
 
     while (attempt < maxRetries) {
-      final response = await call();
+      final response = await call().timeout(
+        timeout,
+        onTimeout: () {
+          _logger.w(() => '[_executeWithRetry] SFU HTTP call timed out after ${timeout.inSeconds}s');
+          throw TimeoutException('SFU HTTP call timed out', timeout);
+        },
+      );
       dynamicResponse = response as dynamic;
 
       if (dynamicResponse.hasError != null &&

--- a/packages/stream_video/lib/src/sfu/sfu_client.dart
+++ b/packages/stream_video/lib/src/sfu/sfu_client.dart
@@ -59,35 +59,50 @@ class SfuClient {
     dynamic dynamicResponse;
 
     while (attempt < maxRetries) {
-      final response = await call().timeout(
-        timeout,
-        onTimeout: () {
-          _logger.w(() => '[_executeWithRetry] SFU HTTP call timed out after ${timeout.inSeconds}s');
-          throw TimeoutException('SFU HTTP call timed out', timeout);
-        },
-      );
-      dynamicResponse = response as dynamic;
-
-      if (dynamicResponse.hasError != null &&
-          dynamicResponse.hasError() &&
-          dynamicResponse.error is sfu_models.Error) {
-        final error = dynamicResponse.error as sfu_models.Error;
-
-        if (error.shouldRetry) {
-          attempt++;
-          if (attempt < maxRetries) {
-            await Future<void>.delayed(
-              Duration(milliseconds: _retryInterval(attempt)),
+      try {
+        final response = await call().timeout(
+          timeout,
+          onTimeout: () {
+            _logger.w(
+              () =>
+                  '[_executeWithRetry] SFU HTTP call timed out after '
+                  '${timeout.inSeconds}s',
             );
-            continue;
-          }
-        }
-        return Result.failure(
-          VideoErrors.compose(error, StackTrace.current),
+            throw TimeoutException('SFU HTTP call timed out', timeout);
+          },
         );
-      }
 
-      return Result.success(response);
+        dynamicResponse = response as dynamic;
+        if (dynamicResponse.hasError != null &&
+            dynamicResponse.hasError() &&
+            dynamicResponse.error is sfu_models.Error) {
+          final error = dynamicResponse.error as sfu_models.Error;
+
+          if (error.shouldRetry) {
+            attempt++;
+            if (attempt < maxRetries) {
+              await Future<void>.delayed(
+                Duration(milliseconds: _retryInterval(attempt)),
+              );
+              continue;
+            }
+          }
+          return Result.failure(
+            VideoErrors.compose(error, StackTrace.current),
+          );
+        }
+
+        return Result.success(response);
+      } on TimeoutException {
+        attempt++;
+        if (attempt < maxRetries) {
+          await Future<void>.delayed(
+            Duration(milliseconds: _retryInterval(attempt)),
+          );
+          continue;
+        }
+        rethrow;
+      }
     }
 
     return Result.failure(

--- a/packages/stream_video/test/src/call/call_audio_processing_test.dart
+++ b/packages/stream_video/test/src/call/call_audio_processing_test.dart
@@ -682,10 +682,12 @@ void main() {
           await Future<void>.delayed(Duration.zero);
           internetStatusController.add(InternetStatus.connected);
 
-          // Poll until the rejoin path calls setAudioProcessingEnabled(true)
-          // again, rather than relying on a fixed sleep duration.
+          // Fast reconnect failure now correctly propagates to the outer
+          // reconnect loop, which runs a 3-second stability window before
+          // attempting REJOIN. Allow 5 seconds total for the rejoin + rebind.
           await _waitForMockCall(
             () => mockStreamVideo.setAudioProcessingEnabled(true),
+            timeout: const Duration(seconds: 5),
           );
         },
       );

--- a/packages/stream_video/test/src/call/call_reconnect_stability_test.dart
+++ b/packages/stream_video/test/src/call/call_reconnect_stability_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:mocktail/mocktail.dart';
@@ -372,6 +374,174 @@ void main() {
           ),
         );
       },
+    );
+
+    test(
+      'rejoin hint received while reconnect lock is held is not dropped',
+      () async {
+        // Override start() to return a long fastReconnectDeadline so
+        // mustPerformRejoin stays false — this isolates the _isRejoinPending
+        // flag as the sole driver of escalation.
+        when(
+          () => callSession.start(
+            reconnectDetails: any(named: 'reconnectDetails'),
+            onRtcManagerCreatedCallback: any(
+              named: 'onRtcManagerCreatedCallback',
+            ),
+            isAnonymousUser: any(named: 'isAnonymousUser'),
+            capabilities: any(named: 'capabilities'),
+            unifiedSessionId: any(named: 'unifiedSessionId'),
+          ),
+        ).thenAnswer(
+          (_) => Future.value(
+            Result.success((
+              callState: createTestSfuCallState(),
+              fastReconnectDeadline: const Duration(minutes: 5),
+            )),
+          ),
+        );
+
+        // fastReconnect hangs until we release the gate.
+        final fastReconnectGate = Completer<void>();
+        when(
+          () => callSession.fastReconnect(
+            reconnectDetails: any(named: 'reconnectDetails'),
+            capabilities: any(named: 'capabilities'),
+            unifiedSessionId: any(named: 'unifiedSessionId'),
+          ),
+        ).thenAnswer((_) async {
+          await fastReconnectGate.future;
+          return Result.error('simulated fast reconnect failure');
+        });
+
+        final call = buildCall();
+        await call.join();
+
+        // Consume the initial joinCall.
+        verify(
+          () => coordinatorClient.joinCall(
+            callCid: any(named: 'callCid'),
+            ringing: any(named: 'ringing'),
+            create: any(named: 'create'),
+            migratingFrom: any(named: 'migratingFrom'),
+            migratingFromList: any(named: 'migratingFromList'),
+            video: any(named: 'video'),
+            membersLimit: any(named: 'membersLimit'),
+          ),
+        ).called(1);
+
+        // Start a fast reconnect — the loop acquires the reconnect lock and
+        // hangs waiting for fastReconnectGate.
+        capturedCallback!(mockPc, SfuReconnectionStrategy.fast);
+        // Wait long enough for the lock to be acquired.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // Signal a rejoin hint while the reconnect lock is held. The call
+        // must record _isRejoinPending=true and not discard the hint.
+        capturedCallback!(mockPc, SfuReconnectionStrategy.rejoin);
+
+        // Release the gate: fast reconnect fails. The loop sees
+        // _isRejoinPending=true → shouldRejoin=true → strategy switches to
+        // rejoin → awaits 3s stability window → issues a second joinCall.
+        fastReconnectGate.complete();
+
+        // 3 s stability window + margin.
+        await Future<void>.delayed(const Duration(milliseconds: 3500));
+
+        verify(
+          () => coordinatorClient.joinCall(
+            callCid: any(named: 'callCid'),
+            ringing: any(named: 'ringing'),
+            create: any(named: 'create'),
+            migratingFrom: any(named: 'migratingFrom'),
+            migratingFromList: any(named: 'migratingFromList'),
+            video: any(named: 'video'),
+            membersLimit: any(named: 'membersLimit'),
+          ),
+        ).called(1);
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
+
+    test(
+      'fast reconnect escalates to rejoin after three consecutive failures',
+      () async {
+        // A long fastReconnectDeadline keeps mustPerformRejoin false so only
+        // fastReconnectAttemptsCount >= 2 drives the escalation to rejoin.
+        when(
+          () => callSession.start(
+            reconnectDetails: any(named: 'reconnectDetails'),
+            onRtcManagerCreatedCallback: any(
+              named: 'onRtcManagerCreatedCallback',
+            ),
+            isAnonymousUser: any(named: 'isAnonymousUser'),
+            capabilities: any(named: 'capabilities'),
+            unifiedSessionId: any(named: 'unifiedSessionId'),
+          ),
+        ).thenAnswer(
+          (_) => Future.value(
+            Result.success((
+              callState: createTestSfuCallState(),
+              fastReconnectDeadline: const Duration(minutes: 5),
+            )),
+          ),
+        );
+
+        var fastReconnectCallCount = 0;
+        when(
+          () => callSession.fastReconnect(
+            reconnectDetails: any(named: 'reconnectDetails'),
+            capabilities: any(named: 'capabilities'),
+            unifiedSessionId: any(named: 'unifiedSessionId'),
+          ),
+        ).thenAnswer((_) async {
+          fastReconnectCallCount++;
+          return Result.error('simulated fast reconnect failure');
+        });
+
+        final call = buildCall();
+        await call.join();
+
+        verify(
+          () => coordinatorClient.joinCall(
+            callCid: any(named: 'callCid'),
+            ringing: any(named: 'ringing'),
+            create: any(named: 'create'),
+            migratingFrom: any(named: 'migratingFrom'),
+            migratingFromList: any(named: 'migratingFromList'),
+            video: any(named: 'video'),
+            membersLimit: any(named: 'membersLimit'),
+          ),
+        ).called(1);
+
+        // Trigger the reconnect loop. Fast reconnect fails 3 times before
+        // fastReconnectAttemptsCount >= 2 causes escalation to rejoin.
+        capturedCallback!(mockPc, SfuReconnectionStrategy.fast);
+
+        // 3 fast-reconnect failures (near-instant with zero backoff) +
+        // 3 s stability window for the subsequent rejoin + margin.
+        await Future<void>.delayed(const Duration(milliseconds: 3500));
+
+        expect(
+          fastReconnectCallCount,
+          3,
+          reason: 'should attempt fast reconnect exactly 3 times before escalating',
+        );
+
+        // After escalation the rejoin path issues a second joinCall.
+        verify(
+          () => coordinatorClient.joinCall(
+            callCid: any(named: 'callCid'),
+            ringing: any(named: 'ringing'),
+            create: any(named: 'create'),
+            migratingFrom: any(named: 'migratingFrom'),
+            migratingFromList: any(named: 'migratingFromList'),
+            video: any(named: 'video'),
+            membersLimit: any(named: 'membersLimit'),
+          ),
+        ).called(1);
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
     );
   });
 }

--- a/packages/stream_video/test/src/call/call_reconnect_stability_test.dart
+++ b/packages/stream_video/test/src/call/call_reconnect_stability_test.dart
@@ -525,7 +525,8 @@ void main() {
         expect(
           fastReconnectCallCount,
           3,
-          reason: 'should attempt fast reconnect exactly 3 times before escalating',
+          reason:
+              'should attempt fast reconnect exactly 3 times before escalating',
         );
 
         // After escalation the rejoin path issues a second joinCall.

--- a/packages/stream_video/test/src/sfu/sfu_client_timeout_test.dart
+++ b/packages/stream_video/test/src/sfu/sfu_client_timeout_test.dart
@@ -1,0 +1,57 @@
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_video/protobuf/video/sfu/signal_rpc/signal.pb.dart'
+    as sfu;
+import 'package:stream_video/src/call/stats/tracer.dart';
+import 'package:stream_video/src/sfu/sfu_client.dart';
+import 'package:tart/tart.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SfuClient RPC timeout', () {
+    test(
+      'returns Result.failure when the SFU HTTP call hangs past rpcTimeout',
+      () async {
+        // An interceptor that never resolves — simulates a hung upstream.
+        // The Completer must carry the concrete response type so tart's
+        // return-type check in sendAnswer(...) async { return interceptor...}
+        // does not fail before the timeout fires.
+        Method<dynamic, dynamic> hangingInterceptor(
+          Method<dynamic, dynamic> next,
+        ) {
+          return (Context ctx, dynamic req) =>
+              Completer<sfu.SendAnswerResponse>().future;
+        }
+
+        final client = SfuClient(
+          baseUrl: 'http://localhost:0',
+          sfuToken: 'test-token',
+          sessionSeq: 0,
+          tracer: Tracer(null),
+          interceptors: [hangingInterceptor],
+          rpcTimeout: const Duration(milliseconds: 100),
+          rpcMaxRetries: 1,
+        );
+
+        final stopwatch = Stopwatch()..start();
+        final result = await client.sendAnswer(sfu.SendAnswerRequest());
+        stopwatch.stop();
+
+        expect(
+          result.isFailure,
+          isTrue,
+          reason: 'hanging call must return failure after timeout',
+        );
+        expect(
+          stopwatch.elapsed,
+          lessThan(const Duration(milliseconds: 1000)),
+          reason: 'must fail well before the default 10 s timeout',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable SFU RPC controls on `SfuClient`, including RPC timeout and maximum retries.
- **Bug Fixes**
  - Improved reconnect reliability by preserving “rejoin pending” signals during fast reconnect, avoiding dropped hints, and preventing fast-reconnect failures from repeatedly escalating to rejoin.
  - Hardened reconnect stability so unexpected disconnections/timeouts exit cleanly.
  - Fixed audio processing filter rebinding timing after rejoin/migrate flows.
- **Tests**
  - Added reconnect stability and SFU RPC timeout coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->