### PR TITLE
ci: raise fastlane's xcodebuild -showBuildSettings timeout

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -37,11 +37,6 @@ env:
   APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
   APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
   FASTLANE_APPLE_ID: ${{ secrets.FASTLANE_APPLE_ID }}
-  # fastlane runs `xcodebuild -showBuildSettings` before building and allows it
-  # 3 seconds by default. That call has to load the Swift package graph, which
-  # for this project is ~57 packages (Firebase, gRPC, StreamWebRTC, and every
-  # Flutter plugin) and takes over a minute on a cold runner — so the default
-  # times out and the build fails before compiling anything.
   FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
 
 concurrency:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -37,6 +37,12 @@ env:
   APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
   APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
   FASTLANE_APPLE_ID: ${{ secrets.FASTLANE_APPLE_ID }}
+  # fastlane runs `xcodebuild -showBuildSettings` before building and allows it
+  # 3 seconds by default. That call has to load the Swift package graph, which
+  # for this project is ~57 packages (Firebase, gRPC, StreamWebRTC, and every
+  # Flutter plugin) and takes over a minute on a cold runner — so the default
+  # times out and the build fails before compiling anything.
+  FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The iOS distribute job intermittently fails **before compiling anything**:

```
[!] xcodebuild -showBuildSettings timed out after 4 retries with a base timeout of 3.
```

Most recently in [run 33056980046](https://github.com/GetStream/stream-video-flutter/actions/runs/33056980046/job/98466125568).

<img width="1053" height="851" alt="image" src="https://github.com/user-attachments/assets/2f7d6502-fdbe-4168-b888-1915d2065e16" />


## Cause

fastlane calls `xcodebuild -showBuildSettings` during `build_app` setup and allows it **3 seconds** by default. That call has to load the Swift package graph, and this project resolves ~57 packages — Firebase, gRPC, GoogleAppMeasurement, StreamWebRTC, and every Flutter plugin.

In a run that *succeeded* on the same commits 90 minutes earlier, `Resolve Package Graph` alone took **67 seconds**. So the default is far below what the step actually needs, and the job passes or fails depending on how warm the runner caches happen to be — which matches the intermittent red on `main`.

Worth noting what this is *not*: the build never starts, so nothing in the app or its dependencies is implicated. The `Cannot find "Runner.xcodeproj/../YES"` warning higher up in the log is a red herring — it appears in successful runs too.

## Change

Raise `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT` to 120s.

Retries are deliberately left at the default. The first attempt should now comfortably succeed, and raising both would multiply the worst-case wait for a build that is genuinely stuck. The job’s own `timeout-minutes: 60` still bounds it.

## Verification

I can only verify this statically — the failure needs a cold GitHub runner to reproduce, so the real check is watching whether the intermittent red goes away.

- YAML parses, and the new key is picked up in the `env` block.
- `app-distribute.yml` is the only workflow that invokes fastlane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved App Distribute workflow reliability by allowing additional time for build settings operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->