### PR TITLE
fix(samples, llc): wasm compatibility

### DIFF
--- a/dogfooding/lib/screens/login_screen.dart
+++ b/dogfooding/lib/screens/login_screen.dart
@@ -189,10 +189,7 @@ class _LoginScreenState extends State<LoginScreen> {
     try {
       await authController.login(user, environment);
     } catch (e, stk) {
-      debugPrint(
-        'Login failed for user ${user.info.id} '
-        'on ${environment.name}: $e\n$stk',
-      );
+      debugPrint('Login failed: $e\n$stk');
       if (mounted) hideLoadingIndicator(context);
       _showSnackBar('Error: $e');
     } finally {

--- a/dogfooding/lib/screens/login_screen.dart
+++ b/dogfooding/lib/screens/login_screen.dart
@@ -51,8 +51,8 @@ class _LoginScreenState extends State<LoginScreen> {
     final googleService = await locator.getAsync<GoogleSignIn>();
     _googleAuthSubscription = googleService.authenticationEvents.listen(
       _handleGoogleAuthEvent,
-      onError: (Object e) {
-        debugPrint('Google auth event error: $e');
+      onError: (Object e, StackTrace stk) {
+        debugPrint('Google auth event error: $e\n$stk');
         _showSnackBar('Google sign-in failed: $e');
       },
     );
@@ -84,8 +84,8 @@ class _LoginScreenState extends State<LoginScreen> {
         // Result delivered via authenticationEvents -> _handleGoogleAuthEvent.
         await googleService.authenticate();
       }
-    } catch (e) {
-      debugPrint('Google sign-in failed: $e');
+    } catch (e, stk) {
+      debugPrint('Google sign-in failed: $e\n$stk');
       _showSnackBar('Google sign-in failed: $e');
     }
   }
@@ -112,8 +112,8 @@ class _LoginScreenState extends State<LoginScreen> {
         name: user.displayName ?? '',
         image: user.photoURL,
       );
-    } catch (e) {
-      debugPrint('Google sign-in failed: $e');
+    } catch (e, stk) {
+      debugPrint('Google sign-in failed: $e\n$stk');
       _showSnackBar('Google sign-in failed: $e');
     }
   }
@@ -188,7 +188,11 @@ class _LoginScreenState extends State<LoginScreen> {
 
     try {
       await authController.login(user, environment);
-    } catch (e) {
+    } catch (e, stk) {
+      debugPrint(
+        'Login failed for user ${user.info.id} '
+        'on ${environment.name}: $e\n$stk',
+      );
       if (mounted) hideLoadingIndicator(context);
       _showSnackBar('Error: $e');
     } finally {

--- a/dogfooding/web/index.html
+++ b/dogfooding/web/index.html
@@ -33,31 +33,10 @@
   <title>dogfooding</title>
   <link rel="manifest" href="manifest.json">
 
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    { { flutter_service_worker_version } }
-  </script>
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script>
 </head>
 
 <body>
-  <script>
-    window.addEventListener('load', function (ev) {
-      // Download main.dart.js
-      _flutter.loader.load({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        }
-      }).then(function (engineInitializer) {
-        return engineInitializer.initializeEngine();
-      }).then(function (appRunner) {
-        return appRunner.runApp();
-      });
-    });
-  </script>
-
-  <script src="main.dart.js" type="application/javascript"></script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 
 </html>

--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added the `ActionCallIncomingFailed` ringing event and `IncomingCallFailureReason`, raised when the platform call UI refuses to display an incoming call. iOS only, and most useful when Do Not Disturb or the block list filtered the call before it was ever shown. Observe it with `onRingingEvent<ActionCallIncomingFailed>` and decide what to do: the SDK deliberately takes no action, because rejecting a filtered call ends the ring on every device the user is being called on.
 
+### 🔄 Changed
+
+- Raised the minimum `dart_webrtc` to `1.8.2`, required for WebAssembly builds.
+
 ### 🐞 Fixed
 
 - [Android] Fixed a call hung up outside the app, from a paired watch, a Bluetooth headset or a car head unit, not leaving the Stream call. Ended events carrying `CallData.endedBySystem` are now applied on Android too, while the ambiguous ones, which on Android also mean the incoming call notification was merely dismissed, keep being ignored. Requires the Android Telecom integration in `stream_video_push_notification`.

--- a/packages/stream_video/pubspec.yaml
+++ b/packages/stream_video/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   battery_plus: ^7.0.0
   collection: ^1.19.1
   connectivity_plus: ^7.0.0
-  dart_webrtc: ^1.5.3+hotfix.2
+  dart_webrtc: ^1.8.2
   device_info_plus: ">=12.1.0 <14.0.0"
   equatable: ^2.0.7
   fixnum: ^1.1.1

--- a/packages/stream_video_flutter/example/web/index.html
+++ b/packages/stream_video_flutter/example/web/index.html
@@ -32,27 +32,8 @@
   <title>example</title>
   <link rel="manifest" href="manifest.json">
 
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    var serviceWorkerVersion = null;
-  </script>
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script>
 </head>
 <body>
-  <script>
-    window.addEventListener('load', function(ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        }
-      }).then(function(engineInitializer) {
-        return engineInitializer.initializeEngine();
-      }).then(function(appRunner) {
-        return appRunner.runApp();
-      });
-    });
-  </script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -397,10 +397,10 @@ packages:
     dependency: transitive
     description:
       name: dart_webrtc
-      sha256: f6d615bddea5e458ce180a914f3055c234ffb52fb7397a51b3491e76d6d7edb2
+      sha256: "078e3c431500147e5cc52b3c6ea41ed538f30c7720cc2467d2186c9251e62716"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   dbus:
     dependency: transitive
     description:
@@ -1073,10 +1073,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -1125,14 +1125,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.5+2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -1241,10 +1233,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1265,10 +1257,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -2054,10 +2046,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   theme_extensions_builder_annotation:
     dependency: transitive
     description:
@@ -2246,10 +2238,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   video_player:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ melos:
 
       # Dependency constraints synced into every package that declares them.
       dependencies:
-        dart_webrtc: ^1.5.3+hotfix.2
+        dart_webrtc: ^1.8.2
         device_info_plus: ">=12.1.0 <14.0.0"
         google_fonts: ^8.0.2
         package_info_plus: ">=9.0.0 <11.0.0"


### PR DESCRIPTION
### 🎯 Goal

Wasm compatibility
https://github.com/GetStream/stream-video-flutter/issues/737#issuecomment-5536592751

### 🛠 Implementation details

This updates dart_webrtc to have wasm compatibility.
Video was already wasm compatible basically, but the demo apps had an outdated index.html file. Also chat couldn't initialize in the dogfooding app: https://github.com/GetStream/stream-chat-flutter/pull/2940

Running it with overrides to a local checkout of stream_chat or git override is needed to test dogfooding.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login and Google authentication errors now include diagnostic stack traces in logs while preserving existing snackbar behavior.

* **Web**
  * Updated Flutter web startup to use the modern asynchronous bootstrap loader for improved compatibility.

* **Chores**
  * Updated the minimum `dart_webrtc` version to 1.8.2, enabling WebAssembly builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->