### PR TITLE
fix(llc): end CallKit call when late push is delivered

### DIFF
--- a/.github/actions/pana/action.yml
+++ b/.github/actions/pana/action.yml
@@ -48,7 +48,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       shell: bash
       run: |
-        PANA=$(pana . --no-warning); PANA_SCORE=$(echo $PANA | sed -n "s/.*Points: \([0-9]*\)\/\([0-9]*\)./\1\/\2/p")
+        PANA=$(pana . --no-warning --project-root "${{ github.workspace }}"); PANA_SCORE=$(echo $PANA | sed -n "s/.*Points: \([0-9]*\)\/\([0-9]*\)./\1\/\2/p")
         echo "Score: $PANA_SCORE"
         IFS='/'; read -a SCORE_ARR <<< "$PANA_SCORE"; SCORE=SCORE_ARR[0];
         if (( $SCORE < ${{inputs.min_score}} )); then echo "The minimum score of ${{inputs.min_score}} was not met!"; exit 1; fi

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 🐞 Fixed
 
+- Fixed the incoming call UI (CallKit on iOS) ringing for a call whose ringing flow was already resolved before the push was delivered.
 - Fixed the publisher announcing a stale track `mid` after a renegotiation or publish retry. It's now resolved from the current peer-connection state so the SFU can reliably match the track to its media.
 - Serialized remote-description and ICE-candidate handling so a candidate arriving mid-negotiation can no longer be dropped.
 - Fixed an issue where republishing could reuse a cached publisher transceiver without renegotiating.

--- a/packages/stream_video/lib/src/call/call_ringing_state.dart
+++ b/packages/stream_video/lib/src/call/call_ringing_state.dart
@@ -1,6 +1,63 @@
+import '../models/call_metadata.dart';
+import 'call_reject_reason.dart';
+
 enum CallRingingState {
   ended,
   rejected,
   accepted,
   ringing,
+}
+
+extension CallRingingStateX on CallRingingState {
+  bool get isRinging => this == CallRingingState.ringing;
+
+  /// The reason to settle the local call state with once the ringing flow is
+  /// over.
+  CallRejectReason? toReason() => switch (this) {
+    CallRingingState.ringing => null,
+    CallRingingState.ended => CallRejectReason.callEnded(),
+    CallRingingState.accepted ||
+    CallRingingState.rejected => CallRejectReason.userRespondedElsewhere(),
+  };
+}
+
+extension CallMetadataRingingStateX on CallMetadata {
+  /// Resolves whether this call is still worth ringing for [currentUserId],
+  /// based on the latest state fetched from the coordinator.
+  ///
+  /// Anything other than [CallRingingState.ringing] means the incoming call UI
+  /// should not be shown, or should be dismissed if it already is.
+  CallRingingState ringingStateFor(String currentUserId) {
+    if (details.endedAt != null || session.endedAt != null) {
+      return CallRingingState.ended;
+    }
+
+    if (session.acceptedBy.containsKey(currentUserId)) {
+      return CallRingingState.accepted;
+    }
+
+    if (session.rejectedBy.containsKey(currentUserId) ||
+        session.missedBy.containsKey(currentUserId)) {
+      return CallRingingState.rejected;
+    }
+
+    final creatorId = details.createdBy.id;
+
+    // The caller cancelled the ring and nobody else picked up in the meantime.
+    if (session.rejectedBy.containsKey(creatorId) &&
+        !session.acceptedBy.keys.any((userId) => userId != creatorId)) {
+      return CallRingingState.rejected;
+    }
+
+    // Everyone else already rejected the call.
+    final otherMembers = members.keys
+        .where((userId) => userId != currentUserId)
+        .toSet();
+    if (otherMembers.isNotEmpty &&
+        otherMembers.every(session.rejectedBy.containsKey)) {
+      return CallRingingState.rejected;
+    }
+
+    return CallRingingState.ringing;
+  }
 }

--- a/packages/stream_video/lib/src/coordinator/open_api/open_api_extensions.dart
+++ b/packages/stream_video/lib/src/coordinator/open_api/open_api_extensions.dart
@@ -593,6 +593,7 @@ extension CallSessionResponseExt on open.CallSessionResponse {
       participantsCountByRole: participantsCountByRole,
       rejectedBy: rejectedBy,
       acceptedBy: acceptedBy,
+      missedBy: missedBy,
       startedAt: startedAt,
       endedAt: endedAt,
       liveStartedAt: liveStartedAt,

--- a/packages/stream_video/lib/src/models/call_session_data.dart
+++ b/packages/stream_video/lib/src/models/call_session_data.dart
@@ -12,6 +12,7 @@ class CallSessionData extends Equatable {
     this.participantsCountByRole = const {},
     this.rejectedBy = const {},
     this.acceptedBy = const {},
+    this.missedBy = const {},
     this.startedAt,
     this.liveStartedAt,
     this.endedAt,
@@ -24,6 +25,7 @@ class CallSessionData extends Equatable {
   final Map<Role, int> participantsCountByRole;
   final Map<String, DateTime> rejectedBy;
   final Map<String, DateTime> acceptedBy;
+  final Map<String, DateTime> missedBy;
   final DateTime? startedAt;
   final DateTime? endedAt;
   final DateTime? liveStartedAt;

--- a/packages/stream_video/lib/src/models/call_session_data.dart
+++ b/packages/stream_video/lib/src/models/call_session_data.dart
@@ -35,8 +35,13 @@ class CallSessionData extends Equatable {
   @override
   List<Object?> get props => [
     id,
+    participants,
+    participantsCountByRole,
+    rejectedBy,
+    acceptedBy,
+    missedBy,
     startedAt,
-    liveStartedAt,
+    endedAt,
     liveStartedAt,
     liveEndedAt,
     timerEndsAt,

--- a/packages/stream_video/lib/src/push_notification/push_notification_manager.dart
+++ b/packages/stream_video/lib/src/push_notification/push_notification_manager.dart
@@ -98,7 +98,10 @@ abstract class PushNotificationManager {
   /// Ends the call.
   ///
   /// [cid] is the call id for the call.
-  Future<void> endCallByCid(String cid);
+  /// When [silent] is `true`, the resulting native events (decline/ended) are
+  /// suppressed. Use it when the ringing flow is already resolved and ending
+  /// the native call must not trigger the decline/ended handling again.
+  Future<void> endCallByCid(String cid, {bool silent = false});
 
   /// Ends all ongoing calls.
   Future<void> endAllCalls();

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -39,6 +39,7 @@ import 'logger/stream_log.dart';
 import 'logger/stream_logger.dart';
 import 'models/audio_configuration_policy.dart';
 import 'models/call_cid.dart';
+import 'models/call_metadata.dart';
 import 'models/call_preferences.dart';
 import 'models/call_received_data.dart';
 import 'models/call_ringing_data.dart';
@@ -335,6 +336,7 @@ class StreamVideo extends Disposable {
   final Map<String, bool> _mutedCameraByStateChange = {};
   final Map<String, bool> _mutedAudioByStateChange = {};
   final Map<String, Timer> _incomingAutoRejectTimers = {};
+  final Set<String> _handledIncomingCallCids = {};
 
   /// Returns the current user.
   UserInfo get currentUser => _state.currentUser.info;
@@ -868,6 +870,11 @@ class StreamVideo extends Disposable {
     observeCallDeclinedRingingEvent()?.addTo(ringingEventSubscriptions);
     observeCallEndedRingingEvent()?.addTo(ringingEventSubscriptions);
 
+    // The incoming call event can be emitted before this call (terminated state), in which case it
+    // isn't delivered to the subscription above at all, so incoming calls that
+    // are already displayed are picked up here.
+    unawaited(verifyDisplayedIncomingCalls());
+
     return ringingEventSubscriptions;
   }
 
@@ -990,13 +997,192 @@ class StreamVideo extends Disposable {
     final cid = event.data.callCid;
     if (uuid == null || cid == null) return;
 
-    final consumeResult = await consumeIncomingCall(uuid: uuid, cid: cid);
+    return _handleIncomingCall(uuid: uuid, cid: cid);
+  }
+
+  /// Verifies the incoming calls that are currently displayed by the OS.
+  ///
+  /// On iOS the incoming call UI is reported to CallKit as soon as the VoIP push
+  /// is received, which happens before the app is started when it was
+  /// terminated. The [ActionCallIncoming] event is then emitted while the app is
+  /// still setting up, before it subscribes to ringing events, and is missed
+  /// (the ringing events are broadcast, they are not replayed). Displayed calls
+  /// are therefore verified directly, so a ringing flow that was already
+  /// resolved is dismissed instead of ringing until the native timeout.
+  ///
+  /// Called automatically by [observeCoreRingingEvents].
+  Future<void> verifyDisplayedIncomingCalls() async {
+    final manager = pushNotificationManager;
+    if (manager == null) return;
+
+    final displayedCalls = await manager.activeCalls();
+    _logger.d(
+      () => '[verifyDisplayedIncomingCalls] calls: $displayedCalls',
+    );
+
+    for (final displayedCall in displayedCalls) {
+      final uuid = displayedCall.uuid;
+      final cid = displayedCall.callCid;
+      if (uuid == null || cid == null) continue;
+
+      // Answered calls are handled by the accept flow.
+      if (displayedCall.isAccepted) continue;
+
+      await _handleIncomingCall(uuid: uuid, cid: cid);
+    }
+  }
+
+  Future<void> _handleIncomingCall({
+    required String uuid,
+    required String cid,
+  }) async {
+    // The same call can be reported by the incoming call event and by the
+    // displayed calls verification at the same time.
+    if (!_handledIncomingCallCids.add(cid)) {
+      _logger.v(() => '[handleIncomingCall] already handling: $cid');
+      return;
+    }
+
+    try {
+      await _verifyAndConsumeIncomingCall(uuid: uuid, cid: cid);
+    } finally {
+      _handledIncomingCallCids.remove(cid);
+    }
+  }
+
+  Future<void> _verifyAndConsumeIncomingCall({
+    required String uuid,
+    required String cid,
+  }) async {
+    // The incoming call UI is already on screen at this point on iOS where the OS
+    // requires the CallKit call to be reported as soon as the VoIP push is
+    // received. Verify the call is still ringing and dismiss it if it isn't.
+    final callCid = StreamCallCid(cid: cid);
+    final metadata = await _getCallForRingingEvent(callCid);
+
+    if (metadata == null) {
+      // The state couldn't be verified. Keep ringing instead of dismissing a
+      // call that might still be valid, consumeIncomingCall retries the fetch.
+      _logger.w(
+        () => '[verifyIncomingCall] could not verify ringing state: $cid',
+      );
+    } else {
+      final ringingState = metadata.ringingStateFor(_state.currentUser.id);
+
+      if (!ringingState.isRinging) {
+        // Never end the native call when it's already being answered on this
+        // device (in the app or on the native call screen while the state was
+        // still being verified), as that would tear down the ongoing call.
+        if (await _isAnsweredOnThisDevice(cid)) {
+          _logger.d(
+            () =>
+                '[verifyIncomingCall] call is no longer ringing ($ringingState) '
+                'but is answered on this device, keeping it: $cid',
+          );
+          return;
+        }
+
+        _logger.d(
+          () =>
+              '[verifyIncomingCall] call is no longer ringing ($ringingState), '
+              'dismissing incoming call UI: $cid',
+        );
+
+        // Silently, as the ringing flow is already resolved and the native end
+        // must not be reported back as a decline/ended action.
+        await pushNotificationManager?.endCallByCid(cid, silent: true);
+
+        _cancelIncomingAutoRejectTimerByCid(cid);
+        await _resolveStaleIncomingCall(cid, ringingState);
+        return;
+      }
+    }
+
+    final consumeResult = await consumeIncomingCall(
+      uuid: uuid,
+      cid: cid,
+      metadata: metadata,
+    );
 
     final incomingCall = consumeResult.getDataOrNull();
     if (incomingCall == null) return;
 
     final timeout = incomingCall.state.value.settings.ring.autoRejectTimeout;
     _startIncomingAutoRejectTimer(incomingCall, timeout);
+  }
+
+  /// Fetches the call state used to decide whether the incoming call UI should
+  /// stay on screen. Returns `null` when the state can't be established.
+  ///
+  /// The push is often delivered while the client is still starting up (cold
+  /// start after the app was terminated), and `getCall` only waits for the
+  /// coordinator connection, it doesn't establish it. Connecting first is what
+  /// makes the check work in that case instead of timing out and leaving a
+  /// resolved call ringing.
+  Future<CallMetadata?> _getCallForRingingEvent(StreamCallCid callCid) async {
+    final connectResult = await connect(
+      includeUserDetails: _options.includeUserDetailsForAutoConnect,
+    );
+
+    if (connectResult.isFailure) {
+      _logger.e(
+        () =>
+            '[getCallForRingingEvent] failed to connect: '
+            '${connectResult.getErrorOrNull()}',
+      );
+      return null;
+    }
+
+    final callResult = await _client.getCall(callCid: callCid);
+    if (callResult is! Success<CallReceivedData>) {
+      _logger.e(
+        () =>
+            '[getCallForRingingEvent] failed to get call: '
+            '${callResult.getErrorOrNull()}',
+      );
+      return null;
+    }
+
+    return callResult.data.metadata;
+  }
+
+  /// Whether the call is already being answered on this device, either in the
+  /// app or on the native call screen.
+  Future<bool> _isAnsweredOnThisDevice(String cid) async {
+    if (activeCalls.any((call) => call.callCid.value == cid)) return true;
+
+    // The native call is marked as accepted from the moment it's answered on the
+    // native call screen, before the call is joined in the app.
+    final nativeCalls = await pushNotificationManager?.activeCalls();
+    return nativeCalls?.any(
+          (call) => call.callCid == cid && call.isAccepted,
+        ) ??
+        false;
+  }
+
+  /// Brings the in-app incoming call in sync with a ringing flow that turned
+  /// out to be already resolved.
+  Future<void> _resolveStaleIncomingCall(
+    String cid,
+    CallRingingState ringingState,
+  ) async {
+    final incomingCall = _state.incomingCall.valueOrNull;
+    if (incomingCall == null || incomingCall.callCid.value != cid) return;
+
+    _logger.d(
+      () => '[resolveStaleIncomingCall] cid: $cid, state: $ringingState',
+    );
+
+    await incomingCall.leave(
+      reason: DisconnectReason.rejected(
+        byUserId: _state.currentUser.id,
+        reason: ringingState.toReason(),
+      ),
+    );
+
+    if (_state.incomingCall.valueOrNull == incomingCall) {
+      _state.incomingCall.value = null;
+    }
   }
 
   Future<void> _onCallDecline(ActionCallDecline event) async {
@@ -1200,44 +1386,24 @@ class StreamVideo extends Disposable {
         return CallRingingState.ended;
       },
       success: (success) {
-        final callData = success.data;
-
-        if (callData.metadata.session.acceptedBy.containsKey(
+        final state = success.data.metadata.ringingStateFor(
           _state.currentUser.id,
-        )) {
-          _logger.d(() => '[getCallRingingState] call already accepted');
-          return CallRingingState.accepted;
-        }
-
-        if (callData.metadata.session.rejectedBy.containsKey(
-          _state.currentUser.id,
-        )) {
-          _logger.d(() => '[getCallRingingState] call already rejected');
-          return CallRingingState.rejected;
-        }
-
-        final otherMembers = callData.metadata.members.keys.toList()
-          ..remove(_state.currentUser.id);
-        if (callData.metadata.session.rejectedBy.keys.toSet().containsAll(
-          otherMembers,
-        )) {
-          _logger.d(
-            () =>
-                '[getCallRingingState] call already rejected by all other members',
-          );
-          return CallRingingState.rejected;
-        }
-
-        return CallRingingState.ringing;
+        );
+        _logger.d(() => '[getCallRingingState] state: $state');
+        return state;
       },
     );
   }
 
   /// Consumes incoming voIP call and returns the [Call] object.
+  ///
+  /// Pass [metadata] when the caller already fetched the call state to avoid
+  /// requesting it a second time.
   Future<Result<Call>> consumeIncomingCall({
     required String uuid,
     required String cid,
     CallPreferences? preferences,
+    CallMetadata? metadata,
   }) async {
     _logger.d(() => '[consumeIncomingCall] uuid: $uuid, cid: $cid');
     final manager = pushNotificationManager;
@@ -1257,16 +1423,22 @@ class StreamVideo extends Disposable {
     }
 
     final callCid = StreamCallCid(cid: cid);
-    final callResult = await _client.getCall(callCid: callCid);
-    if (callResult is! Success<CallReceivedData>) {
-      return callResult as Failure;
+
+    var callMetadata = metadata;
+    if (callMetadata == null) {
+      final callResult = await _client.getCall(callCid: callCid);
+      if (callResult is! Success<CallReceivedData>) {
+        return callResult as Failure;
+      }
+
+      callMetadata = callResult.data.metadata;
     }
 
     final call = _makeCallFromRinging(
       data: CallRingingData(
         callCid: callCid,
         ringing: true,
-        metadata: callResult.data.metadata,
+        metadata: callMetadata,
       ),
       preferences: preferences ?? _options.defaultCallPreferences,
     );

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -1122,6 +1122,9 @@ class StreamVideo extends Disposable {
   Future<CallMetadata?> _getCallForRingingEvent(StreamCallCid callCid) async {
     final connectResult = await connect(
       includeUserDetails: _options.includeUserDetailsForAutoConnect,
+      // The device is registered already, otherwise the push wouldn't have been
+      // delivered. Registering it is not this flow's concern.
+      registerPushDevice: false,
     );
 
     if (connectResult.isFailure) {

--- a/packages/stream_video/test/src/call/call_ringing_state_test.dart
+++ b/packages/stream_video/test/src/call/call_ringing_state_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_video/src/call/call_reject_reason.dart';
+import 'package:stream_video/src/call/call_ringing_state.dart';
+import 'package:stream_video/src/call/call_type.dart';
+import 'package:stream_video/src/models/models.dart';
+
+const _currentUserId = 'current-user';
+const _creatorId = 'creator';
+
+CallMetadata _metadata({
+  DateTime? endedAt,
+  DateTime? sessionEndedAt,
+  Map<String, DateTime> acceptedBy = const {},
+  Map<String, DateTime> rejectedBy = const {},
+  Map<String, DateTime> missedBy = const {},
+  List<String> memberIds = const [_creatorId, _currentUserId],
+  String creatorId = _creatorId,
+}) {
+  return CallMetadata(
+    cid: StreamCallCid.from(
+      type: StreamCallType.defaultType(),
+      id: 'test-cid',
+    ),
+    session: CallSessionData(
+      acceptedBy: acceptedBy,
+      rejectedBy: rejectedBy,
+      missedBy: missedBy,
+      endedAt: sessionEndedAt,
+    ),
+    users: const {},
+    members: {
+      for (final userId in memberIds)
+        userId: CallMember(
+          userId: userId,
+          roles: const ['user'],
+          custom: const {},
+        ),
+    },
+    details: CallDetails(
+      createdBy: CallUser(
+        id: creatorId,
+        name: creatorId,
+        roles: const ['user'],
+        image: '',
+      ),
+      team: '',
+      ownCapabilities: const [],
+      blockedUserIds: const [],
+      broadcasting: false,
+      recording: false,
+      backstage: false,
+      transcribing: false,
+      captioning: false,
+      egress: const CallEgress(),
+      custom: const {},
+      rtmpIngress: '',
+      endedAt: endedAt,
+    ),
+    settings: const CallSettings(),
+  );
+}
+
+Map<String, DateTime> _at(List<String> userIds) => {
+  for (final userId in userIds) userId: DateTime.utc(2026),
+};
+
+void main() {
+  group('ringingStateFor', () {
+    test('is ringing while nothing resolved the flow', () {
+      final state = _metadata(
+        memberIds: const [_creatorId, _currentUserId, 'other-1', 'other-2'],
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.ringing);
+    });
+
+    test('is ended when the call ended', () {
+      final state = _metadata(
+        endedAt: DateTime.utc(2026),
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.ended);
+    });
+
+    test('is ended when the session ended', () {
+      final state = _metadata(
+        sessionEndedAt: DateTime.utc(2026),
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.ended);
+    });
+
+    test('is accepted when accepted by the current user elsewhere', () {
+      final state = _metadata(
+        acceptedBy: _at([_currentUserId]),
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.accepted);
+    });
+
+    test('is rejected when rejected by the current user elsewhere', () {
+      final state = _metadata(
+        rejectedBy: _at([_currentUserId]),
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.rejected);
+    });
+
+    test('is rejected when missed by the current user', () {
+      final state = _metadata(
+        missedBy: _at([_currentUserId]),
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.rejected);
+    });
+
+    test('is rejected when the caller cancelled the ring', () {
+      final state = _metadata(
+        rejectedBy: _at([_creatorId]),
+        memberIds: const [_creatorId, _currentUserId, 'other-1'],
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.rejected);
+    });
+
+    test('keeps ringing when the caller cancelled but someone accepted', () {
+      final state = _metadata(
+        rejectedBy: _at([_creatorId]),
+        acceptedBy: _at(['other-1']),
+        memberIds: const [_creatorId, _currentUserId, 'other-1'],
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.ringing);
+    });
+
+    test('keeps ringing when only one other invitee rejected', () {
+      final state = _metadata(
+        rejectedBy: _at(['other-1']),
+        memberIds: const [_creatorId, _currentUserId, 'other-1', 'other-2'],
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.ringing);
+    });
+
+    test('keeps ringing when every invitee but the caller rejected', () {
+      final state = _metadata(
+        rejectedBy: _at(['other-1', 'other-2']),
+        memberIds: const [_creatorId, _currentUserId, 'other-1', 'other-2'],
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.ringing);
+    });
+
+    test('is rejected when everyone else, caller included, rejected', () {
+      final state = _metadata(
+        rejectedBy: _at([_creatorId, 'other-1', 'other-2']),
+        memberIds: const [_creatorId, _currentUserId, 'other-1', 'other-2'],
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.rejected);
+    });
+
+    test('is rejected when everyone else rejected without the caller', () {
+      // The caller isn't part of the member list here, so the everyone-rejected
+      // fallback is the only rule that can resolve the flow.
+      final state = _metadata(
+        rejectedBy: _at(['other-1', 'other-2']),
+        memberIds: const [_currentUserId, 'other-1', 'other-2'],
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.rejected);
+    });
+
+    test('keeps ringing when the current user is the only member', () {
+      final state = _metadata(
+        memberIds: const [_currentUserId],
+      ).ringingStateFor(_currentUserId);
+
+      expect(state, CallRingingState.ringing);
+    });
+  });
+
+  group('CallRingingState', () {
+    test('isRinging is only set for the ringing state', () {
+      expect(CallRingingState.ringing.isRinging, isTrue);
+      expect(CallRingingState.ended.isRinging, isFalse);
+      expect(CallRingingState.accepted.isRinging, isFalse);
+      expect(CallRingingState.rejected.isRinging, isFalse);
+    });
+
+    test('toReason maps every state to a reject reason', () {
+      expect(CallRingingState.ringing.toReason(), isNull);
+      expect(
+        CallRingingState.ended.toReason(),
+        CallRejectReason.callEnded(),
+      );
+      expect(
+        CallRingingState.accepted.toReason(),
+        CallRejectReason.userRespondedElsewhere(),
+      );
+      expect(
+        CallRingingState.rejected.toReason(),
+        CallRejectReason.userRespondedElsewhere(),
+      );
+    });
+  });
+}

--- a/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
+++ b/packages/stream_video_push_notification/lib/src/stream_video_push_notification.dart
@@ -425,7 +425,7 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
       StreamVideoPushNotificationPlatform.instance.endCall(uuid);
 
   @override
-  Future<void> endCallByCid(String cid) async {
+  Future<void> endCallByCid(String cid, {bool silent = false}) async {
     final activeCalls = await this.activeCalls();
     final calls = activeCalls
         .where((call) => call.callCid == cid && call.uuid != null)
@@ -434,9 +434,11 @@ class StreamVideoPushNotificationManager implements PushNotificationManager {
     // If multiple native ringing calls are stacked with identical metadata,
     // ending by callCid may not be sufficient; fall back to endAllCalls.
     if (activeCalls.length == calls.length) {
+      if (silent) RingingEventBroadcaster().suppressEvent();
       await endAllCalls();
     } else {
       for (final call in calls) {
+        if (silent) RingingEventBroadcaster().suppressEvent();
         await endCall(call.uuid!);
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS incoming-call handling when ringing has already been resolved before push delivery.
  * Automatically dismisses stale native call screens without triggering duplicate events.
  * Keeps in-app and system call states synchronized for missed, rejected, cancelled, and ended calls.
  * Prevents duplicate processing of simultaneous incoming-call notifications.

* **Improvements**
  * Added clearer ringing-state and rejection-reason handling.
  * Added tracking for missed-call details.
  * Added optional silent call ending to suppress native events when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->