### PR TITLE
fix(llc): rejoin escalation fixes

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ### 🐞 Fixed
 
+- Reconnection now keeps trying a fast reconnect for the full fast-reconnect deadline before escalating to a full rejoin.
+  - A failed ICE restart now triggers a fast reconnect and lets the reconnect loop decide when to escalate, rather than jumping straight to a rejoin.
+  - A `failed` peer-connection state now enters the reconnect loop with the fast strategy instead of forcing an immediate rejoin.
+  - A transient ICE `disconnected` state is no longer treated as unhealthy, only a permanently `closed` peer connection forces an immediate rejoin.
 - Fixed connection quality indicator blanking after reconnect.
 - Fixed SFU stats not being flushed on call end.
 

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2063,17 +2063,22 @@ class Call {
                 DateTime.now().difference(reconnectStartTime) >
                 _fastReconnectDeadline;
 
-            // don't immediately switch to the REJOIN strategy, but instead
-            // attempt to reconnect with the FAST strategy a few times first.
             final hasPendingRejoin = _isRejoinPending;
             _isRejoinPending = false;
+
+            final hasClosedPeerConnection =
+                (_session?.rtcManager?.publisher?.isClosed() ?? false) ||
+                (_session?.rtcManager?.subscriber.isClosed() ?? false);
+
+            final hasReachedFastReconnectLimit =
+                fastReconnectAttemptsCount >= 2;
+
             final shouldRejoin =
                 hasPendingRejoin ||
                 mustPerformRejoin ||
                 wasMigrating ||
-                fastReconnectAttemptsCount >= 2 ||
-                !(_session?.rtcManager?.publisher?.isHealthy() ?? true) ||
-                !(_session?.rtcManager?.subscriber.isHealthy() ?? true);
+                hasReachedFastReconnectLimit ||
+                hasClosedPeerConnection;
 
             if (!shouldRejoin) {
               fastReconnectAttemptsCount++;

--- a/packages/stream_video/lib/src/call/call.dart
+++ b/packages/stream_video/lib/src/call/call.dart
@@ -2073,7 +2073,11 @@ class Call {
             final hasReachedFastReconnectLimit =
                 fastReconnectAttemptsCount >= 2;
 
+            final isAlreadyRejoining =
+                _reconnectStrategy == SfuReconnectionStrategy.rejoin;
+
             final shouldRejoin =
+                isAlreadyRejoining ||
                 hasPendingRejoin ||
                 mustPerformRejoin ||
                 wasMigrating ||

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -46,8 +46,6 @@ const _tag = 'SV:CallSession';
 const _debounceDuration = Duration(milliseconds: 200);
 const _migrationCompleteEventTimeout = Duration(seconds: 7);
 const _publisherConnectionCheckDelay = Duration(seconds: 15);
-const _maxPublisherNegotiationAttempts = 3;
-const _publisherNegotiationRetryDelay = Duration(milliseconds: 300);
 
 class CallSession extends Disposable {
   CallSession({

--- a/packages/stream_video/lib/src/call/session/call_session.dart
+++ b/packages/stream_video/lib/src/call/session/call_session.dart
@@ -46,6 +46,8 @@ const _tag = 'SV:CallSession';
 const _debounceDuration = Duration(milliseconds: 200);
 const _migrationCompleteEventTimeout = Duration(seconds: 7);
 const _publisherConnectionCheckDelay = Duration(seconds: 15);
+const _maxPublisherNegotiationAttempts = 3;
+const _publisherNegotiationRetryDelay = Duration(milliseconds: 300);
 
 class CallSession extends Disposable {
   CallSession({
@@ -584,18 +586,18 @@ class CallSession extends Disposable {
     }
   }
 
-  /// Starts a one-shot timer that verifies the publisher's ICE transport
-  /// transitions out of the `new` state within [_publisherConnectionCheckDelay].
+  /// Checks after [_publisherConnectionCheckDelay] that the publisher finished
+  /// connecting.
   ///
-  /// If the transport is still `new` after the deadline, the SDP answer was
-  /// likely never received (e.g. network dropped before the SFU could reply)
-  /// and we trigger a reconnection.
+  /// Recovers two stalls: ICE still `new` (likely no SDP answer) → rejoin;
+  /// signaling `have-local-offer` (SetPublisher incomplete, no further
+  /// negotiation) → renegotiate, then rejoin if needed.
   void startPublisherConnectionCheck() {
     _publisherConnectionCheckTimer?.cancel();
 
     _publisherConnectionCheckTimer = Timer(
       _publisherConnectionCheckDelay,
-      () {
+      () async {
         if (_isLeavingOrClosed) return;
 
         final publisher = rtcManager?.publisher;
@@ -613,14 +615,45 @@ class CallSession extends Disposable {
             'iceState': iceState.toString(),
             'timeoutSeconds': _publisherConnectionCheckDelay.inSeconds,
           });
+
           onReconnectionNeeded(publisher, SfuReconnectionStrategy.rejoin);
-        } else {
-          _logger.v(
-            () =>
-                '[publisherConnectionCheck] publisher ICE state: '
-                '$iceState — OK',
-          );
+          return;
         }
+
+        // Signaling stall: local offer created but SetPublisher never completed,
+        // leaving the peer connection wedged in `have-local-offer`. Negotiation
+        // won't resume on its own, so renegotiate and rejoin if recovery fails.
+        final signalingState = publisher.pc.signalingState;
+        if (signalingState ==
+            rtc.RTCSignalingState.RTCSignalingStateHaveLocalOffer) {
+          _logger.w(
+            () =>
+                '[publisherConnectionCheck] publisher stuck in '
+                '"have-local-offer" after '
+                '${_publisherConnectionCheckDelay.inSeconds}s — renegotiating',
+          );
+          _tracer.trace(TraceTag.publisherConnectionCheckStalled, {
+            'signalingState': signalingState.toString(),
+            'timeoutSeconds': _publisherConnectionCheckDelay.inSeconds,
+          });
+
+          final result = await _onRenegotiationNeeded(publisher);
+          if (result.isFailure && !_isLeavingOrClosed) {
+            _logger.w(
+              () =>
+                  '[publisherConnectionCheck] recovery renegotiation failed '
+                  '(${result.getErrorOrNull()}) — triggering rejoin',
+            );
+            onReconnectionNeeded(publisher, SfuReconnectionStrategy.rejoin);
+          }
+          return;
+        }
+
+        _logger.v(
+          () =>
+              '[publisherConnectionCheck] publisher ICE state: '
+              '$iceState — OK',
+        );
       },
     );
   }

--- a/packages/stream_video/lib/src/webrtc/peer_connection.dart
+++ b/packages/stream_video/lib/src/webrtc/peer_connection.dart
@@ -5,7 +5,6 @@ import 'package:stream_webrtc_flutter/stream_webrtc_flutter.dart' as rtc;
 import '../../protobuf/video/sfu/models/models.pbenum.dart';
 import '../../protobuf/video/sfu/signal_rpc/signal.pb.dart';
 import '../disposable.dart';
-import '../errors/video_error.dart';
 import '../errors/video_error_composer.dart';
 import '../logger/impl/tagged_logger.dart';
 import '../models/call_cid.dart';
@@ -141,16 +140,7 @@ class StreamPeerConnection extends Disposable {
 
     restartIce().then((result) {
       if (result.isFailure) {
-        final error = result.getErrorOrNull();
-        if (error is VideoErrorWithCause && error.cause is SfuError) {
-          final sfuError = error.cause as SfuError;
-          if (sfuError.code == SfuErrorCode.participantSignalLost) {
-            onReconnectionNeeded?.call(this, SfuReconnectionStrategy.fast);
-            return;
-          }
-        }
-
-        onReconnectionNeeded?.call(this, SfuReconnectionStrategy.rejoin);
+        onReconnectionNeeded?.call(this, SfuReconnectionStrategy.fast);
       }
     });
   }
@@ -393,22 +383,28 @@ class StreamPeerConnection extends Disposable {
 
   /// Checks if the `RTCPeerConnection` is healthy.
   /// It checks the ICE connection state and the peer connection state.
-  /// If either state is `failed`, `disconnected`, or `closed`,
-  /// it returns `false`, otherwise it returns `true`.
+  /// A `failed` or `closed` state is considered unhealthy.
   bool isHealthy() {
     const failedStates = {
       rtc.RTCIceConnectionState.RTCIceConnectionStateFailed,
       rtc.RTCIceConnectionState.RTCIceConnectionStateClosed,
-      rtc.RTCIceConnectionState.RTCIceConnectionStateDisconnected,
       rtc.RTCPeerConnectionState.RTCPeerConnectionStateFailed,
       rtc.RTCPeerConnectionState.RTCPeerConnectionStateClosed,
-      rtc.RTCPeerConnectionState.RTCPeerConnectionStateDisconnected,
     };
 
     final iceState = pc.iceConnectionState;
     final connectionState = pc.connectionState;
     return !failedStates.contains(iceState) &&
         !failedStates.contains(connectionState);
+  }
+
+  /// Whether the `RTCPeerConnection` is permanently closed and therefore
+  /// cannot be recovered by an ICE restart / fast reconnect.
+  bool isClosed() {
+    return pc.iceConnectionState ==
+            rtc.RTCIceConnectionState.RTCIceConnectionStateClosed ||
+        pc.connectionState ==
+            rtc.RTCPeerConnectionState.RTCPeerConnectionStateClosed;
   }
 
   void _initRtcCallbacks() {
@@ -517,7 +513,7 @@ class StreamPeerConnection extends Disposable {
 
     if (state == rtc.RTCPeerConnectionState.RTCPeerConnectionStateFailed) {
       _logger.w(() => '[onConnectionState] state: $state');
-      onReconnectionNeeded?.call(this, SfuReconnectionStrategy.rejoin);
+      onReconnectionNeeded?.call(this, SfuReconnectionStrategy.fast);
     } else {
       _logger.v(() => '[onConnectionState] state: $state');
     }

--- a/packages/stream_video/test/src/call/session/call_session_reconnect_safety_test.dart
+++ b/packages/stream_video/test/src/call/session/call_session_reconnect_safety_test.dart
@@ -244,6 +244,73 @@ void main() {
         expect(called, 0);
       });
     });
+
+    test(
+      'renegotiates and escalates to rejoin when the publisher is wedged in '
+      '"have-local-offer" after the delay',
+      () {
+        fakeAsync((async) {
+          final reconnects =
+              <(StreamPeerConnection, SfuReconnectionStrategy)>[];
+          final session = _buildTestSession(
+            onReconnectionNeeded: (pc, strategy) =>
+                reconnects.add((pc, strategy)),
+          );
+          // ICE progressed past "new", so the ICE-stall branch does NOT fire.
+          final wires = _wirePublisher(
+            session,
+            iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateConnected,
+          );
+          // ...but the publisher created a local offer and never completed
+          // SetPublisher, so it is stuck in have-local-offer.
+          when(() => wires.pc.signalingState).thenReturn(
+            rtc.RTCSignalingState.RTCSignalingStateHaveLocalOffer,
+          );
+
+          session.startPublisherConnectionCheck();
+          async
+            ..elapse(const Duration(seconds: 16))
+            ..flushMicrotasks();
+
+          // The recovery renegotiation cannot complete (no SFU connection in
+          // the test), so the watchdog falls back to a full rejoin.
+          expect(reconnects, hasLength(1));
+          expect(reconnects.single.$1, same(wires.publisher));
+          expect(reconnects.single.$2, SfuReconnectionStrategy.rejoin);
+        });
+      },
+    );
+
+    test(
+      'does NOT trigger recovery when the publisher signaling state is '
+      'stable',
+      () {
+        fakeAsync((async) {
+          var called = 0;
+          final session = _buildTestSession(
+            onReconnectionNeeded: (_, __) => called++,
+          );
+          final wires = _wirePublisher(
+            session,
+            iceState: rtc.RTCIceConnectionState.RTCIceConnectionStateConnected,
+          );
+          when(() => wires.pc.signalingState).thenReturn(
+            rtc.RTCSignalingState.RTCSignalingStateStable,
+          );
+
+          session.startPublisherConnectionCheck();
+          async
+            ..elapse(const Duration(seconds: 16))
+            ..flushMicrotasks();
+
+          expect(
+            called,
+            0,
+            reason: 'publisher is connected and stable — nothing to recover',
+          );
+        });
+      },
+    );
   });
 
   group('CallSession.getReconnectDetails', () {

--- a/packages/stream_video/test/src/webrtc/peer_connection_renegotiation_test.dart
+++ b/packages/stream_video/test/src/webrtc/peer_connection_renegotiation_test.dart
@@ -190,7 +190,7 @@ void main() {
 
   group('StreamPeerConnection.onConnectionState', () {
     test(
-      'fires onReconnectionNeeded with rejoin when the peer enters Failed',
+      'fires onReconnectionNeeded with fast when the peer enters Failed',
       () {
         final pc = _FakeRtcPeerConnection();
         final sp = _build(pc: pc, type: StreamPeerType.publisher);
@@ -205,7 +205,7 @@ void main() {
 
         expect(calls, hasLength(1));
         expect(calls.single.$1, same(sp));
-        expect(calls.single.$2, SfuReconnectionStrategy.rejoin);
+        expect(calls.single.$2, SfuReconnectionStrategy.fast);
       },
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call recovery by keeping fast reconnection attempts active until the fast-reconnect deadline before escalating.
  * ICE restart and peer-connection failures now trigger fast reconnection rather than an immediate rejoin.
  * Transient ICE `disconnected` no longer forces an unhealthy-path rejoin; only permanently `closed` connections do.
  * Enhanced publisher recovery for stalled negotiation scenarios, including `new` ICE and stuck `have-local-offer` signaling.
* **Tests**
  * Added and updated reconnection test cases to reflect the new fast/rejoin decision behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->