### PR TITLE
fix(samples): replace login email with name

### DIFF
--- a/dogfooding/lib/screens/login_screen.dart
+++ b/dogfooding/lib/screens/login_screen.dart
@@ -28,7 +28,8 @@ class LoginScreen extends StatefulWidget {
 
 class _LoginScreenState extends State<LoginScreen> {
   final _appPreferences = locator<AppPreferences>();
-  final _emailController = TextEditingController();
+  final _userNameController = TextEditingController();
+  var _userNameHasError = false;
 
   Future<void> _loginWithGoogle() async {
     final googleService = locator<GoogleSignIn>();
@@ -62,14 +63,24 @@ class _LoginScreenState extends State<LoginScreen> {
     return _login(User(info: userInfo), _appPreferences.environment);
   }
 
-  Future<void> _loginWithEmail() async {
-    final email = _emailController.text;
-    if (email.isEmpty) return debugPrint('Email is empty');
+  Future<void> _loginWithName() async {
+    final userName = _userNameController.text;
+    if (userName.isEmpty) {
+      setState(() {
+        _userNameHasError = true;
+      });
+      return debugPrint('User name is empty');
+    }
+    if (_userNameHasError) {
+      setState(() {
+        _userNameHasError = false;
+      });
+    }
 
     final userInfo = UserInfo(
       role: 'admin',
-      id: createValidId(email),
-      name: email,
+      id: createValidId(userName),
+      name: userName,
     );
 
     return _login(User(info: userInfo), _appPreferences.environment);
@@ -114,7 +125,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   void dispose() {
-    _emailController.dispose();
+    _userNameController.dispose();
     super.dispose();
   }
 
@@ -162,14 +173,17 @@ class _LoginScreenState extends State<LoginScreen> {
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 16),
                     child: TextField(
-                      controller: _emailController,
+                      controller: _userNameController,
                       style: theme.textTheme.bodyMedium?.apply(
                         color: Colors.white,
                       ),
-                      decoration: const InputDecoration(
-                        labelText: 'Enter Email',
+                      decoration: InputDecoration(
+                        labelText: 'Choose display name',
                         isDense: true,
-                        border: OutlineInputBorder(),
+                        border: const OutlineInputBorder(),
+                        errorText: _userNameHasError
+                            ? 'Please enter a name'
+                            : null,
                       ),
                     ),
                   ),
@@ -177,12 +191,8 @@ class _LoginScreenState extends State<LoginScreen> {
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 16),
                     child: StreamButton.active(
-                      label: 'Sign up with email',
-                      icon: const Icon(
-                        Icons.email_outlined,
-                        color: Colors.white,
-                      ),
-                      onPressed: _loginWithEmail,
+                      label: 'Continue',
+                      onPressed: _loginWithName,
                     ),
                   ),
                   const SizedBox(height: 16),


### PR DESCRIPTION
### 🎯 Goal

The login screen is confusing for many people because of the login with email.

### 🛠 Implementation details

This replaces the email with a display name, how it's also actually working. 
The React pronto app only asks the name later, but that would be a bigger change.

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| <img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/08a244e9-1721-4fa7-aadf-43b4280634f3" /> | <img width="1988" height="1117" alt="image" src="https://github.com/user-attachments/assets/40ea6f64-020a-44d4-a16c-1bedec780c18" /> |

from pronto: 
<img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/ae0f0d30-0724-47d9-8b58-74506783a4f0" />

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [x] Sample runs & works
- [x] UI Changes correct (before & after images)
- [x] Bugs validated (bugfixes)
- [x] New feature tested and works
- [x] All code we touched has new or updated Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The login screen now lets users choose a display name instead of entering an email.
  * Added clearer validation for empty display names, with inline error feedback.
  * Updated the primary action to continue with the chosen display name.

* **Bug Fixes**
  * Improved the login flow so the entered name is used consistently when signing in.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->