### PR TITLE
fix(llc): duplicate track publishing fix

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 🐞 Fixed
 
+- Fixed duplicate publisher tracks: concurrent enable/publish calls of the same type (e.g. a double camera enable racing the join flow) could create two senders for the same track type, which the SFU rejects with a forced rejoin loop. A publish now claims its `(trackType, publishOptionId)` before creating the sender, so a concurrent one reuses that sender instead of adding a second, and a repeated enable joins the media acquisition already in flight rather than opening the camera twice.
 - Fixed the publisher announcing a stale track `mid` after a renegotiation or publish retry. It's now resolved from the current peer-connection state so the SFU can reliably match the track to its media.
 - Serialized remote-description and ICE-candidate handling so a candidate arriving mid-negotiation can no longer be dropped.
 - Fixed an issue where republishing could reuse a cached publisher transceiver without renegotiating.

--- a/packages/stream_video/lib/src/webrtc/rtc_manager.dart
+++ b/packages/stream_video/lib/src/webrtc/rtc_manager.dart
@@ -50,6 +50,14 @@ typedef OnRemoteTrackReceived =
 
 const _tag = 'SV:RtcManager';
 
+/// How long [PublisherRtcManager.getAnnouncedTracks] waits for in-flight
+/// transceiver creations before giving up on the current negotiation.
+///
+/// `addTransceiver` is a sub-100ms platform call in practice; anything near
+/// this is wedged, and a wedged publisher recovers through a reconnect rather
+/// than by waiting longer.
+const _pendingTransceiverSettleTimeout = Duration(seconds: 5);
+
 class RtcManager extends Disposable {
   RtcManager({
     required this.sessionId,
@@ -87,6 +95,40 @@ class RtcManager extends Disposable {
   final StreamPeerConnectionFactory pcFactory;
 
   final transceiversManager = TransceiverManager();
+
+  bool _isDisposing = false;
+
+  /// Publishes that have claimed a `(trackType, publishOptionId)` and are
+  /// still creating their transceiver.
+  final _pendingTransceivers = <TransceiverKey, Future<void>>{};
+
+  /// Track creations (`getUserMedia` and the publish that follows) in flight
+  /// per track type, so a double "enable" opens the camera once instead of
+  /// twice.
+  final _pendingTrackCreations =
+      <SfuTrackType, Future<Result<RtcLocalTrack>>>{};
+
+  /// Runs [create] as the single in-flight creation for [trackType], returning
+  /// the already-running one when there is one.
+  Future<Result<RtcLocalTrack>> _singleFlightCreate(
+    SfuTrackType trackType,
+    Future<Result<RtcLocalTrack>> Function() create,
+  ) {
+    final inFlight = _pendingTrackCreations[trackType];
+    if (inFlight != null) {
+      _logger.i(
+        () =>
+            '[createTrack] $trackType is already being created; '
+            'joining the in-flight request instead of acquiring media again',
+      );
+      return inFlight;
+    }
+
+    final pending = create();
+    _pendingTrackCreations[trackType] = pending;
+
+    return pending.whenComplete(() => _pendingTrackCreations.remove(trackType));
+  }
 
   List<SfuPublishOptions> publishOptions;
   AudioConstraints _defaultAudioConstraints = const AudioConstraints();
@@ -407,6 +449,23 @@ class RtcManager extends Disposable {
       final mediaTrackClone = await item.track.mediaTrack.clone();
       final trackToPublish = item.track.copyWith(mediaTrack: mediaTrackClone);
 
+      // Cloning suspended; a publish may have taken this key in the meantime.
+      var pending = _pendingTransceivers[publishOption.transceiverKey];
+      while (pending != null) {
+        await pending;
+        pending = _pendingTransceivers[publishOption.transceiverKey];
+      }
+
+      if (transceiversManager.has(publishOption)) {
+        _logger.v(
+          () =>
+              '[onPublishOptionsChanged] $trackType with codec: '
+              '${publishOption.codec.name} was published while preparing',
+        );
+        await mediaTrackClone.stop();
+        continue;
+      }
+
       final result = await _addTransceiver(
         trackToPublish,
         publishOption,
@@ -443,6 +502,12 @@ class RtcManager extends Disposable {
       // it is safe to stop the track here, it is a clone
       await item.transceiver.sender.track?.stop();
       await _updateTransceiver(item.transceiver, null, publishOption.trackType);
+
+      // Stopping the transceiver releases its m-line for reuse. Dropping the
+      // cache entry without it leaves the m-line on the peer connection with
+      // nobody owning it.
+      await _stopTransceiver(item.transceiver);
+      transceiversManager.remove(publishOption);
     }
   }
 
@@ -555,6 +620,7 @@ class RtcManager extends Disposable {
   @override
   Future<void> dispose() async {
     _logger.d(() => '[dispose] no args');
+    _isDisposing = true;
 
     await _screenSharingStartedSubscription?.cancel();
     _screenSharingStartedSubscription = null;
@@ -747,14 +813,38 @@ extension PublisherRtcManager on RtcManager {
   }
 
   /// The tracks to announce in `SetPublisher`, or null when the mid of at least
-  /// one sending transceiver could not be resolved.
+  /// one sending transceiver that is part of the offer could not be resolved.
   ///
   /// All-or-nothing on purpose: announcing a subset commits an offer whose
   /// omitted m-lines keep sending media the SFU cannot map, and the SFU may read
   /// a missing entry as an unpublish of a track that was working. A null tells
   /// the caller to roll the offer back and retry instead. An empty list is a
   /// different answer — nothing is sending, which is a legitimate no-op.
+  ///
+  /// A transceiver whose track is absent from the offer entirely (a publish
+  /// that landed while this negotiation was preparing) is skipped, not failed
+  /// its own queued negotiation announces it right after.
   Future<List<RtcTrackInfo>?> getAnnouncedTracks({String? sdp}) async {
+    // Wait for all pending transceivers to settle before announcing tracks.
+    //
+    // Bounded on purpose: this runs inside the negotiation lock with the offer
+    // already applied locally, so waiting forever on a wedged platform call
+    // would hold that lock open.
+    try {
+      await _settlePendingTransceivers().timeout(
+        _pendingTransceiverSettleTimeout,
+      );
+    } on TimeoutException {
+      _logger.w(
+        () =>
+            '[getAnnouncedTracks] pending transceivers did not settle within '
+            '$_pendingTransceiverSettleTimeout; failing the announce so the '
+            'offer is rolled back',
+      );
+
+      return null;
+    }
+
     final finalSdp = sdp ?? await _localSdp();
     final liveTransceivers = await _liveTransceivers();
     final infos = <RtcTrackInfo>[];
@@ -767,11 +857,24 @@ extension PublisherRtcManager on RtcManager {
         liveTransceivers: liveTransceivers,
       );
 
-      if (info == null) return null;
+      if (info == null) {
+        // A publish that landed after this offer was created is announced by
+        // its own queued negotiation, not this one.
+        if (_isMidFlightPublish(item, finalSdp)) continue;
+        return null;
+      }
       infos.add(info);
     }
 
     return infos;
+  }
+
+  /// Waits out every in-flight transceiver creation, so the cache reflects
+  /// what the peer connection is actually sending.
+  Future<void> _settlePendingTransceivers() async {
+    while (_pendingTransceivers.isNotEmpty) {
+      await Future.wait(_pendingTransceivers.values.toList());
+    }
   }
 
   /// The tracks to report in `ReconnectDetails`.
@@ -788,13 +891,12 @@ extension PublisherRtcManager on RtcManager {
     final finalSdp = sdp ?? await _localSdp();
     final liveTransceivers = await _liveTransceivers();
     final infos = <RtcTrackInfo>[];
+    final seenKeys = <TransceiverKey>{};
 
     for (final publishOption in publishOptions) {
-      final item = transceiversManager.find(
-        (c) =>
-            c.publishOption.id == publishOption.id &&
-            c.publishOption.trackType == publishOption.trackType,
-      );
+      if (!seenKeys.add(publishOption.transceiverKey)) continue;
+
+      final item = transceiversManager.get(publishOption);
 
       if (item?.transceiver.sender.track == null) continue;
       final info = _transceiverToTrackInfo(
@@ -803,14 +905,37 @@ extension PublisherRtcManager on RtcManager {
         liveTransceivers: liveTransceivers,
       );
 
-      if (info == null) {
-        continue;
-      }
+      if (info == null) continue;
 
       infos.add(info);
     }
 
     return infos;
+  }
+
+  /// True when [sdp] carries no m-line for [transceiverCache] — a publish that
+  /// landed after the offer was created.
+  ///
+  /// Absence is proven against every id the transceiver has ever sent, not just
+  /// the current one. An m-line is named by whichever id its sender held at
+  /// `createOffer` time, so a `replaceTrack` that landed afterwards leaves the
+  /// offer naming an older id while the m-line is very much part of it. Matching
+  /// only the current id would read that as a late publish and quietly drop a
+  /// track [getAnnouncedTracks] is contractually required to fail on instead.
+  bool _isMidFlightPublish(TransceiverCache transceiverCache, String? sdp) {
+    if (sdp == null) return false;
+    if (transceiverCache.negotiated) return false;
+
+    final currentTrackId = transceiverCache.transceiver.sender.track?.id;
+    final candidateIds = <String>{
+      ...transceiverCache.sentTrackIds,
+      if (currentTrackId != null) currentTrackId,
+    };
+
+    // Unknown track ids — cannot prove absence, stay conservative.
+    if (candidateIds.isEmpty) return false;
+
+    return !candidateIds.any(sdp.contains);
   }
 
   RtcTrackInfo? _transceiverToTrackInfo(
@@ -832,6 +957,16 @@ extension PublisherRtcManager on RtcManager {
     );
 
     if (mid == null) {
+      if (_isMidFlightPublish(transceiverCache, sdp)) {
+        _logger.v(
+          () =>
+              '[transceiverToTrackInfo] track $sentTrackId '
+              '(${track.trackType}) is not part of the current offer yet; '
+              'deferring to its own negotiation',
+        );
+        return null;
+      }
+
       _logger.w(
         () =>
             '[transceiverToTrackInfo] could not resolve mid for track '
@@ -960,6 +1095,15 @@ extension PublisherRtcManager on RtcManager {
       final mediaTrackClone = await audioTrack.mediaTrack.clone();
       final trackToPublish = audioTrack.copyWith(mediaTrack: mediaTrackClone);
 
+      // Another publish may have claimed this key and still be waiting on the
+      // platform. Let it settle, then re-read: whoever claimed first creates
+      // the sender, everyone else reuses it through `replaceTrack` below.
+      var pending = _pendingTransceivers[option.transceiverKey];
+      while (pending != null) {
+        await pending;
+        pending = _pendingTransceivers[option.transceiverKey];
+      }
+
       final cachedBundle = transceiversManager.get(option);
       final cachedTransceiver = cachedBundle?.transceiver;
       if (cachedTransceiver == null) {
@@ -1017,6 +1161,16 @@ extension PublisherRtcManager on RtcManager {
       _forceRenegotiation('[publishAudioTrack]');
     }
 
+    if (_isDisposing) {
+      _logger.w(
+        () =>
+            '[publishAudioTrack] disposed mid-publish; discarding '
+            '${updatedTrack.trackId}',
+      );
+      await updatedTrack.stop();
+      return Result.error('RtcManager was disposed while publishing');
+    }
+
     // Notify listeners.
     onLocalTrackPublished?.call(updatedTrack);
     tracks[updatedTrack.trackId] = updatedTrack;
@@ -1063,6 +1217,15 @@ extension PublisherRtcManager on RtcManager {
       // in the SDP, matching the JS SDK pattern.
       final mediaTrackClone = await videoTrack.mediaTrack.clone();
       final trackToPublish = videoTrack.copyWith(mediaTrack: mediaTrackClone);
+
+      // Another publish may have claimed this key and still be waiting on the
+      // platform. Let it settle, then re-read: whoever claimed first creates
+      // the sender, everyone else reuses it through `replaceTrack` below.
+      var pending = _pendingTransceivers[option.transceiverKey];
+      while (pending != null) {
+        await pending;
+        pending = _pendingTransceivers[option.transceiverKey];
+      }
 
       final cachedBundle = transceiversManager.get(option);
       final cachedTransceiver = cachedBundle?.transceiver;
@@ -1111,6 +1274,16 @@ extension PublisherRtcManager on RtcManager {
 
     if (needsRenegotiation) {
       _forceRenegotiation('[publishVideoTrack]');
+    }
+
+    if (_isDisposing) {
+      _logger.w(
+        () =>
+            '[publishVideoTrack] disposed mid-publish; discarding '
+            '${updatedTrack.trackId}',
+      );
+      await updatedTrack.stop();
+      return Result.error('RtcManager was disposed while publishing');
     }
 
     // Notify listeners.
@@ -1202,15 +1375,64 @@ extension PublisherRtcManager on RtcManager {
     }
   }
 
+  /// Creates the sender for [publishOptions], claiming its
+  /// `(trackType, publishOptionId)` for the duration.
+  ///
+  /// Deliberately **not** `async`: everything up to the claim runs in the same
+  /// synchronous step as the caller's cache lookup, so no other publish can
+  /// slip between "this key is free" and "this key is mine".
   Future<Result<rtc.RTCRtpTransceiver>> _addTransceiver(
     RtcLocalTrack track,
     SfuPublishOptions publishOptions,
     RtcTrackPublishOptions trackPublishOptions,
-  ) async {
+  ) {
     if (publisher == null) {
-      return Result.error('Publisher is not created, cannot add transceiver');
+      return Future.value(
+        Result.error('Publisher is not created, cannot add transceiver'),
+      );
     }
 
+    // The SFU rejects a publisher that announces the same key twice, so a
+    // second sender must never exist — not even briefly. Callers check the
+    // cache and wait out [_pendingTransceivers] before getting here, so this
+    // is a backstop; failing is the honest answer, since the caller's track
+    // would not be the one on the wire.
+    final key = publishOptions.transceiverKey;
+    if (transceiversManager.has(publishOptions) ||
+        _pendingTransceivers.containsKey(key)) {
+      _logger.e(
+        () =>
+            '[addTransceiver] duplicate publish for trackType: '
+            '${publishOptions.trackType}, publishOptionId: '
+            '${publishOptions.id} — rejecting',
+      );
+
+      return Future.value(
+        Result.error(
+          'Already publishing trackType: ${publishOptions.trackType} with '
+          'publishOptionId: ${publishOptions.id}',
+        ),
+      );
+    }
+
+    final claim = Completer<void>();
+    _pendingTransceivers[key] = claim.future;
+
+    return _createTransceiver(
+      track,
+      publishOptions,
+      trackPublishOptions,
+    ).whenComplete(() {
+      _pendingTransceivers.remove(key);
+      claim.complete();
+    });
+  }
+
+  Future<Result<rtc.RTCRtpTransceiver>> _createTransceiver(
+    RtcLocalTrack track,
+    SfuPublishOptions publishOptions,
+    RtcTrackPublishOptions trackPublishOptions,
+  ) async {
     Result<rtc.RTCRtpTransceiver>? transceiverResult;
 
     _logger.v(
@@ -1254,12 +1476,29 @@ extension PublisherRtcManager on RtcManager {
     if (transceiverResult is Failure) return transceiverResult;
 
     final transceiver = transceiverResult.getDataOrNull()!;
-    transceiversManager.add(
+
+    final cached = transceiversManager.add(
       track,
       publishOptions,
       transceiver,
       trackPublishOptions,
     );
+
+    if (!cached) {
+      _logger.e(
+        () =>
+            '[addTransceiver] cache already holds trackType: '
+            '${publishOptions.trackType}, publishOptionId: '
+            '${publishOptions.id} — discarding the sender just created',
+      );
+
+      await _stopTransceiver(transceiver);
+
+      return Result.error(
+        'Already publishing trackType: ${publishOptions.trackType} with '
+        'publishOptionId: ${publishOptions.id}',
+      );
+    }
 
     return Result.success(transceiver);
   }
@@ -1277,6 +1516,15 @@ extension PublisherRtcManager on RtcManager {
         track.trackType,
         trackPublishOptions ?? const RtcTrackPublishOptions(),
       );
+    }
+  }
+
+  /// Stops [transceiver] so its m-line becomes recyclable.
+  Future<void> _stopTransceiver(RTCRtpTransceiver transceiver) async {
+    try {
+      await transceiver.stop();
+    } catch (e, stk) {
+      _logger.w(() => '[stopTransceiver] failed: $e\n$stk');
     }
   }
 
@@ -1344,7 +1592,9 @@ extension PublisherRtcManager on RtcManager {
     return Result.success(track);
   }
 
-  Future<Result<RtcLocalTrack>> unmuteTrack({required String trackId}) async {
+  Future<Result<RtcLocalTrack>> unmuteTrack({
+    required String trackId,
+  }) async {
     final track = tracks[trackId];
     if (track == null) {
       _logger.w(() => 'unmuteTrack: track not found');
@@ -1747,7 +1997,28 @@ extension RtcManagerTrackHelper on RtcManager {
     required bool enabled,
     MediaConstraints? constraints,
   }) async {
-    final track = getPublisherTrackByType(trackType);
+    var track = getPublisherTrackByType(trackType);
+
+    // Wait out an in-flight creation before deciding anything.
+    //
+    // Screen share is left out on the enable side: it deliberately creates a
+    // fresh track every time so a new screen can be picked, and waiting here
+    // would queue a second picker behind the one still on screen.
+    final awaitsCreation =
+        track == null && (!enabled || trackType != SfuTrackType.screenShare);
+
+    if (awaitsCreation) {
+      final inFlight = _pendingTrackCreations[trackType];
+      if (inFlight != null) {
+        _logger.i(
+          () =>
+              '[setTrackEnabled] $trackType is still being created; '
+              'waiting for it before applying enabled: $enabled',
+        );
+        await inFlight;
+        track = getPublisherTrackByType(trackType);
+      }
+    }
 
     // Track found, mute/unmute it.
     if (track != null) {
@@ -1813,7 +2084,29 @@ extension RtcManagerTrackHelper on RtcManager {
     return track;
   }
 
+  /// Acquires media for [trackType] and publishes it.
+  ///
+  /// Collapsed per track type: a second "enable" arriving while the first is
+  /// still in `getUserMedia` joins it rather than opening the camera or
+  /// microphone a second time. That is the window the duplicate-publish bug
+  /// came through — `tracks` is only populated once acquisition returns, so
+  /// until then every caller sees "nothing published yet". A joining caller's
+  /// [constraints] are ignored, which matches what it would have observed had
+  /// it arrived a moment later and found the track already published.
   Future<Result<RtcLocalTrack>> _createAndPublishTrack({
+    required SfuTrackType trackType,
+    MediaConstraints? constraints,
+  }) {
+    return _singleFlightCreate(
+      trackType,
+      () => _acquireAndPublishTrack(
+        trackType: trackType,
+        constraints: constraints,
+      ),
+    );
+  }
+
+  Future<Result<RtcLocalTrack>> _acquireAndPublishTrack({
     required SfuTrackType trackType,
     MediaConstraints? constraints,
   }) async {

--- a/packages/stream_video/lib/src/webrtc/rtc_manager.dart
+++ b/packages/stream_video/lib/src/webrtc/rtc_manager.dart
@@ -52,10 +52,6 @@ const _tag = 'SV:RtcManager';
 
 /// How long [PublisherRtcManager.getAnnouncedTracks] waits for in-flight
 /// transceiver creations before giving up on the current negotiation.
-///
-/// `addTransceiver` is a sub-100ms platform call in practice; anything near
-/// this is wedged, and a wedged publisher recovers through a reconnect rather
-/// than by waiting longer.
 const _pendingTransceiverSettleTimeout = Duration(seconds: 5);
 
 class RtcManager extends Disposable {

--- a/packages/stream_video/lib/src/webrtc/transceiver_cache.dart
+++ b/packages/stream_video/lib/src/webrtc/transceiver_cache.dart
@@ -15,7 +15,9 @@ class TransceiverCache {
     required this.trackPublishOptions,
     this.negotiated = false,
     this.negotiatedMid,
-  });
+  }) {
+    rememberSentTrack(track);
+  }
 
   RtcLocalTrack track;
   SfuPublishOptions publishOption;
@@ -28,6 +30,15 @@ class TransceiverCache {
 
   /// The mid announced in the last negotiation the SFU acknowledged.
   String? negotiatedMid;
+
+  /// Every media track id this transceiver has sent, the current one included.
+  final Set<String> sentTrackIds = {};
+
+  /// Records [sentTrack]'s media id as one this transceiver has sent.
+  void rememberSentTrack(RtcLocalTrack sentTrack) {
+    final id = sentTrack.mediaTrack.id;
+    if (id != null) sentTrackIds.add(id);
+  }
 
   @override
   String toString() {
@@ -42,38 +53,49 @@ class TrackLayersCache {
   List<RTCRtpEncoding> layers;
 }
 
+/// Represents the unique identity of a publisher sender for the SFU,
+/// defined by a combination of `(trackType, publishOptionId)`.
+typedef TransceiverKey = (SfuTrackType, int);
+
+extension SfuPublishOptionsTransceiverKey on SfuPublishOptions {
+  TransceiverKey get transceiverKey => (trackType, id);
+}
+
 class TransceiverManager {
-  final List<TransceiverCache> _transceivers = [];
-  final List<TrackLayersCache> _layers = [];
+  final Map<TransceiverKey, TransceiverCache> _transceivers = {};
+  final Map<TransceiverKey, TrackLayersCache> _layers = {};
 
   /// Adds a transceiver to the cache.
-  void add(
+  ///
+  /// Returns false and leaves the cache untouched when an entry for the same
+  /// `(trackType, publishOptionId)` already exists.
+  bool add(
     RtcLocalTrack track,
     SfuPublishOptions publishOption,
     RTCRtpTransceiver transceiver,
     RtcTrackPublishOptions trackPublishOptions,
   ) {
-    _transceivers.add(
-      TransceiverCache(
-        track: track,
-        publishOption: publishOption,
-        transceiver: transceiver,
-        trackPublishOptions: trackPublishOptions,
-      ),
+    final key = publishOption.transceiverKey;
+    if (_transceivers.containsKey(key)) return false;
+
+    _transceivers[key] = TransceiverCache(
+      track: track,
+      publishOption: publishOption,
+      transceiver: transceiver,
+      trackPublishOptions: trackPublishOptions,
     );
+
+    return true;
   }
 
   /// Gets the transceiver for the given publish option.
   TransceiverCache? get(SfuPublishOptions publishOption) {
-    return _findTransceiver(
-      publishOption.trackType,
-      publishOption.id,
-    );
+    return _transceivers[publishOption.transceiverKey];
   }
 
-  /// Gets the last transceiver for the given track type and publish option id.
+  /// Gets the transceiver for the given track type and publish option id.
   RTCRtpTransceiver? getWith(SfuTrackType trackType, int publishOptionId) {
-    return _findTransceiver(trackType, publishOptionId)?.transceiver;
+    return _transceivers[(trackType, publishOptionId)]?.transceiver;
   }
 
   /// Updates the cached bundle for the given publish option.
@@ -84,35 +106,46 @@ class TransceiverManager {
   }) {
     final bundle = get(publishOption);
     if (bundle == null) return;
-    if (track != null) bundle.track = track;
+    if (track != null) {
+      bundle.track = track;
+      bundle.rememberSentTrack(track);
+    }
     if (trackPublishOptions != null) {
       bundle.trackPublishOptions = trackPublishOptions;
     }
   }
 
+  /// Removes and returns the cached bundle for the given publish option, or
+  /// null when none exists. Any cached layers for the key go with it.
+  TransceiverCache? remove(SfuPublishOptions publishOption) {
+    final key = publishOption.transceiverKey;
+    _layers.remove(key);
+    return _transceivers.remove(key);
+  }
+
   /// Checks if the cache has the given publish option.
   bool has(SfuPublishOptions publishOption) {
-    return get(publishOption) != null;
+    return _transceivers.containsKey(publishOption.transceiverKey);
   }
 
   /// Finds the first transceiver that satisfies the given predicate.
   TransceiverCache? find(bool Function(TransceiverCache) predicate) {
-    return _transceivers.firstWhereOrNull(predicate);
+    return _transceivers.values.firstWhereOrNull(predicate);
   }
 
   Iterable<TransceiverCache> findAll(
     bool Function(TransceiverCache) predicate,
   ) {
-    return _transceivers.where(predicate);
+    return _transceivers.values.where(predicate);
   }
 
   Iterable<RTCRtpTransceiver> getTransceiversForTrack(String trackId) {
     return findAll((t) => t.track.trackId == trackId).map((t) => t.transceiver);
   }
 
-  /// Provides all the items in the cache.
+  /// Provides all the items in the cache, in insertion order.
   List<TransceiverCache> items() {
-    return _transceivers;
+    return _transceivers.values.toList();
   }
 
   /// Marks the cached transceivers that were part of [announced] as negotiated,
@@ -138,46 +171,19 @@ class TransceiverManager {
 
   /// Gets cached video layers for the given track.
   List<RTCRtpEncoding>? getLayers(SfuPublishOptions publishOption) {
-    final entry = _layers.firstWhereOrNull(
-      (item) =>
-          item.publishOption.id == publishOption.id &&
-          item.publishOption.trackType == publishOption.trackType,
-    );
-
-    return entry?.layers;
+    return _layers[publishOption.transceiverKey]?.layers;
   }
 
   /// Sets the video layers for the given track.
   void setLayers(SfuPublishOptions publishOption, List<RTCRtpEncoding> layers) {
-    final entry = _findLayer(publishOption.trackType, publishOption.id);
+    final entry = _layers[publishOption.transceiverKey];
     if (entry != null) {
       entry.layers = layers;
     } else {
-      _layers.add(
-        TrackLayersCache(publishOption: publishOption, layers: layers),
+      _layers[publishOption.transceiverKey] = TrackLayersCache(
+        publishOption: publishOption,
+        layers: layers,
       );
     }
-  }
-
-  TransceiverCache? _findTransceiver(
-    SfuTrackType trackType,
-    int publishOptionId,
-  ) {
-    return _transceivers.firstWhereOrNull(
-      (item) =>
-          item.publishOption.id == publishOptionId &&
-          item.publishOption.trackType == trackType,
-    );
-  }
-
-  TrackLayersCache? _findLayer(
-    SfuTrackType trackType,
-    int publishOptionId,
-  ) {
-    return _layers.firstWhereOrNull(
-      (item) =>
-          item.publishOption.id == publishOptionId &&
-          item.publishOption.trackType == trackType,
-    );
   }
 }

--- a/packages/stream_video/test/src/call/session/call_session_announce_test.dart
+++ b/packages/stream_video/test/src/call/session/call_session_announce_test.dart
@@ -116,8 +116,25 @@ _wireStalledPublisher(
   when(pc.getTransceivers).thenAnswer((_) async => const []);
   when(pc.getLocalDescription).thenAnswer((_) async => null);
 
+  // The offer names the sending track (so it is part of this negotiation —
+  // not a publish that landed mid-flight) but carries no a=mid for it, which
+  // makes the mid genuinely unresolvable.
   when(publisher.createOffer).thenAnswer(
-    (_) async => Result.success(rtc.RTCSessionDescription('v=0\r\n', 'offer')),
+    (_) async => Result.success(
+      rtc.RTCSessionDescription(
+        [
+          'v=0\r\n',
+          'o=- 1 2 IN IP4 127.0.0.1\r\n',
+          's=-\r\n',
+          't=0 0\r\n',
+          'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n',
+          'c=IN IP4 0.0.0.0\r\n',
+          'a=sendonly\r\n',
+          'a=msid:stream-id media-track-id\r\n',
+        ].join(),
+        'offer',
+      ),
+    ),
   );
   when(publisher.rollbackLocalDescription).thenAnswer(
     (_) async => const Result.success(null),

--- a/packages/stream_video/test/src/webrtc/rtc_manager_announced_tracks_test.dart
+++ b/packages/stream_video/test/src/webrtc/rtc_manager_announced_tracks_test.dart
@@ -224,6 +224,130 @@ void main() {
 
       expect(announced?.single.mid, '5');
     });
+
+    test(
+      'skips a publish that landed after the offer was created instead of '
+      'failing the announce — its own queued negotiation announces it',
+      () async {
+        final wires = buildManager();
+        // track-a is part of the offer; track-b was published concurrently
+        // while this negotiation was preparing (its m-line is absent).
+        cacheTrack(wires.manager, option: _option(1), trackId: 'track-a');
+        cacheTrack(wires.manager, option: _option(2), trackId: 'track-b');
+
+        stubPeerConnection(
+          wires.pc,
+          liveTransceivers: [_transceiver(trackId: 'track-a', mid: '0')],
+        );
+
+        final announced = await wires.manager.getAnnouncedTracks(
+          sdp: [
+            'v=0\r\n',
+            'o=- 1 2 IN IP4 127.0.0.1\r\n',
+            's=-\r\n',
+            't=0 0\r\n',
+            'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n',
+            'c=IN IP4 0.0.0.0\r\n',
+            'a=mid:0\r\n',
+            'a=sendonly\r\n',
+            'a=msid:stream-id track-a\r\n',
+          ].join(),
+        );
+
+        expect(announced, isNotNull);
+        expect(announced!.single.trackId, 'track-a');
+      },
+    );
+
+    test(
+      'fails the announce for a track the SFU already acknowledged, even when '
+      'the offer does not name it — dropping it would read as an unpublish',
+      () async {
+        final wires = buildManager();
+        cacheTrack(wires.manager, option: _option(1), trackId: 'track-a');
+        cacheTrack(wires.manager, option: _option(2), trackId: 'track-b');
+
+        // track-b was announced and acknowledged, but the ack carried no mid,
+        // so there is no negotiatedMid to fall back on. It is a live sender —
+        // absence from the offer must not be read as a mid-flight publish.
+        wires.manager.transceiversManager.markNegotiated([
+          _announced(_option(2), trackId: 'track-b', mid: ''),
+        ]);
+
+        stubPeerConnection(
+          wires.pc,
+          liveTransceivers: [_transceiver(trackId: 'track-a', mid: '0')],
+        );
+
+        final announced = await wires.manager.getAnnouncedTracks(
+          sdp: [
+            'v=0\r\n',
+            'o=- 1 2 IN IP4 127.0.0.1\r\n',
+            's=-\r\n',
+            't=0 0\r\n',
+            'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n',
+            'c=IN IP4 0.0.0.0\r\n',
+            'a=mid:0\r\n',
+            'a=sendonly\r\n',
+            'a=msid:stream-id track-a\r\n',
+          ].join(),
+        );
+
+        expect(announced, isNull);
+      },
+    );
+
+    test(
+      'fails the announce when a republish swapped the track after the offer '
+      'was created — the m-line is in the offer under the id it replaced',
+      () async {
+        final wires = buildManager();
+        final option = _option(1);
+        cacheTrack(wires.manager, option: option, trackId: 'clone-0');
+
+        // The republish path: `replaceTrack` swaps a fresh clone onto the same
+        // sender, and the cache follows it. Nothing is negotiated yet, so there
+        // is no negotiatedMid to fall back on either.
+        final swappedMedia = _MockMediaStreamTrack();
+        when(() => swappedMedia.id).thenReturn('clone-1');
+        when(() => swappedMedia.kind).thenReturn('audio');
+        when(() => swappedMedia.enabled).thenReturn(true);
+
+        final swapped = _MockLocalAudioTrack();
+        when(() => swapped.trackId).thenReturn('track-clone-1');
+        when(() => swapped.trackType).thenReturn(SfuTrackType.audio);
+        when(() => swapped.mediaTrack).thenReturn(swappedMedia);
+
+        final cached = wires.manager.transceiversManager.get(option)!;
+        final sender = cached.transceiver.sender;
+        when(() => sender.track).thenReturn(swappedMedia);
+        wires.manager.transceiversManager.update(option, track: swapped);
+
+        // The sender now holds clone-1, while the offer — created before the
+        // swap — still names clone-0 on the very m-line this sender owns.
+        stubPeerConnection(
+          wires.pc,
+          liveTransceivers: [_transceiver(trackId: 'clone-1')],
+        );
+
+        final announced = await wires.manager.getAnnouncedTracks(
+          sdp: [
+            'v=0\r\n',
+            'o=- 1 2 IN IP4 127.0.0.1\r\n',
+            's=-\r\n',
+            't=0 0\r\n',
+            'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n',
+            'c=IN IP4 0.0.0.0\r\n',
+            'a=sendonly\r\n',
+            'a=msid:stream-id clone-0\r\n',
+          ].join(),
+        );
+
+        // Skipping it would commit an offer whose m-line keeps sending media
+        // the SFU was never told about. Roll back and retry instead.
+        expect(announced, isNull);
+      },
+    );
   });
 
   group('getAnnouncedTracksForReconnect', () {
@@ -316,6 +440,30 @@ void main() {
         final reported = await wires.manager.getAnnouncedTracksForReconnect();
 
         expect(reported.single.mid, '2');
+      },
+    );
+
+    test(
+      'announces a track once even when publishOptions repeats the same '
+      'option — a duplicate (trackType, publishOptionId) would collide on '
+      'the SFU',
+      () async {
+        final wires = buildManager();
+        final option = _option(1);
+        cacheTrack(wires.manager, option: option, trackId: 'track-a');
+
+        // A duplicated option list must not produce a duplicated announce.
+        wires.manager.publishOptions = [option, option];
+
+        stubPeerConnection(
+          wires.pc,
+          liveTransceivers: [_transceiver(trackId: 'track-a', mid: '0')],
+        );
+
+        final reported = await wires.manager.getAnnouncedTracksForReconnect();
+
+        expect(reported, hasLength(1));
+        expect(reported.single.trackId, 'track-a');
       },
     );
   });

--- a/packages/stream_video/test/src/webrtc/rtc_manager_concurrent_publish_test.dart
+++ b/packages/stream_video/test/src/webrtc/rtc_manager_concurrent_publish_test.dart
@@ -1,0 +1,453 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_video/src/sfu/data/models/sfu_codec.dart';
+import 'package:stream_video/src/sfu/data/models/sfu_publish_options.dart';
+import 'package:stream_video/src/sfu/data/models/sfu_track_type.dart';
+import 'package:stream_video/src/utils/result.dart';
+import 'package:stream_video/src/webrtc/media/media_constraints.dart';
+import 'package:stream_video/src/webrtc/peer_connection_factory.dart';
+import 'package:stream_video/src/webrtc/rtc_manager.dart';
+import 'package:stream_video/src/webrtc/rtc_track/rtc_local_track.dart';
+import 'package:stream_video/src/webrtc/traced_peer_connection.dart';
+import 'package:stream_webrtc_flutter/stream_webrtc_flutter.dart' as rtc;
+
+import '../call/fixtures/call_test_helpers.dart';
+import '../call/fixtures/data.dart';
+
+class _MockTracedStreamPeerConnection extends Mock
+    implements TracedStreamPeerConnection {}
+
+class _MockPeerConnection extends Mock implements rtc.RTCPeerConnection {}
+
+class _MockTransceiver extends Mock implements rtc.RTCRtpTransceiver {}
+
+class _MockSender extends Mock implements rtc.RTCRtpSender {}
+
+class _MockMediaStreamTrack extends Mock implements rtc.MediaStreamTrack {}
+
+class _MockMediaStream extends Mock implements rtc.MediaStream {}
+
+class _MockPcFactory extends Mock implements StreamPeerConnectionFactory {}
+
+const _audioCodec = SfuCodec(
+  name: 'opus',
+  payloadType: 111,
+  fmtpLine: '',
+  clockRate: 48000,
+  encodingParameters: '',
+);
+
+const _videoCodec = SfuCodec(
+  name: 'vp8',
+  payloadType: 96,
+  fmtpLine: '',
+  clockRate: 90000,
+  encodingParameters: '',
+);
+
+final _videoOption = SfuPublishOptions(
+  id: 1,
+  codec: _videoCodec,
+  trackType: SfuTrackType.video,
+);
+
+final _audioOption = SfuPublishOptions(
+  id: 2,
+  codec: _audioCodec,
+  trackType: SfuTrackType.audio,
+);
+
+rtc.MediaStreamTrack _mediaTrack(String id, {required String kind}) {
+  final track = _MockMediaStreamTrack();
+  when(() => track.id).thenReturn(id);
+  when(() => track.kind).thenReturn(kind);
+  when(() => track.enabled).thenReturn(true);
+  when(track.stop).thenAnswer((_) async {});
+  return track;
+}
+
+/// A transceiver whose sender currently exposes [senderTrack], returned
+/// together with the sender so tests can stub/verify it directly (mocktail
+/// forbids stubbing through the `transceiver.sender.track` chain).
+({rtc.RTCRtpTransceiver transceiver, rtc.RTCRtpSender sender}) _transceiver(
+  rtc.MediaStreamTrack? senderTrack,
+) {
+  final sender = _MockSender();
+  when(() => sender.track).thenReturn(senderTrack);
+  when(() => sender.replaceTrack(any())).thenAnswer((_) async {});
+
+  final transceiver = _MockTransceiver();
+  when(() => transceiver.sender).thenReturn(sender);
+  when(() => transceiver.mid).thenReturn('');
+  return (transceiver: transceiver, sender: sender);
+}
+
+/// A real local track backed by mocks, cloning to a fresh media track on
+/// every publish just like a real one.
+RtcLocalTrack<T> _localTrack<T extends MediaConstraints>(
+  String mediaId, {
+  required SfuTrackType trackType,
+  required T constraints,
+  required String kind,
+}) {
+  final mediaTrack = _mediaTrack(mediaId, kind: kind);
+  var cloneCount = 0;
+  when(mediaTrack.clone).thenAnswer(
+    (_) async => _mediaTrack('$mediaId-clone-${cloneCount++}', kind: kind),
+  );
+
+  final mediaStream = _MockMediaStream();
+  when(mediaStream.dispose).thenAnswer((_) async {});
+
+  return RtcLocalTrack(
+    trackIdPrefix: 'pub',
+    trackType: trackType,
+    mediaStream: mediaStream,
+    mediaTrack: mediaTrack,
+    mediaConstraints: constraints,
+  );
+}
+
+RtcLocalVideoTrack _videoTrack(String mediaId) => _localTrack(
+  mediaId,
+  trackType: SfuTrackType.video,
+  constraints: const CameraConstraints(),
+  kind: 'video',
+);
+
+RtcLocalAudioTrack _audioTrack(String mediaId) => _localTrack(
+  mediaId,
+  trackType: SfuTrackType.audio,
+  constraints: const AudioConstraints(),
+  kind: 'audio',
+);
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    registerMockFallbackValues();
+    registerFallbackValue(_MockMediaStreamTrack());
+    registerFallbackValue(_MockSender());
+    registerFallbackValue(<rtc.RTCRtpEncoding>[]);
+  });
+
+  ({
+    RtcManager manager,
+    _MockTracedStreamPeerConnection publisher,
+    _MockPeerConnection pc,
+  })
+  buildManager({
+    required List<SfuPublishOptions> publishOptions,
+    StreamPeerConnectionFactory? pcFactory,
+  }) {
+    final pc = _MockPeerConnection();
+    final publisher = _MockTracedStreamPeerConnection();
+    when(() => publisher.pc).thenReturn(pc);
+    when(() => publisher.isReconnecting).thenReturn(false);
+    when(() => publisher.onRenegotiationNeeded).thenReturn(null);
+    when(publisher.dispose).thenAnswer((_) async {});
+
+    final subscriber = _MockTracedStreamPeerConnection();
+    when(subscriber.dispose).thenAnswer((_) async {});
+
+    final manager = RtcManager(
+      sessionId: 'test-session',
+      callCid: SampleCallData.defaultCid,
+      publisherId: 'test-publisher',
+      publisher: publisher,
+      subscriber: subscriber,
+      publishOptions: publishOptions,
+      stateManager: createTestCallStateManager(),
+      streamVideo: setupMockStreamVideo(),
+      pcFactory:
+          pcFactory ??
+          StreamPeerConnectionFactory(callCid: SampleCallData.defaultCid),
+    );
+
+    return (manager: manager, publisher: publisher, pc: pc);
+  }
+
+  /// Stubs [publisher]'s addVideoTransceiver to block on [gate] before
+  /// returning, counting invocations via the returned callable.
+  int Function() gateVideoTransceiver(
+    _MockTracedStreamPeerConnection publisher, {
+    required rtc.RTCRtpTransceiver transceiver,
+    Completer<void>? gate,
+  }) {
+    var calls = 0;
+    when(
+      () => publisher.addVideoTransceiver(
+        track: any(named: 'track'),
+        encodings: any(named: 'encodings'),
+        degradationPreference: any(named: 'degradationPreference'),
+      ),
+    ).thenAnswer((_) async {
+      calls++;
+      if (gate != null) await gate.future;
+      return Result.success(transceiver);
+    });
+    return () => calls;
+  }
+
+  group('concurrent publish serialization', () {
+    test(
+      'two concurrent publishes of the same type create exactly one '
+      'transceiver — the loser reuses the winner instead of duplicating',
+      () async {
+        final wires = buildManager(publishOptions: [_videoOption]);
+
+        final gate = Completer<void>();
+        // The winner's clone appears as the sender's current track, which the
+        // loser replaces (and stops) on its reuse path.
+        final wired = _transceiver(_mediaTrack('winner-clone', kind: 'video'));
+        final addCalls = gateVideoTransceiver(
+          wires.publisher,
+          transceiver: wired.transceiver,
+          gate: gate,
+        );
+
+        // Both publishes race, as when a double camera-enable fires two
+        // getUserMedia flows.
+        final first = wires.manager.publishVideoTrack(track: _videoTrack('a'));
+        final second = wires.manager.publishVideoTrack(track: _videoTrack('b'));
+
+        // Let the winner reach the gated addVideoTransceiver.
+        await Future<void>.delayed(Duration.zero);
+        expect(addCalls(), 1);
+
+        gate.complete();
+        final results = await Future.wait([
+          first,
+          second,
+        ]).timeout(const Duration(seconds: 5));
+
+        expect(results.every((r) => r.isSuccess), isTrue);
+        // One platform transceiver; the second publish went through
+        // replaceTrack on the cached one.
+        expect(addCalls(), 1);
+        expect(wires.manager.transceiversManager.items(), hasLength(1));
+        verify(() => wired.sender.replaceTrack(any())).called(1);
+      },
+    );
+
+    test(
+      'audio and video publishes do not serialize against each other',
+      () async {
+        final wires = buildManager(
+          publishOptions: [_videoOption, _audioOption],
+        );
+
+        final videoGate = Completer<void>();
+        gateVideoTransceiver(
+          wires.publisher,
+          transceiver: _transceiver(null).transceiver,
+          gate: videoGate,
+        );
+        when(
+          () => wires.publisher.addAudioTransceiver(
+            track: any(named: 'track'),
+            encodings: any(named: 'encodings'),
+          ),
+        ).thenAnswer(
+          (_) async => Result.success(_transceiver(null).transceiver),
+        );
+
+        var videoDone = false;
+        final videoFuture = wires.manager
+            .publishVideoTrack(track: _videoTrack('cam'))
+            .then((r) {
+              videoDone = true;
+              return r;
+            });
+
+        // The audio publish must complete while the video publish is still
+        // blocked in the platform: claims are per `(trackType,
+        // publishOptionId)`, so camera and microphone acquisition stay
+        // parallel at join.
+        final audioResult = await wires.manager
+            .publishAudioTrack(track: _audioTrack('mic'))
+            .timeout(const Duration(seconds: 5));
+
+        expect(audioResult.isSuccess, isTrue);
+        expect(videoDone, isFalse);
+
+        videoGate.complete();
+        final videoResult = await videoFuture.timeout(
+          const Duration(seconds: 5),
+        );
+        expect(videoResult.isSuccess, isTrue);
+        expect(wires.manager.transceiversManager.items(), hasLength(2));
+      },
+    );
+
+    test(
+      'a publish landing while another is still creating its transceiver '
+      'reuses it instead of adding a second sender',
+      () async {
+        final wires = buildManager(publishOptions: [_videoOption]);
+
+        final gate = Completer<void>();
+        final wired = _transceiver(_mediaTrack('winner-clone', kind: 'video'));
+        final addCalls = gateVideoTransceiver(
+          wires.publisher,
+          transceiver: wired.transceiver,
+          gate: gate,
+        );
+
+        final first = wires.manager.publishVideoTrack(track: _videoTrack('a'));
+
+        // Let the first publish claim the key and suspend inside the platform
+        // call, then start the second — the window the old code duplicated in.
+        // The claim, not a lock, is what makes the second one wait.
+        await Future<void>.delayed(Duration.zero);
+        expect(addCalls(), 1);
+
+        final second = wires.manager.publishVideoTrack(track: _videoTrack('b'));
+        await Future<void>.delayed(Duration.zero);
+
+        // The second publish is parked on the claim, not creating its own.
+        expect(addCalls(), 1);
+
+        gate.complete();
+        final results = await Future.wait([
+          first,
+          second,
+        ]).timeout(const Duration(seconds: 5));
+
+        expect(results.every((r) => r.isSuccess), isTrue);
+        expect(addCalls(), 1);
+        expect(wires.manager.transceiversManager.items(), hasLength(1));
+        verify(() => wired.sender.replaceTrack(any())).called(1);
+      },
+    );
+
+    test(
+      'a publish landing after dispose discards its track instead of '
+      'stranding it with the camera still captured',
+      () async {
+        final wires = buildManager(publishOptions: [_videoOption]);
+        when(() => wires.pc.removeTrack(any())).thenAnswer((_) async => true);
+
+        final gate = Completer<void>();
+        final source = _videoTrack('cam');
+        gateVideoTransceiver(
+          wires.publisher,
+          transceiver: _transceiver(
+            _mediaTrack('sent', kind: 'video'),
+          ).transceiver,
+          gate: gate,
+        );
+
+        final publishing = wires.manager.publishVideoTrack(track: source);
+        await Future<void>.delayed(Duration.zero);
+
+        final disposing = wires.manager.dispose();
+        gate.complete();
+
+        final result = await publishing.timeout(const Duration(seconds: 5));
+        await disposing.timeout(const Duration(seconds: 5));
+
+        expect(result.isFailure, isTrue);
+        expect(wires.manager.tracks, isEmpty);
+        // The source the publish was holding is released, not left running.
+        verify(source.mediaTrack.stop).called(greaterThanOrEqualTo(1));
+      },
+    );
+
+    test(
+      'getAnnouncedTracks waits for a transceiver still being created, so the '
+      'offer never carries an m-line the announce omits',
+      () async {
+        final wires = buildManager(publishOptions: [_videoOption]);
+
+        final gate = Completer<void>();
+        final sent = _mediaTrack('sent', kind: 'video');
+        final wired = _transceiver(sent);
+        when(() => wired.transceiver.mid).thenReturn('0');
+        gateVideoTransceiver(
+          wires.publisher,
+          transceiver: wired.transceiver,
+          gate: gate,
+        );
+        when(
+          wires.pc.getTransceivers,
+        ).thenAnswer((_) async => [wired.transceiver]);
+        when(wires.pc.getLocalDescription).thenAnswer(
+          (_) async => rtc.RTCSessionDescription('v=0\r\n', 'offer'),
+        );
+
+        unawaited(wires.manager.publishVideoTrack(track: _videoTrack('cam')));
+        await Future<void>.delayed(Duration.zero);
+
+        var announced = false;
+        final announcing = wires.manager.getAnnouncedTracks().then((it) {
+          announced = true;
+          return it;
+        });
+
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          announced,
+          isFalse,
+          reason: 'must not announce while a sender is mid-creation',
+        );
+
+        gate.complete();
+        final tracks = await announcing.timeout(const Duration(seconds: 5));
+
+        expect(tracks, isNotNull);
+        expect(tracks!.single.trackId, 'sent');
+      },
+    );
+  });
+
+  group('media acquisition single-flight', () {
+    /// A factory whose native-factory build never resolves, so the camera
+    /// acquisition behind `setCameraEnabled` stays in flight.
+    ({_MockPcFactory factory, Completer<void> release}) stalledFactory() {
+      final release = Completer<void>();
+      final factory = _MockPcFactory();
+      when(factory.ensureNativeFactory).thenAnswer((_) async {
+        await release.future;
+        return null;
+      });
+      return (factory: factory, release: release);
+    }
+
+    test(
+      'a disable arriving mid-acquisition waits for it rather than being '
+      'dropped as "track not found"',
+      () async {
+        final stalled = stalledFactory();
+        final wires = buildManager(
+          publishOptions: [_videoOption],
+          pcFactory: stalled.factory,
+        );
+
+        unawaited(wires.manager.setCameraEnabled());
+        await Future<void>.delayed(Duration.zero);
+
+        var disabled = false;
+        final disabling = wires.manager.setCameraEnabled(enabled: false).then((
+          it,
+        ) {
+          disabled = true;
+          return it;
+        });
+
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          disabled,
+          isFalse,
+          reason: 'the disable must join the in-flight enable, not give up',
+        );
+
+        stalled.release.complete();
+        await disabling.timeout(const Duration(seconds: 5));
+        expect(disabled, isTrue);
+      },
+    );
+  });
+}

--- a/packages/stream_video/test/src/webrtc/rtc_manager_publish_options_test.dart
+++ b/packages/stream_video/test/src/webrtc/rtc_manager_publish_options_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_video/src/sfu/data/models/sfu_codec.dart';
+import 'package:stream_video/src/sfu/data/models/sfu_publish_options.dart';
+import 'package:stream_video/src/sfu/data/models/sfu_track_type.dart';
+import 'package:stream_video/src/utils/result.dart';
+import 'package:stream_video/src/webrtc/media/media_constraints.dart';
+import 'package:stream_video/src/webrtc/peer_connection_factory.dart';
+import 'package:stream_video/src/webrtc/rtc_manager.dart';
+import 'package:stream_video/src/webrtc/rtc_track/rtc_local_track.dart';
+import 'package:stream_video/src/webrtc/traced_peer_connection.dart';
+import 'package:stream_webrtc_flutter/stream_webrtc_flutter.dart' as rtc;
+
+import '../call/fixtures/call_test_helpers.dart';
+import '../call/fixtures/data.dart';
+
+class _MockTracedStreamPeerConnection extends Mock
+    implements TracedStreamPeerConnection {}
+
+class _MockPeerConnection extends Mock implements rtc.RTCPeerConnection {}
+
+class _MockTransceiver extends Mock implements rtc.RTCRtpTransceiver {}
+
+class _MockSender extends Mock implements rtc.RTCRtpSender {}
+
+class _MockMediaStreamTrack extends Mock implements rtc.MediaStreamTrack {}
+
+class _MockMediaStream extends Mock implements rtc.MediaStream {}
+
+SfuPublishOptions _videoOption(int id, String codecName) {
+  return SfuPublishOptions(
+    id: id,
+    codec: SfuCodec(
+      name: codecName,
+      payloadType: 96,
+      fmtpLine: '',
+      clockRate: 90000,
+      encodingParameters: '',
+    ),
+    trackType: SfuTrackType.video,
+  );
+}
+
+final _vp8 = _videoOption(1, 'vp8');
+final _vp9 = _videoOption(2, 'vp9');
+
+/// A media track that can be cloned indefinitely, like a real one.
+rtc.MediaStreamTrack _mediaTrack(String id, {String kind = 'video'}) {
+  final track = _MockMediaStreamTrack();
+  var clones = 0;
+  when(() => track.id).thenReturn(id);
+  when(() => track.kind).thenReturn(kind);
+  when(() => track.enabled).thenReturn(true);
+  when(track.stop).thenAnswer((_) async {});
+  when(track.clone).thenAnswer(
+    (_) async => _mediaTrack('$id-c${clones++}', kind: kind),
+  );
+  return track;
+}
+
+/// A transceiver whose sender starts out sending [senderTrack] and follows
+/// `replaceTrack`, so `sender.track` reflects reality across a codec switch.
+rtc.RTCRtpTransceiver _transceiver(rtc.MediaStreamTrack? senderTrack) {
+  var current = senderTrack;
+
+  final sender = _MockSender();
+  when(() => sender.track).thenAnswer((_) => current);
+  when(() => sender.replaceTrack(any())).thenAnswer((invocation) async {
+    current = invocation.positionalArguments.first as rtc.MediaStreamTrack?;
+  });
+
+  final transceiver = _MockTransceiver();
+  when(() => transceiver.sender).thenReturn(sender);
+  when(() => transceiver.mid).thenReturn('');
+  when(transceiver.stop).thenAnswer((_) async {});
+  return transceiver;
+}
+
+RtcLocalVideoTrack _videoTrack(String mediaId) {
+  final mediaStream = _MockMediaStream();
+  when(mediaStream.dispose).thenAnswer((_) async {});
+
+  return RtcLocalTrack(
+    trackIdPrefix: 'pub',
+    trackType: SfuTrackType.video,
+    mediaStream: mediaStream,
+    mediaTrack: _mediaTrack(mediaId),
+    mediaConstraints: const CameraConstraints(),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    registerMockFallbackValues();
+    registerFallbackValue(_MockMediaStreamTrack());
+    registerFallbackValue(<rtc.RTCRtpEncoding>[]);
+  });
+
+  ({RtcManager manager, int Function() addCalls}) buildManager() {
+    final pc = _MockPeerConnection();
+    final publisher = _MockTracedStreamPeerConnection();
+    when(() => publisher.pc).thenReturn(pc);
+    when(() => publisher.isReconnecting).thenReturn(false);
+    when(() => publisher.onRenegotiationNeeded).thenReturn(null);
+
+    // A distinct transceiver per call, each tracking its own sender track.
+    var calls = 0;
+    when(
+      () => publisher.addVideoTransceiver(
+        track: any(named: 'track'),
+        encodings: any(named: 'encodings'),
+        degradationPreference: any(named: 'degradationPreference'),
+      ),
+    ).thenAnswer((invocation) async {
+      calls++;
+      final track = invocation.namedArguments[#track] as rtc.MediaStreamTrack?;
+      return Result.success(_transceiver(track));
+    });
+
+    final manager = RtcManager(
+      sessionId: 'test-session',
+      callCid: SampleCallData.defaultCid,
+      publisherId: 'test-publisher',
+      publisher: publisher,
+      subscriber: _MockTracedStreamPeerConnection(),
+      publishOptions: [_vp8],
+      stateManager: createTestCallStateManager(),
+      streamVideo: setupMockStreamVideo(),
+      pcFactory: StreamPeerConnectionFactory(
+        callCid: SampleCallData.defaultCid,
+      ),
+    );
+
+    return (manager: manager, addCalls: () => calls);
+  }
+
+  group('onPublishOptionsChanged', () {
+    test(
+      'a codec switched away and back is published again — retiring an option '
+      'must free its key, not leave it occupied by a trackless transceiver',
+      () async {
+        final wires = buildManager();
+
+        final published = await wires.manager.publishVideoTrack(
+          track: _videoTrack('cam'),
+        );
+        expect(published.isSuccess, isTrue);
+        expect(wires.addCalls(), 1);
+
+        // vp8 -> vp9: vp9 gets its own sender, vp8 is retired.
+        await wires.manager.onPublishOptionsChanged([_vp9]);
+        expect(wires.addCalls(), 2);
+        expect(wires.manager.transceiversManager.get(_vp9), isNotNull);
+        expect(
+          wires.manager.transceiversManager.get(_vp8),
+          isNull,
+          reason: 'the retired option must not keep its cache slot',
+        );
+
+        // ...and back. Without freeing the slot this reads as "already
+        // publishing in vp8" and the codec is silently never republished.
+        await wires.manager.onPublishOptionsChanged([_vp8]);
+
+        expect(wires.addCalls(), 3);
+        final revived = wires.manager.transceiversManager.get(_vp8);
+        expect(revived, isNotNull);
+        expect(
+          revived!.transceiver.sender.track,
+          isNotNull,
+          reason: 'the revived transceiver must actually be sending',
+        );
+      },
+    );
+
+    test('retiring an option stops its sender and clears the cache', () async {
+      final wires = buildManager();
+
+      await wires.manager.publishVideoTrack(track: _videoTrack('cam'));
+      final retired = wires.manager.transceiversManager.get(_vp8)!.transceiver;
+
+      await wires.manager.onPublishOptionsChanged([_vp9]);
+
+      expect(retired.sender.track, isNull);
+      expect(wires.manager.transceiversManager.get(_vp8), isNull);
+      expect(wires.manager.transceiversManager.items(), hasLength(1));
+      // The cache entry is gone, so the transceiver has to be stopped as well:
+      // `replaceTrack(null)` alone keeps its m-line sending, so it could never
+      // be recycled and every codec flip would append another one.
+      verify(retired.stop).called(1);
+    });
+
+    test(
+      'a transceiver that refuses to stop still leaves the retirement '
+      'complete — a closed peer connection must not strand the update',
+      () async {
+        final wires = buildManager();
+
+        await wires.manager.publishVideoTrack(track: _videoTrack('cam'));
+        final retired = wires.manager.transceiversManager
+            .get(_vp8)!
+            .transceiver;
+        when(retired.stop).thenThrow(StateError('peer connection is closed'));
+
+        await wires.manager.onPublishOptionsChanged([_vp9]);
+
+        expect(wires.manager.transceiversManager.get(_vp8), isNull);
+        expect(wires.manager.transceiversManager.get(_vp9), isNotNull);
+      },
+    );
+  });
+}

--- a/packages/stream_video/test/src/webrtc/rtc_manager_unmute_renegotiation_test.dart
+++ b/packages/stream_video/test/src/webrtc/rtc_manager_unmute_renegotiation_test.dart
@@ -116,6 +116,7 @@ void main() {
 
     final track = MockRtcLocalTrack();
     when(() => track.trackId).thenReturn(_trackId);
+    when(() => track.trackType).thenReturn(SfuTrackType.audio);
     when(() => track.stopTrackOnMute).thenReturn(false);
     when(() => track.mediaTrack).thenReturn(mediaTrack);
     manager.tracks[_trackId] = track;

--- a/packages/stream_video/test/src/webrtc/transceiver_cache_test.dart
+++ b/packages/stream_video/test/src/webrtc/transceiver_cache_test.dart
@@ -84,9 +84,9 @@ void main() {
       final option = _option(1, SfuTrackType.video);
 
       manager.add(
-        _MockLocalTrack(),
+        _localTrack('media-1'),
         option,
-        _transceiverWithTrack(_MockMediaStreamTrack()),
+        _transceiverWithTrack(_mediaTrack('media-1')),
         const RtcTrackPublishOptions(),
       );
 
@@ -313,6 +313,139 @@ void main() {
       manager.markNegotiated([_trackInfo('media-other', option, mid: '3')]);
 
       expect(manager.get(option)!.negotiatedMid, isNull);
+    });
+  });
+
+  group('TransceiverManager uniqueness', () {
+    test(
+      'add rejects a second transceiver with the same '
+      '(trackType, publishOptionId) — the SFU supports one track per type',
+      () {
+        final manager = TransceiverManager();
+        final option = _option(1, SfuTrackType.video);
+
+        expect(
+          manager.add(
+            _localTrack('media-1'),
+            option,
+            _transceiverWithTrack(_mediaTrack('media-1')),
+            const RtcTrackPublishOptions(),
+          ),
+          isTrue,
+        );
+
+        expect(
+          manager.add(
+            _localTrack('media-2'),
+            option,
+            _transceiverWithTrack(_mediaTrack('media-2')),
+            const RtcTrackPublishOptions(),
+          ),
+          isFalse,
+          reason: 'the caller has to dispose of the sender it just created',
+        );
+
+        // The incumbent is untouched — a rejected add must not half-replace it.
+        expect(manager.items(), hasLength(1));
+        expect(manager.get(option)!.track.mediaTrack.id, 'media-1');
+        expect(manager.get(option)!.sentTrackIds, {'media-1'});
+      },
+    );
+
+    test('allows the same publishOptionId across different track types', () {
+      final manager = TransceiverManager();
+
+      manager.add(
+        _localTrack('media-audio'),
+        _option(1, SfuTrackType.audio),
+        _transceiverWithTrack(_mediaTrack('media-audio')),
+        const RtcTrackPublishOptions(),
+      );
+      manager.add(
+        _localTrack('media-video'),
+        _option(1, SfuTrackType.video),
+        _transceiverWithTrack(_mediaTrack('media-video')),
+        const RtcTrackPublishOptions(),
+      );
+
+      expect(manager.items(), hasLength(2));
+    });
+
+    test('remove drops the entry and returns it', () {
+      final manager = TransceiverManager();
+      final option = _option(1, SfuTrackType.video);
+
+      manager.add(
+        _localTrack('media-1'),
+        option,
+        _transceiverWithTrack(_mediaTrack('media-1')),
+        const RtcTrackPublishOptions(),
+      );
+
+      final removed = manager.remove(option);
+
+      expect(removed, isNotNull);
+      expect(removed!.track.mediaTrack.id, 'media-1');
+      expect(manager.has(option), isFalse);
+      expect(manager.items(), isEmpty);
+
+      // The slot is publishable again after removal.
+      manager.add(
+        _localTrack('media-2'),
+        option,
+        _transceiverWithTrack(_mediaTrack('media-2')),
+        const RtcTrackPublishOptions(),
+      );
+      expect(manager.get(option)!.track.mediaTrack.id, 'media-2');
+    });
+
+    test('remove of an absent entry returns null', () {
+      final manager = TransceiverManager();
+
+      expect(manager.remove(_option(1, SfuTrackType.video)), isNull);
+    });
+  });
+
+  group('TransceiverCache.sentTrackIds', () {
+    test('accumulates every track the transceiver has sent', () {
+      final manager = TransceiverManager();
+      final option = _option(1, SfuTrackType.video);
+
+      manager.add(
+        _localTrack('clone-0'),
+        option,
+        _transceiverWithTrack(_mediaTrack('clone-0')),
+        const RtcTrackPublishOptions(),
+      );
+
+      // Each republish swaps in a fresh clone via `replaceTrack`. An offer
+      // created before the swap still names the id it replaced, so the history
+      // is what identifies the m-line as this transceiver's.
+      manager.update(option, track: _localTrack('clone-1'));
+      manager.update(option, track: _localTrack('clone-2'));
+
+      final entry = manager.get(option)!;
+      expect(entry.track.mediaTrack.id, 'clone-2');
+      expect(entry.sentTrackIds, {'clone-0', 'clone-1', 'clone-2'});
+    });
+
+    test('an update that carries no track leaves the history alone', () {
+      final manager = TransceiverManager();
+      final option = _option(1, SfuTrackType.video);
+
+      manager.add(
+        _localTrack('clone-0'),
+        option,
+        _transceiverWithTrack(_mediaTrack('clone-0')),
+        const RtcTrackPublishOptions(),
+      );
+
+      manager.update(
+        option,
+        trackPublishOptions: const RtcTrackPublishOptions(),
+      );
+
+      expect(manager.get(option)!.sentTrackIds, {'clone-0'});
     });
   });
 }


### PR DESCRIPTION
Fixes an issue where the same track could be published and announced twice in some cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate audio and video tracks during concurrent publishing or enabling.
  * Improved WebRTC reliability during reconnects, codec changes, and disposal while publishing.
  * Ensured transceivers and media tracks are correctly reused, stopped, and cleaned up.
  * Improved synchronization for track announcements, including pending and republished tracks.

* **Tests**
  * Added comprehensive coverage for concurrent publishing, renegotiation, codec switching, reconnects, and transceiver management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->