### PR TITLE
chore(repo): add update_goldens workflow

### DIFF
--- a/.github/workflows/update_goldens.yml
+++ b/.github/workflows/update_goldens.yml
@@ -1,0 +1,51 @@
+name: update_goldens
+
+env:
+  FLUTTER_CHANNEL: stable
+  FLUTTER_VERSION: 3.44.1
+
+on: workflow_dispatch
+
+permissions:
+  contents: write
+
+jobs:
+  update_goldens:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          # Bot token so the pushed commit can re-trigger CI on the branch.
+          token: ${{ secrets.BOT_GITHUB_API_TOKEN }}
+
+      - name: 🐦 Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          cache: true
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+
+      - name: 🛠️ Install Tools
+        run: flutter pub global activate melos
+
+      - name: 🧹 Clean Workspace
+        run: melos postclean
+
+      - name: 🔧 Bootstrap Workspace
+        run: melos bootstrap --verbose
+
+      - name: ⚙️ Prepare Environment
+        run: melos run generate:all
+
+      - name: 🖼️ Update Goldens
+        run: melos run update:goldens
+
+      - name: 📤 Commit Changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "chore: update goldens"
+          file_pattern: "**/test/**/goldens/**/*.png"
+          commit_user_name: "Stream SDK Bot"
+          commit_user_email: "60655709+Stream-SDK-Bot@users.noreply.github.com"


### PR DESCRIPTION
### 🎯 Goal

We should improve on the golden snapshot tests, but we don't have a workflow to make snapshots on remote.

### 🛠 Implementation details

This adds same workflow as chat and core have.
