### PR TITLE
feat(ui): pick any participant layout from a menu

### DIFF
--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'dart:convert';
 
 // � Package imports:
+import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
 // �🐦 Flutter imports:
 import 'package:flutter/material.dart';
@@ -221,31 +222,31 @@ class _CallScreenState extends State<CallScreen> {
   // than held as fields: they close over the call the content builder hands
   // in, and a bar rebuilds whenever the window crosses a breakpoint anyway.
 
-  // The sample offers every layout, minus the two that stand a column of
-  // participants beside the speaker: on a phone-width window that column
-  // leaves the speaker too narrow to be worth looking at.
-  List<ParticipantLayoutMode> get _layoutOptions => [
-    for (final layout in ParticipantLayoutModeX.selectable)
-      if (!context.streamScreenSize.isSmall ||
-          (layout != ParticipantLayoutMode.speakerLeft &&
-              layout != ParticipantLayoutMode.speakerRight))
-        layout,
-  ];
-
   // The menu opens away from wherever the button sits: upwards out of the
   // control bar along the bottom, downwards out of the app bar.
   StreamLayoutButton _layoutToggle({
     StreamMenuDirection direction = StreamMenuDirection.up,
-  }) => StreamLayoutButton(
-    layout: _currentLayoutMode,
-    layouts: _layoutOptions,
-    direction: direction,
-    onLayoutModeChanged: (layout) {
-      setState(() {
-        _currentLayoutMode = layout;
-      });
-    },
-  );
+  }) {
+    final blocked = context.streamScreenSize.isSmall
+        ? const [
+            ParticipantLayoutMode.speakerLeft,
+            ParticipantLayoutMode.speakerRight,
+          ]
+        : const <ParticipantLayoutMode>[];
+
+    return StreamLayoutButton(
+      layout: _currentLayoutMode,
+      layouts: ParticipantLayoutModeX.selectable
+          .whereNot(blocked.contains)
+          .toList(),
+      direction: direction,
+      onLayoutModeChanged: (layout) {
+        setState(() {
+          _currentLayoutMode = layout;
+        });
+      },
+    );
+  }
 
   StreamScreenShareButton _screenShareOption(Call call) =>
       StreamScreenShareButton(

--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -225,7 +225,7 @@ class _CallScreenState extends State<CallScreen> {
   // The menu opens away from wherever the button sits: upwards out of the
   // control bar along the bottom, downwards out of the app bar.
   StreamLayoutButton _layoutToggle({
-    StreamMenuDirection direction = StreamMenuDirection.up,
+    StreamMenuDirection menuDirection = StreamMenuDirection.up,
   }) {
     final blocked = context.streamScreenSize.isSmall
         ? const [
@@ -239,7 +239,7 @@ class _CallScreenState extends State<CallScreen> {
       layouts: ParticipantLayoutModeX.selectable
           .whereNot(blocked.contains)
           .toList(),
-      direction: direction,
+      menuDirection: menuDirection,
       onLayoutModeChanged: (layout) {
         setState(() {
           _currentLayoutMode = layout;
@@ -507,7 +507,9 @@ class _CallScreenState extends State<CallScreen> {
                   leading: Row(
                     children: [
                       if (isCompact)
-                        _layoutToggle(direction: StreamMenuDirection.down),
+                        _layoutToggle(
+                          menuDirection: StreamMenuDirection.down,
+                        ),
                       PartialCallStateBuilder(
                         call: call,
                         selector: (state) => state.localParticipant != null,

--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -73,7 +73,7 @@ class _CallScreenState extends State<CallScreen> {
 
   Channel? _channel;
   StreamSubscription<Event>? _chatConnectionRecoverySubscription;
-  ParticipantLayoutMode _currentLayoutMode = ParticipantLayoutMode.grid;
+  ParticipantLayoutMode _currentLayoutMode = ParticipantLayoutMode.auto;
   bool _moreMenuVisible = false;
 
   @override
@@ -221,8 +221,25 @@ class _CallScreenState extends State<CallScreen> {
   // than held as fields: they close over the call the content builder hands
   // in, and a bar rebuilds whenever the window crosses a breakpoint anyway.
 
-  StreamLayoutButton _layoutToggle() => StreamLayoutButton(
+  // The sample offers every layout, minus the two that stand a column of
+  // participants beside the speaker: on a phone-width window that column
+  // leaves the speaker too narrow to be worth looking at.
+  List<ParticipantLayoutMode> get _layoutOptions => [
+    for (final layout in ParticipantLayoutModeX.selectable)
+      if (!context.streamScreenSize.isSmall ||
+          (layout != ParticipantLayoutMode.speakerLeft &&
+              layout != ParticipantLayoutMode.speakerRight))
+        layout,
+  ];
+
+  // The menu opens away from wherever the button sits: upwards out of the
+  // control bar along the bottom, downwards out of the app bar.
+  StreamLayoutButton _layoutToggle({
+    StreamMenuDirection direction = StreamMenuDirection.up,
+  }) => StreamLayoutButton(
     layout: _currentLayoutMode,
+    layouts: _layoutOptions,
+    direction: direction,
     onLayoutModeChanged: (layout) {
       setState(() {
         _currentLayoutMode = layout;
@@ -488,7 +505,8 @@ class _CallScreenState extends State<CallScreen> {
                   showLeaveCallAction: isCompact,
                   leading: Row(
                     children: [
-                      if (isCompact) _layoutToggle(),
+                      if (isCompact)
+                        _layoutToggle(direction: StreamMenuDirection.down),
                       PartialCallStateBuilder(
                         call: call,
                         selector: (state) => state.localParticipant != null,

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -204,6 +204,7 @@
 
 - `ParticipantLayoutMode.auto` is the default layout of `StreamCallContent`, `StreamCallParticipants` and `RegularCallParticipantsContent`, and renders what `grid` used to. The livestream widgets still default to `grid`.
 - `ParticipantLayoutMode.grid` gives the local participant a tile of its own instead of floating them over the grid.
+- `ParticipantLayoutMode.auto` floats the self-view on mobile only while at most two other people are in the call, and gives the local participant a tile beyond that.
 - `speakerOneToOne` floats the self-view on desktop too. Passing `enableLocalVideo: false` still suppresses it.
 - `ParticipantLayoutMode.pictureInPicture` spotlights the speaker alone under its new name, where it used to draw a grid.
 - `enableLocalVideo` is `enableFloatingSelfView` now, and `localVideoParticipantBuilder` is `floatingSelfViewBuilder`. `dart fix --apply` renames both.

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -157,7 +157,8 @@
 - The floating self-view draws no name pill, whatever an app-wide participant tile theme asks for. `StreamFloatingParticipantTileStyle.tileStyle` still can.
 - A participant tile keeps the name in its label at every size it draws the label at, truncating with an ellipsis.
 - The participant label stops growing at 268px, set by `StreamParticipantLabelStyle.maxWidth`.
-
+- `StreamCallParticipants` re-sorts when the layout changes, so a speaker layout spotlights the speaker instead of whoever the previous layout put first.
+- A speaker layout with no participants bar spotlights a remote participant rather than the local one.
 - An in-call device menu marks the device the call is using, instead of leaving every row unselected.
 - A device menu no longer offers the platform's own choice twice on web, once as "Default" and once as the browser's own entry.
 - The microphone and camera controls no longer flash the muted look while a call is being joined.

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added layout strings to the localizations, in English and Dutch: `layoutMenuTitle`, `layoutSelectTooltip`, `layoutDefault`, `layoutGrid`, `layoutSpeakerTop`, `layoutSpeakerBottom`, `layoutSpeakerLeft`, `layoutSpeakerRight` and `layoutSpeakerOneToOne`.
 - `ParticipantLayoutMode` offers `auto`, `grid`, `speakerTop`, `speakerBottom`, `speakerLeft`, `speakerRight` and `speakerOneToOne`.
 - `ParticipantLayoutMode` carries its own presentation: `selectable`, `canonical`, `barAlignment`, `isSpeakerLayout`, `icon` and `label`.
-- `StreamLayoutButton` takes `layouts`, to choose what it offers, and `direction`, for which way the menu opens.
+- `StreamLayoutButton` takes `layouts`, to choose what it offers, and `menuDirection`, for which way the menu opens.
 - `CallParticipantsSpotlightView` and `ParticipantsBarAlignment` are exported.
 - `StreamAdaptiveMenuAnchor` fills the row of the selected option in the anchored menu.
 - Added `StreamContextMenuAnchor.defaultActionStyle`, the design's menu row metrics.

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -205,7 +205,8 @@
 - `ParticipantLayoutMode.grid` gives the local participant a tile of its own instead of floating them over the grid.
 - `speakerOneToOne` floats the self-view on desktop too. Passing `enableLocalVideo: false` still suppresses it.
 - `ParticipantLayoutMode.pictureInPicture` spotlights the speaker alone under its new name, where it used to draw a grid.
-- `enableLocalVideo` is read only by `auto` and `speakerOneToOne`; the grid and the four bar layouts give the local participant a tile regardless.
+- `enableLocalVideo` is `enableFloatingSelfView` now, and `localVideoParticipantBuilder` is `floatingSelfViewBuilder`. `dart fix --apply` renames both.
+- `enableFloatingSelfView` is read only by `auto` and `speakerOneToOne`; the grid and the four bar layouts give the local participant a tile regardless.
 - `translations.defaultDevice` replaces `lobbySystemDefaultDevice` and `lobbyDefaultDeviceHint`, and reads "Default" rather than "System default". The two strings were shown side by side — the menu's row and the field's placeholder — so a translation could make them disagree about the same choice.
 - `StreamLayoutButton` takes `layout` instead of `initialLayout` and keeps no state, so the caller passes the mode back in through it. `dart fix --apply` renames the parameter.
 - `onError` on the device controls takes a `StreamDeviceErrorCallback`, receiving a typed `VideoError` and the action that failed.

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -208,7 +208,7 @@
 - `speakerOneToOne` floats the self-view on desktop too. Passing `enableLocalVideo: false` still suppresses it.
 - `ParticipantLayoutMode.pictureInPicture` spotlights the speaker alone under its new name, where it used to draw a grid.
 - `enableLocalVideo` is `enableFloatingSelfView` now, and `localVideoParticipantBuilder` is `floatingSelfViewBuilder`. `dart fix --apply` renames both.
-- `enableFloatingSelfView` is read only by `auto` and `speakerOneToOne`; the grid and the four bar layouts give the local participant a tile regardless.
+- `enableFloatingSelfView` is read only by `auto` and `speakerOneToOne`; on `grid` and the four bar layouts the local participant takes a tile and an explicit `true` is ignored.
 - `translations.defaultDevice` replaces `lobbySystemDefaultDevice` and `lobbyDefaultDeviceHint`, and reads "Default" rather than "System default". The two strings were shown side by side — the menu's row and the field's placeholder — so a translation could make them disagree about the same choice.
 - `StreamLayoutButton` takes `layout` instead of `initialLayout` and keeps no state, so the caller passes the mode back in through it. `dart fix --apply` renames the parameter.
 - `onError` on the device controls takes a `StreamDeviceErrorCallback`, receiving a typed `VideoError` and the action that failed.

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### ✅ Added
 
+- `StreamLayoutButton` draws the participant layout in effect, and offers the rest through a `StreamAdaptiveMenuAnchor` — a context menu on desktop and web, a bottom sheet on Android and iOS. Given two layouts it toggles between them instead of opening a menu.
+- `StreamLayoutButton.defaultLayouts` is `auto` and `speakerBottom`, so the button toggles unless it is given more.
+- `ParticipantLayoutMode` offers `auto`, `grid`, `speakerTop`, `speakerBottom`, `speakerLeft`, `speakerRight` and `speakerOneToOne`.
+- `ParticipantLayoutMode` carries its own presentation: `selectable`, `canonical`, `barAlignment`, `isSpeakerLayout`, `icon` and `label`.
+- `StreamLayoutButton` takes `layouts`, to choose what it offers, and `direction`, for which way the menu opens.
+- `CallParticipantsSpotlightView` and `ParticipantsBarAlignment` are exported.
+- `StreamAdaptiveMenuAnchor` fills the row of the selected option in the anchored menu, which only the sheet did before.
+- Added `StreamContextMenuAnchor.defaultActionStyle`, the design's menu row metrics, so a caller varying one row can re-merge them.
 - `CallFeatureButton` takes a `tone`, so a selected feature can paint destructive red instead of accent blue. `StreamRecordingButton` uses it.
 - `StreamMicrophoneButton` and `StreamCameraButton` take an `onError`, called with a typed `VideoError` and the action that failed when the call refuses the change. The split buttons take the same.
 - `StreamMicrophoneButton` and `StreamMicrophoneSplitButton` take `stopTrackOnMute`, passed on to `Call.setMicrophoneEnabled`.
@@ -180,6 +188,7 @@
 
 ### ⚠️ Deprecated
 
+- `ParticipantLayoutMode.spotlight` is `speakerBottom` now, and `pictureInPicture` is `speakerOneToOne`. `dart fix --apply` migrates both.
 - `StreamLocalVideoThemeData`, `StreamLocalVideoTheme` and `StreamVideoTheme.localVideoTheme` are deprecated in favour of `StreamFloatingParticipantTileThemeData`. `StreamLocalVideo` only positions the self-view now, so nothing reads them.
 - Every call control is named `Stream<Thing>Button` now, matching the split buttons, the `CallControlButton` / `CallFeatureButton` primitives, and the design system's own components. `ToggleMicrophoneOption` is `StreamMicrophoneButton`, and alongside it `ToggleCameraOption`, `ToggleScreenShareOption`, `ToggleRecordingOption`, `ToggleClosedCaptionsOption`, `ToggleLayoutOption`, `ToggleSpeakerphoneOption`, `FlipCameraOption`, `AddReactionOption` and `LeaveCallOption` become `StreamCameraButton`, `StreamScreenShareButton`, `StreamRecordingButton`, `StreamClosedCaptionsButton`, `StreamLayoutButton`, `StreamSpeakerphoneButton`, `StreamFlipCameraButton`, `StreamAddReactionButton` and `StreamLeaveCallButton`.
 
@@ -191,6 +200,10 @@
 
 ### ⚠️ Breaking
 
+- `ParticipantLayoutMode.auto` is the default wherever `grid` was, and renders what `grid` used to.
+- `ParticipantLayoutMode.grid` gives the local participant a tile of its own instead of floating them over the grid. `auto` and `speakerOneToOne` are the layouts that float the self-view.
+- `speakerOneToOne` floats the self-view on desktop too, where `enableLocalVideo` otherwise defaults to off. Passing `enableLocalVideo: false` still suppresses it.
+- `ParticipantLayoutMode.pictureInPicture` spotlights the speaker alone under its new name, where it used to draw a grid.
 - `translations.defaultDevice` replaces `lobbySystemDefaultDevice` and `lobbyDefaultDeviceHint`, and reads "Default" rather than "System default". The two strings were shown side by side — the menu's row and the field's placeholder — so a translation could make them disagree about the same choice.
 - `StreamLayoutButton` takes `layout` instead of `initialLayout` and keeps no state, so the caller passes the mode back in through it. `dart fix --apply` renames the parameter.
 - `onError` on the device controls takes a `StreamDeviceErrorCallback`, receiving a typed `VideoError` and the action that failed.

--- a/packages/stream_video_flutter/CHANGELOG.md
+++ b/packages/stream_video_flutter/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ### ✅ Added
 
-- `StreamLayoutButton` draws the participant layout in effect, and offers the rest through a `StreamAdaptiveMenuAnchor` — a context menu on desktop and web, a bottom sheet on Android and iOS. Given two layouts it toggles between them instead of opening a menu.
+- `StreamLayoutButton` draws the participant layout in effect and offers the rest through a `StreamAdaptiveMenuAnchor`.
 - `StreamLayoutButton.defaultLayouts` is `auto` and `speakerBottom`, so the button toggles unless it is given more.
+- Added layout strings to the localizations, in English and Dutch: `layoutMenuTitle`, `layoutSelectTooltip`, `layoutDefault`, `layoutGrid`, `layoutSpeakerTop`, `layoutSpeakerBottom`, `layoutSpeakerLeft`, `layoutSpeakerRight` and `layoutSpeakerOneToOne`.
 - `ParticipantLayoutMode` offers `auto`, `grid`, `speakerTop`, `speakerBottom`, `speakerLeft`, `speakerRight` and `speakerOneToOne`.
 - `ParticipantLayoutMode` carries its own presentation: `selectable`, `canonical`, `barAlignment`, `isSpeakerLayout`, `icon` and `label`.
 - `StreamLayoutButton` takes `layouts`, to choose what it offers, and `direction`, for which way the menu opens.
 - `CallParticipantsSpotlightView` and `ParticipantsBarAlignment` are exported.
-- `StreamAdaptiveMenuAnchor` fills the row of the selected option in the anchored menu, which only the sheet did before.
-- Added `StreamContextMenuAnchor.defaultActionStyle`, the design's menu row metrics, so a caller varying one row can re-merge them.
+- `StreamAdaptiveMenuAnchor` fills the row of the selected option in the anchored menu.
+- Added `StreamContextMenuAnchor.defaultActionStyle`, the design's menu row metrics.
 - `CallFeatureButton` takes a `tone`, so a selected feature can paint destructive red instead of accent blue. `StreamRecordingButton` uses it.
 - `StreamMicrophoneButton` and `StreamCameraButton` take an `onError`, called with a typed `VideoError` and the action that failed when the call refuses the change. The split buttons take the same.
 - `StreamMicrophoneButton` and `StreamMicrophoneSplitButton` take `stopTrackOnMute`, passed on to `Call.setMicrophoneEnabled`.
@@ -188,7 +189,7 @@
 
 ### ⚠️ Deprecated
 
-- `ParticipantLayoutMode.spotlight` is `speakerBottom` now, and `pictureInPicture` is `speakerOneToOne`. `dart fix --apply` migrates both.
+- `ParticipantLayoutMode.spotlight` is `speakerTop` now, and `pictureInPicture` is `speakerOneToOne`. `dart fix --apply` migrates both.
 - `StreamLocalVideoThemeData`, `StreamLocalVideoTheme` and `StreamVideoTheme.localVideoTheme` are deprecated in favour of `StreamFloatingParticipantTileThemeData`. `StreamLocalVideo` only positions the self-view now, so nothing reads them.
 - Every call control is named `Stream<Thing>Button` now, matching the split buttons, the `CallControlButton` / `CallFeatureButton` primitives, and the design system's own components. `ToggleMicrophoneOption` is `StreamMicrophoneButton`, and alongside it `ToggleCameraOption`, `ToggleScreenShareOption`, `ToggleRecordingOption`, `ToggleClosedCaptionsOption`, `ToggleLayoutOption`, `ToggleSpeakerphoneOption`, `FlipCameraOption`, `AddReactionOption` and `LeaveCallOption` become `StreamCameraButton`, `StreamScreenShareButton`, `StreamRecordingButton`, `StreamClosedCaptionsButton`, `StreamLayoutButton`, `StreamSpeakerphoneButton`, `StreamFlipCameraButton`, `StreamAddReactionButton` and `StreamLeaveCallButton`.
 
@@ -200,10 +201,11 @@
 
 ### ⚠️ Breaking
 
-- `ParticipantLayoutMode.auto` is the default wherever `grid` was, and renders what `grid` used to.
-- `ParticipantLayoutMode.grid` gives the local participant a tile of its own instead of floating them over the grid. `auto` and `speakerOneToOne` are the layouts that float the self-view.
-- `speakerOneToOne` floats the self-view on desktop too, where `enableLocalVideo` otherwise defaults to off. Passing `enableLocalVideo: false` still suppresses it.
+- `ParticipantLayoutMode.auto` is the default layout of `StreamCallContent`, `StreamCallParticipants` and `RegularCallParticipantsContent`, and renders what `grid` used to. The livestream widgets still default to `grid`.
+- `ParticipantLayoutMode.grid` gives the local participant a tile of its own instead of floating them over the grid.
+- `speakerOneToOne` floats the self-view on desktop too. Passing `enableLocalVideo: false` still suppresses it.
 - `ParticipantLayoutMode.pictureInPicture` spotlights the speaker alone under its new name, where it used to draw a grid.
+- `enableLocalVideo` is read only by `auto` and `speakerOneToOne`; the grid and the four bar layouts give the local participant a tile regardless.
 - `translations.defaultDevice` replaces `lobbySystemDefaultDevice` and `lobbyDefaultDeviceHint`, and reads "Default" rather than "System default". The two strings were shown side by side — the menu's row and the field's placeholder — so a translation could make them disagree about the same choice.
 - `StreamLayoutButton` takes `layout` instead of `initialLayout` and keeps no state, so the caller passes the mode back in through it. `dart fix --apply` renames the parameter.
 - `onError` on the device controls takes a `StreamDeviceErrorCallback`, receiving a typed `VideoError` and the action that failed.

--- a/packages/stream_video_flutter/lib/fix_data.yaml
+++ b/packages/stream_video_flutter/lib/fix_data.yaml
@@ -822,3 +822,35 @@ transforms:
         newName: "StreamLeaveCallButton"
 
   #endregion
+
+  #region Participant layout modes
+
+  - title: "replace ParticipantLayoutMode.spotlight with ParticipantLayoutMode.speakerBottom"
+    date: "2026-09-08"
+    bulkApply: true
+    element:
+      uris: ["package:stream_video_flutter/stream_video_flutter.dart"]
+      constant: "spotlight"
+      inEnum: "ParticipantLayoutMode"
+    changes:
+      - kind: "replacedBy"
+        newElement:
+          uris: ["package:stream_video_flutter/stream_video_flutter.dart"]
+          constant: "speakerBottom"
+          inEnum: "ParticipantLayoutMode"
+
+  - title: "replace ParticipantLayoutMode.pictureInPicture with ParticipantLayoutMode.speakerOneToOne"
+    date: "2026-09-08"
+    bulkApply: true
+    element:
+      uris: ["package:stream_video_flutter/stream_video_flutter.dart"]
+      constant: "pictureInPicture"
+      inEnum: "ParticipantLayoutMode"
+    changes:
+      - kind: "replacedBy"
+        newElement:
+          uris: ["package:stream_video_flutter/stream_video_flutter.dart"]
+          constant: "speakerOneToOne"
+          inEnum: "ParticipantLayoutMode"
+
+  #endregion Participant layout modes

--- a/packages/stream_video_flutter/lib/fix_data.yaml
+++ b/packages/stream_video_flutter/lib/fix_data.yaml
@@ -825,7 +825,7 @@ transforms:
 
   #region Participant layout modes
 
-  - title: "replace ParticipantLayoutMode.spotlight with ParticipantLayoutMode.speakerBottom"
+  - title: "replace ParticipantLayoutMode.spotlight with ParticipantLayoutMode.speakerTop"
     date: "2026-09-08"
     bulkApply: true
     element:
@@ -836,7 +836,7 @@ transforms:
       - kind: "replacedBy"
         newElement:
           uris: ["package:stream_video_flutter/stream_video_flutter.dart"]
-          constant: "speakerBottom"
+          constant: "speakerTop"
           inEnum: "ParticipantLayoutMode"
 
   - title: "replace ParticipantLayoutMode.pictureInPicture with ParticipantLayoutMode.speakerOneToOne"

--- a/packages/stream_video_flutter/lib/fix_data.yaml
+++ b/packages/stream_video_flutter/lib/fix_data.yaml
@@ -854,3 +854,37 @@ transforms:
           inEnum: "ParticipantLayoutMode"
 
   #endregion Participant layout modes
+
+  #region Floating self-view
+
+  # The flag and its builder are named after what they control — a self-view
+  # that floats over the layout — rather than after local video in general.
+  # The grid and the four bar layouts give the local participant a tile and
+  # read neither. RegularCallParticipantsContent takes the same pair but is
+  # not exported, so it needs no transform.
+
+  - title: "rename enableLocalVideo to enableFloatingSelfView on StreamCallParticipants"
+    date: "2026-09-10"
+    bulkApply: true
+    element:
+      uris: ["package:stream_video_flutter/stream_video_flutter.dart"]
+      constructor: ""
+      inClass: "StreamCallParticipants"
+    changes:
+      - kind: "renameParameter"
+        oldName: "enableLocalVideo"
+        newName: "enableFloatingSelfView"
+
+  - title: "rename localVideoParticipantBuilder to floatingSelfViewBuilder on StreamCallParticipants"
+    date: "2026-09-10"
+    bulkApply: true
+    element:
+      uris: ["package:stream_video_flutter/stream_video_flutter.dart"]
+      constructor: ""
+      inClass: "StreamCallParticipants"
+    changes:
+      - kind: "renameParameter"
+        oldName: "localVideoParticipantBuilder"
+        newName: "floatingSelfViewBuilder"
+
+  #endregion Floating self-view

--- a/packages/stream_video_flutter/lib/src/call_controls/controls/stream_layout_button.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/controls/stream_layout_button.dart
@@ -1,18 +1,51 @@
 import 'package:flutter/material.dart';
 
 import '../../../stream_video_flutter.dart';
+import '../../l10n/localization_extension.dart';
 
-/// A widget that switches the call between a grid and a spotlight layout.
+/// A widget that picks how the participants of a call are laid out.
+///
+/// Draws the icon of the layout currently in effect. Given three or more
+/// [layouts] it opens a [StreamAdaptiveMenuAnchor], so the choices are a
+/// context menu on desktop and web and a bottom sheet on Android and iOS.
+/// Given two it toggles between them instead: a menu of two rows is a longer
+/// way to press a button that has only one thing to do.
 class StreamLayoutButton extends StatelessWidget {
   /// Creates a new instance of [StreamLayoutButton].
   const StreamLayoutButton({
     required this.onLayoutModeChanged,
-    this.layout = ParticipantLayoutMode.grid,
+    this.layout = ParticipantLayoutMode.auto,
+    this.layouts = defaultLayouts,
+    this.direction = StreamMenuDirection.up,
     super.key,
   });
 
+  /// The layouts the button offers unless it is given others.
+  ///
+  /// Two, so the button toggles rather than opening a menu. Pass
+  /// [ParticipantLayoutModeX.selectable] for every layout the SDK has.
+  static const List<ParticipantLayoutMode> defaultLayouts = [
+    ParticipantLayoutMode.auto,
+    ParticipantLayoutMode.speakerBottom,
+  ];
+
   /// The layout mode the button draws.
   final ParticipantLayoutMode layout;
+
+  /// The layouts the button offers.
+  ///
+  /// Three or more open a menu; two toggle. Narrow it to keep a layout out of
+  /// an app's reach — a window too narrow for a column of participants beside
+  /// the speaker has no use for the left and right bar layouts.
+  final List<ParticipantLayoutMode> layouts;
+
+  /// Which way the menu is expected to open.
+  ///
+  /// Defaults to [StreamMenuDirection.up], for the button's usual home in a
+  /// control bar along the bottom of the call. Pass [StreamMenuDirection.down]
+  /// where it sits in an app bar instead. The bottom sheet ignores this, and so
+  /// does a button that toggles.
+  final StreamMenuDirection direction;
 
   /// Callback that is called when the layout mode is changed.
   ///
@@ -20,16 +53,50 @@ class StreamLayoutButton extends StatelessWidget {
   /// the new mode back in through [layout].
   final void Function(ParticipantLayoutMode) onLayoutModeChanged;
 
+  /// The layout a press moves to, or null when there is nowhere to go.
+  ///
+  /// The first one that isn't already in effect, so a [layout] outside
+  /// [layouts] — an app driving the mode from somewhere else — lands on the
+  /// first entry rather than on nothing.
+  ParticipantLayoutMode? get _next =>
+      layouts.where((mode) => mode.canonical != layout.canonical).firstOrNull;
+
+  Widget _button(BuildContext context, {VoidCallback? onPressed}) =>
+      CallControlButton(
+        icon: Icon(layout.icon(context)),
+        tooltip: context.translations.layoutSelectTooltip,
+        onPressed: onPressed,
+      );
+
   @override
   Widget build(BuildContext context) {
-    final icons = context.streamIcons;
-    final isGrid = layout == ParticipantLayoutMode.grid;
+    if (layouts.length < 3) {
+      return _button(
+        context,
+        onPressed: switch (_next) {
+          final next? => () => onLayoutModeChanged(next),
+          null => null,
+        },
+      );
+    }
 
-    return CallControlButton(
-      icon: Icon(isGrid ? icons.gridFill : icons.speakerLeftFill),
-      onPressed: () => onLayoutModeChanged(
-        isGrid ? ParticipantLayoutMode.spotlight : ParticipantLayoutMode.grid,
-      ),
+    return StreamAdaptiveMenuAnchor(
+      title: context.translations.layoutMenuTitle,
+      direction: direction,
+      sections: [
+        StreamMenuSection(
+          options: [
+            for (final mode in layouts)
+              StreamMenuOption(
+                label: mode.label(context),
+                leading: Icon(mode.icon(context)),
+                selected: mode.canonical == layout.canonical,
+                onSelected: () => onLayoutModeChanged(mode),
+              ),
+          ],
+        ),
+      ],
+      builder: (context, handle) => _button(context, onPressed: handle.toggle),
     );
   }
 }

--- a/packages/stream_video_flutter/lib/src/call_controls/controls/stream_layout_button.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/controls/stream_layout_button.dart
@@ -15,7 +15,7 @@ class StreamLayoutButton extends StatelessWidget {
     required this.onLayoutModeChanged,
     this.layout = ParticipantLayoutMode.auto,
     this.layouts = defaultLayouts,
-    this.direction = StreamMenuDirection.up,
+    this.menuDirection = StreamMenuDirection.down,
     super.key,
   });
 
@@ -38,13 +38,12 @@ class StreamLayoutButton extends StatelessWidget {
   /// beside the speaker has no use for the left and right bar layouts.
   final List<ParticipantLayoutMode> layouts;
 
-  /// Which way the menu is expected to open.
+  /// Which way the button expects its menu to open.
   ///
-  /// Defaults to [StreamMenuDirection.up], for the button's usual home in a
-  /// control bar along the bottom of the call. Pass [StreamMenuDirection.down]
-  /// where it sits in an app bar instead. The bottom sheet ignores this, and so
-  /// does a button that toggles.
-  final StreamMenuDirection direction;
+  /// A control bar along the bottom of a call opens upwards; the default suits
+  /// a control with room below it. The bottom sheet ignores this, and so does
+  /// a button that toggles.
+  final StreamMenuDirection menuDirection;
 
   /// Callback that is called when the layout mode is changed.
   ///
@@ -81,7 +80,7 @@ class StreamLayoutButton extends StatelessWidget {
 
     return StreamAdaptiveMenuAnchor(
       title: context.translations.layoutMenuTitle,
-      direction: direction,
+      direction: menuDirection,
       sections: [
         StreamMenuSection(
           options: [

--- a/packages/stream_video_flutter/lib/src/call_controls/controls/stream_layout_button.dart
+++ b/packages/stream_video_flutter/lib/src/call_controls/controls/stream_layout_button.dart
@@ -7,9 +7,8 @@ import '../../l10n/localization_extension.dart';
 ///
 /// Draws the icon of the layout currently in effect. Given three or more
 /// [layouts] it opens a [StreamAdaptiveMenuAnchor], so the choices are a
-/// context menu on desktop and web and a bottom sheet on Android and iOS.
-/// Given two it toggles between them instead: a menu of two rows is a longer
-/// way to press a button that has only one thing to do.
+/// context menu on a desktop platform and a bottom sheet on Android and iOS.
+/// Given fewer it toggles to the next one instead.
 class StreamLayoutButton extends StatelessWidget {
   /// Creates a new instance of [StreamLayoutButton].
   const StreamLayoutButton({
@@ -34,9 +33,9 @@ class StreamLayoutButton extends StatelessWidget {
 
   /// The layouts the button offers.
   ///
-  /// Three or more open a menu; two toggle. Narrow it to keep a layout out of
-  /// an app's reach — a window too narrow for a column of participants beside
-  /// the speaker has no use for the left and right bar layouts.
+  /// Three or more open a menu; fewer toggle. Narrow it to keep a layout out
+  /// of an app's reach — a window too narrow for a column of participants
+  /// beside the speaker has no use for the left and right bar layouts.
   final List<ParticipantLayoutMode> layouts;
 
   /// Which way the menu is expected to open.

--- a/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
@@ -49,9 +49,9 @@ class StreamCallParticipants extends StatefulWidget {
     this.participants,
     this.filter = _defaultFilter,
     CallParticipantSort<CallParticipantState>? sort,
-    this.enableLocalVideo,
+    this.enableFloatingSelfView,
     this.callParticipantBuilder = _defaultParticipantBuilder,
-    this.localVideoParticipantBuilder,
+    this.floatingSelfViewBuilder,
     this.screenShareContentBuilder,
     this.screenShareParticipantBuilder = _defaultParticipantBuilder,
     this.layoutMode = ParticipantLayoutMode.auto,
@@ -74,15 +74,19 @@ class StreamCallParticipants extends StatefulWidget {
   ///
   /// Only [ParticipantLayoutMode.auto] and
   /// [ParticipantLayoutMode.speakerOneToOne] read it, the layouts that leave
-  /// the local participant out of the arrangement. Defaults to true under
-  /// `speakerOneToOne`, and to false on desktop under `auto`.
-  final bool? enableLocalVideo;
+  /// the local participant out of the arrangement. The grid and the four bar
+  /// layouts give them a tile, so a self-view would show them twice.
+  ///
+  /// Defaults to true under `speakerOneToOne`, which `auto` resolves to in a
+  /// one-on-one call. Under `auto` in a group call it defaults to true on
+  /// mobile and false on desktop.
+  final bool? enableFloatingSelfView;
 
   /// Builder function used to build a participant grid item.
   final CallParticipantBuilder callParticipantBuilder;
 
-  /// Builder function used to build a local video participant widget.
-  final CallParticipantBuilder? localVideoParticipantBuilder;
+  /// Builder function used to build the floating self-view.
+  final CallParticipantBuilder? floatingSelfViewBuilder;
 
   /// Builder function used to build a screen sharing item.
   final ScreenShareContentBuilder? screenShareContentBuilder;
@@ -184,9 +188,9 @@ class _StreamCallParticipantsState extends State<StreamCallParticipants>
       call: widget.call,
       participants: sortedParticipants,
       layoutMode: widget.layoutMode,
-      enableLocalVideo: widget.enableLocalVideo,
+      enableFloatingSelfView: widget.enableFloatingSelfView,
       callParticipantBuilder: widget.callParticipantBuilder,
-      localVideoParticipantBuilder: widget.localVideoParticipantBuilder,
+      floatingSelfViewBuilder: widget.floatingSelfViewBuilder,
     );
   }
 }

--- a/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
@@ -70,7 +70,12 @@ class StreamCallParticipants extends StatefulWidget {
   /// Used for sorting the call participants.
   final CallParticipantSort<CallParticipantState> sort;
 
-  /// Enable local video view for the local participant.
+  /// Whether the local participant's self-view floats over the layout.
+  ///
+  /// Only [ParticipantLayoutMode.auto] and
+  /// [ParticipantLayoutMode.speakerOneToOne] read it, the layouts that leave
+  /// the local participant out of the arrangement. Defaults to true under
+  /// `speakerOneToOne`, and to false on desktop under `auto`.
   final bool? enableLocalVideo;
 
   /// Builder function used to build a participant grid item.

--- a/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
@@ -79,7 +79,8 @@ class StreamCallParticipants extends StatefulWidget {
   ///
   /// Defaults to true under `speakerOneToOne`, which `auto` resolves to in a
   /// one-on-one call. Under `auto` in a group call it defaults to true on
-  /// mobile and false on desktop.
+  /// mobile while at most two other people are in the call, and to false
+  /// otherwise.
   final bool? enableFloatingSelfView;
 
   /// Builder function used to build a participant grid item.

--- a/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
@@ -153,13 +153,18 @@ class _StreamCallParticipantsState extends State<StreamCallParticipants>
   void didUpdateWidget(covariant StreamCallParticipants oldWidget) {
     super.didUpdateWidget(oldWidget);
 
+    // The sort follows layoutMode unless the caller supplied one, so picking
+    // a speaker layout swaps the preset and the list has to be ordered again.
+    final sortChanged = widget.sort != oldWidget.sort;
+
     if (widget.participants != null) {
       _participantsSubscription?.cancel();
 
-      if (!const ListEquality<CallParticipantState>().equals(
-        widget.participants!.toList(),
-        oldWidget.participants?.toList(),
-      )) {
+      if (sortChanged ||
+          !const ListEquality<CallParticipantState>().equals(
+            widget.participants!.toList(),
+            oldWidget.participants?.toList(),
+          )) {
         recalculateParticipants(widget.participants!);
       }
     } else if (widget.call != oldWidget.call) {
@@ -168,6 +173,8 @@ class _StreamCallParticipantsState extends State<StreamCallParticipants>
           .partialState((state) => state.callParticipants)
           .listen(recalculateParticipants);
 
+      recalculateParticipants(widget.call.state.value.callParticipants);
+    } else if (sortChanged) {
       recalculateParticipants(widget.call.state.value.callParticipants);
     }
   }

--- a/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
@@ -154,9 +154,13 @@ class _StreamCallParticipantsState extends State<StreamCallParticipants>
   void didUpdateWidget(covariant StreamCallParticipants oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    // The sort follows layoutMode unless the caller supplied one, so picking
-    // a speaker layout swaps the preset and the list has to be ordered again.
-    final sortChanged = widget.sort != oldWidget.sort;
+    // Picking a speaker layout swaps the preset the list is ordered by, so it
+    // has to be ordered again. Compared through layoutMode rather than
+    // through sort: the presets are two cached instances, where a sort the
+    // caller passed is a function, and an inline closure is a new object on
+    // every build.
+    final sortChanged =
+        widget.layoutMode.sorting != oldWidget.layoutMode.sorting;
 
     if (widget.participants != null) {
       _participantsSubscription?.cancel();

--- a/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/call_participants.dart
@@ -54,7 +54,7 @@ class StreamCallParticipants extends StatefulWidget {
     this.localVideoParticipantBuilder,
     this.screenShareContentBuilder,
     this.screenShareParticipantBuilder = _defaultParticipantBuilder,
-    this.layoutMode = ParticipantLayoutMode.grid,
+    this.layoutMode = ParticipantLayoutMode.auto,
   }) : sort = sort ?? layoutMode.sorting;
 
   /// Represents a call.

--- a/packages/stream_video_flutter/lib/src/call_participants/layout/participant_layout_mode.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/layout/participant_layout_mode.dart
@@ -15,7 +15,7 @@ enum ParticipantLayoutMode {
   ///
   /// In a one-on-one call the local participant floats over the speaker. In a
   /// group call they float on mobile and take a grid tile on desktop.
-  /// `enableLocalVideo` overrides either default.
+  /// `enableFloatingSelfView` overrides either default.
   auto,
 
   /// Every participant, including the local one, takes a tile in a grid.
@@ -40,7 +40,8 @@ enum ParticipantLayoutMode {
   /// The speaker takes the whole frame, with the local participant floating
   /// over them and nobody else shown.
   ///
-  /// The self-view floats on every platform unless `enableLocalVideo` is false.
+  /// The self-view floats on every platform unless `enableFloatingSelfView`
+  /// is false.
   speakerOneToOne,
 
   /// Alias for [ParticipantLayoutMode.speakerTop].

--- a/packages/stream_video_flutter/lib/src/call_participants/layout/participant_layout_mode.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/layout/participant_layout_mode.dart
@@ -14,7 +14,8 @@ enum ParticipantLayoutMode {
   /// everybody sits in a grid otherwise.
   ///
   /// In a one-on-one call the local participant floats over the speaker. In a
-  /// group call they float on mobile and take a grid tile on desktop.
+  /// group call they float on mobile while at most two other people are in
+  /// the call, and take a grid tile otherwise.
   /// `enableFloatingSelfView` overrides either default.
   auto,
 

--- a/packages/stream_video_flutter/lib/src/call_participants/layout/participant_layout_mode.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/layout/participant_layout_mode.dart
@@ -1,26 +1,182 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
+import 'package:flutter/widgets.dart';
+import 'package:stream_core_flutter/core.dart';
 import 'package:stream_video/stream_video.dart';
 
+import '../../l10n/localization_extension.dart';
 import '../call_participants.dart';
+import 'call_participants_spotlight_view.dart';
 
+/// How the participants of a call are arranged on screen.
 enum ParticipantLayoutMode {
-  /// The layout mode is set to grid view.
+  /// Follows the call: the speaker fills the frame in a one-on-one call, and
+  /// everybody sits in a grid otherwise.
+  ///
+  /// The local participant floats over the layout rather than taking a tile of
+  /// its own, subject to `enableLocalVideo`.
+  auto,
+
+  /// Every participant, including the local one, takes an equal tile in a
+  /// grid.
   grid,
 
+  /// The speaker fills the frame, with everybody else in a bar above them.
+  speakerTop,
+
+  /// The speaker fills the frame, with everybody else in a bar below them.
+  speakerBottom,
+
+  /// The speaker fills the frame, with everybody else in a bar to their left.
+  speakerLeft,
+
+  /// The speaker fills the frame, with everybody else in a bar to their right.
+  speakerRight,
+
+  /// The speaker fills the frame alone, with the local participant floating
+  /// over them and nobody else shown.
+  speakerOneToOne,
+
   /// The layout mode is set to spotlight view.
+  @Deprecated(
+    'Use ParticipantLayoutMode.speakerBottom instead, which is where the '
+    'participants bar already sat. Will be removed in the next major version.',
+  )
   spotlight,
 
+  /// The layout mode is set to picture-in-picture view.
+  @Deprecated(
+    'Use ParticipantLayoutMode.speakerOneToOne instead. Will be removed in '
+    'the next major version.',
+  )
   pictureInPicture,
 }
 
+/// The participant sorting each layout asks for.
 extension SortingExtension on ParticipantLayoutMode {
+  /// The sorting preset that puts the right participant first for this layout.
   CallParticipantSort<CallParticipantState> get sorting {
     switch (this) {
+      case ParticipantLayoutMode.auto:
       case ParticipantLayoutMode.grid:
         return CallParticipantSortingPresets.regular;
+      case ParticipantLayoutMode.speakerTop:
+      case ParticipantLayoutMode.speakerBottom:
+      case ParticipantLayoutMode.speakerLeft:
+      case ParticipantLayoutMode.speakerRight:
+      case ParticipantLayoutMode.speakerOneToOne:
       case ParticipantLayoutMode.spotlight:
-        return CallParticipantSortingPresets.speaker;
       case ParticipantLayoutMode.pictureInPicture:
         return CallParticipantSortingPresets.speaker;
+    }
+  }
+}
+
+/// How a layout presents itself: where its bar sits, what it is called and
+/// which icon stands for it.
+extension ParticipantLayoutModeX on ParticipantLayoutMode {
+  /// The layouts offered by default, newest naming only.
+  ///
+  /// [ParticipantLayoutMode.values] still carries the deprecated aliases, which
+  /// would show up as duplicate rows in a menu built from it.
+  static const List<ParticipantLayoutMode> selectable = [
+    ParticipantLayoutMode.auto,
+    ParticipantLayoutMode.grid,
+    ParticipantLayoutMode.speakerTop,
+    ParticipantLayoutMode.speakerBottom,
+    ParticipantLayoutMode.speakerLeft,
+    ParticipantLayoutMode.speakerRight,
+    ParticipantLayoutMode.speakerOneToOne,
+  ];
+
+  /// The layout this one is an alias for, or itself.
+  ///
+  /// Lets the rest of the SDK switch over the current names alone while the
+  /// deprecated values are still around.
+  ParticipantLayoutMode get canonical => switch (this) {
+    ParticipantLayoutMode.spotlight => ParticipantLayoutMode.speakerBottom,
+    ParticipantLayoutMode.pictureInPicture =>
+      ParticipantLayoutMode.speakerOneToOne,
+    _ => this,
+  };
+
+  /// Where the participants bar sits, or null for a layout that has no bar.
+  ParticipantsBarAlignment? get barAlignment {
+    switch (this) {
+      case ParticipantLayoutMode.speakerTop:
+        return ParticipantsBarAlignment.top;
+      case ParticipantLayoutMode.speakerBottom:
+      case ParticipantLayoutMode.spotlight:
+        return ParticipantsBarAlignment.bottom;
+      case ParticipantLayoutMode.speakerLeft:
+        return ParticipantsBarAlignment.left;
+      case ParticipantLayoutMode.speakerRight:
+        return ParticipantsBarAlignment.right;
+      case ParticipantLayoutMode.auto:
+      case ParticipantLayoutMode.grid:
+      case ParticipantLayoutMode.speakerOneToOne:
+      case ParticipantLayoutMode.pictureInPicture:
+        return null;
+    }
+  }
+
+  /// Whether this layout spotlights a single participant.
+  ///
+  /// True for every speaker layout, including the one that shows nobody else.
+  bool get isSpeakerLayout => switch (canonical) {
+    ParticipantLayoutMode.speakerTop ||
+    ParticipantLayoutMode.speakerBottom ||
+    ParticipantLayoutMode.speakerLeft ||
+    ParticipantLayoutMode.speakerRight ||
+    ParticipantLayoutMode.speakerOneToOne => true,
+    _ => false,
+  };
+
+  /// The icon standing for this layout in a menu and on its button.
+  IconData icon(BuildContext context) {
+    final icons = context.streamIcons;
+    switch (canonical) {
+      case ParticipantLayoutMode.auto:
+        return icons.gridDefaultFill;
+      case ParticipantLayoutMode.grid:
+        return icons.gridFill;
+      case ParticipantLayoutMode.speakerTop:
+        return icons.speakerTopFill;
+      case ParticipantLayoutMode.speakerBottom:
+        return icons.speakerBottomFill;
+      case ParticipantLayoutMode.speakerLeft:
+        return icons.speakerLeftFill;
+      case ParticipantLayoutMode.speakerRight:
+        return icons.speakerRightFill;
+      case ParticipantLayoutMode.speakerOneToOne:
+        return icons.pipFill;
+      case ParticipantLayoutMode.spotlight:
+      case ParticipantLayoutMode.pictureInPicture:
+        throw StateError('canonical never returns a deprecated value');
+    }
+  }
+
+  /// The name of this layout, in the app's language.
+  String label(BuildContext context) {
+    final translations = context.translations;
+    switch (canonical) {
+      case ParticipantLayoutMode.auto:
+        return translations.layoutDefault;
+      case ParticipantLayoutMode.grid:
+        return translations.layoutGrid;
+      case ParticipantLayoutMode.speakerTop:
+        return translations.layoutSpeakerTop;
+      case ParticipantLayoutMode.speakerBottom:
+        return translations.layoutSpeakerBottom;
+      case ParticipantLayoutMode.speakerLeft:
+        return translations.layoutSpeakerLeft;
+      case ParticipantLayoutMode.speakerRight:
+        return translations.layoutSpeakerRight;
+      case ParticipantLayoutMode.speakerOneToOne:
+        return translations.layoutSpeakerOneToOne;
+      case ParticipantLayoutMode.spotlight:
+      case ParticipantLayoutMode.pictureInPicture:
+        throw StateError('canonical never returns a deprecated value');
     }
   }
 }

--- a/packages/stream_video_flutter/lib/src/call_participants/layout/participant_layout_mode.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/layout/participant_layout_mode.dart
@@ -10,44 +10,51 @@ import 'call_participants_spotlight_view.dart';
 
 /// How the participants of a call are arranged on screen.
 enum ParticipantLayoutMode {
-  /// Follows the call: the speaker fills the frame in a one-on-one call, and
+  /// Follows the call: the speaker takes the frame in a one-on-one call, and
   /// everybody sits in a grid otherwise.
   ///
-  /// The local participant floats over the layout rather than taking a tile of
-  /// its own, subject to `enableLocalVideo`.
+  /// In a one-on-one call the local participant floats over the speaker. In a
+  /// group call they float on mobile and take a grid tile on desktop.
+  /// `enableLocalVideo` overrides either default.
   auto,
 
-  /// Every participant, including the local one, takes an equal tile in a
-  /// grid.
+  /// Every participant, including the local one, takes a tile in a grid.
   grid,
 
-  /// The speaker fills the frame, with everybody else in a bar above them.
+  /// The speaker takes the top of the frame, with everybody else in a bar
+  /// below them.
   speakerTop,
 
-  /// The speaker fills the frame, with everybody else in a bar below them.
+  /// The speaker takes the bottom of the frame, with everybody else in a bar
+  /// above them.
   speakerBottom,
 
-  /// The speaker fills the frame, with everybody else in a bar to their left.
+  /// The speaker takes the left of the frame, with everybody else in a bar to
+  /// their right.
   speakerLeft,
 
-  /// The speaker fills the frame, with everybody else in a bar to their right.
+  /// The speaker takes the right of the frame, with everybody else in a bar to
+  /// their left.
   speakerRight,
 
-  /// The speaker fills the frame alone, with the local participant floating
+  /// The speaker takes the whole frame, with the local participant floating
   /// over them and nobody else shown.
+  ///
+  /// The self-view floats on every platform unless `enableLocalVideo` is false.
   speakerOneToOne,
 
-  /// The layout mode is set to spotlight view.
+  /// Alias for [ParticipantLayoutMode.speakerTop].
   @Deprecated(
-    'Use ParticipantLayoutMode.speakerBottom instead, which is where the '
-    'participants bar already sat. Will be removed in the next major version.',
+    'Use ParticipantLayoutMode.speakerTop instead. Will be removed in the '
+    'next major version.',
   )
   spotlight,
 
-  /// The layout mode is set to picture-in-picture view.
+  /// Alias for [ParticipantLayoutMode.speakerOneToOne].
   @Deprecated(
-    'Use ParticipantLayoutMode.speakerOneToOne instead. Will be removed in '
-    'the next major version.',
+    'Use ParticipantLayoutMode.speakerOneToOne instead, which spotlights the '
+    'speaker alone rather than drawing a grid. Will be removed in the next '
+    'major version.',
   )
   pictureInPicture,
 }
@@ -75,7 +82,8 @@ extension SortingExtension on ParticipantLayoutMode {
 /// How a layout presents itself: where its bar sits, what it is called and
 /// which icon stands for it.
 extension ParticipantLayoutModeX on ParticipantLayoutMode {
-  /// The layouts offered by default, newest naming only.
+  /// Every layout the SDK renders, in menu order, without the deprecated
+  /// aliases.
   ///
   /// [ParticipantLayoutMode.values] still carries the deprecated aliases, which
   /// would show up as duplicate rows in a menu built from it.
@@ -91,27 +99,29 @@ extension ParticipantLayoutModeX on ParticipantLayoutMode {
 
   /// The layout this one is an alias for, or itself.
   ///
-  /// Lets the rest of the SDK switch over the current names alone while the
-  /// deprecated values are still around.
+  /// Lets the rest of the SDK switch over the current names alone.
   ParticipantLayoutMode get canonical => switch (this) {
-    ParticipantLayoutMode.spotlight => ParticipantLayoutMode.speakerBottom,
+    ParticipantLayoutMode.spotlight => ParticipantLayoutMode.speakerTop,
     ParticipantLayoutMode.pictureInPicture =>
       ParticipantLayoutMode.speakerOneToOne,
     _ => this,
   };
 
   /// Where the participants bar sits, or null for a layout that has no bar.
+  ///
+  /// The bar takes the edge opposite the speaker, so
+  /// [ParticipantLayoutMode.speakerTop] puts it along the bottom.
   ParticipantsBarAlignment? get barAlignment {
     switch (this) {
       case ParticipantLayoutMode.speakerTop:
-        return ParticipantsBarAlignment.top;
-      case ParticipantLayoutMode.speakerBottom:
       case ParticipantLayoutMode.spotlight:
         return ParticipantsBarAlignment.bottom;
+      case ParticipantLayoutMode.speakerBottom:
+        return ParticipantsBarAlignment.top;
       case ParticipantLayoutMode.speakerLeft:
-        return ParticipantsBarAlignment.left;
-      case ParticipantLayoutMode.speakerRight:
         return ParticipantsBarAlignment.right;
+      case ParticipantLayoutMode.speakerRight:
+        return ParticipantsBarAlignment.left;
       case ParticipantLayoutMode.auto:
       case ParticipantLayoutMode.grid:
       case ParticipantLayoutMode.speakerOneToOne:
@@ -120,9 +130,9 @@ extension ParticipantLayoutModeX on ParticipantLayoutMode {
     }
   }
 
-  /// Whether this layout spotlights a single participant.
+  /// Whether this layout always spotlights a single participant.
   ///
-  /// True for every speaker layout, including the one that shows nobody else.
+  /// False for [ParticipantLayoutMode.auto], which decides per call.
   bool get isSpeakerLayout => switch (canonical) {
     ParticipantLayoutMode.speakerTop ||
     ParticipantLayoutMode.speakerBottom ||

--- a/packages/stream_video_flutter/lib/src/call_participants/livestream_hosts.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/livestream_hosts.dart
@@ -128,9 +128,7 @@ class _StreamLivestreamHostsState extends State<StreamLivestreamHosts>
       return _buildScreenShareContent(screenShareParticipant!);
     }
 
-    if (sortedParticipants.isNotEmpty &&
-        (widget.layoutMode == ParticipantLayoutMode.pictureInPicture ||
-            widget.layoutMode == ParticipantLayoutMode.spotlight)) {
+    if (sortedParticipants.isNotEmpty && widget.layoutMode.isSpeakerLayout) {
       return widget.callParticipantBuilder(
         context,
         widget.call,

--- a/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
@@ -12,8 +12,8 @@ class RegularCallParticipantsContent extends StatelessWidget {
     required this.call,
     required this.participants,
     this.callParticipantBuilder = _defaultParticipantBuilder,
-    this.enableLocalVideo,
-    this.localVideoParticipantBuilder,
+    this.enableFloatingSelfView,
+    this.floatingSelfViewBuilder,
     this.layoutMode = ParticipantLayoutMode.auto,
   });
 
@@ -27,15 +27,19 @@ class RegularCallParticipantsContent extends StatelessWidget {
   ///
   /// Only [ParticipantLayoutMode.auto] and
   /// [ParticipantLayoutMode.speakerOneToOne] read it, the layouts that leave
-  /// the local participant out of the arrangement. Defaults to true under
-  /// `speakerOneToOne`, and to false on desktop under `auto`.
-  final bool? enableLocalVideo;
+  /// the local participant out of the arrangement. The grid and the four bar
+  /// layouts give them a tile, so a self-view would show them twice.
+  ///
+  /// Defaults to true under `speakerOneToOne`, which `auto` resolves to in a
+  /// one-on-one call. Under `auto` in a group call it defaults to true on
+  /// mobile and false on desktop.
+  final bool? enableFloatingSelfView;
 
   /// Builder function used to build a participant grid item.
   final CallParticipantBuilder callParticipantBuilder;
 
-  /// Builder function used to build a local video participant widget.
-  final CallParticipantBuilder? localVideoParticipantBuilder;
+  /// Builder function used to build the floating self-view.
+  final CallParticipantBuilder? floatingSelfViewBuilder;
 
   /// The layout mode used to display the participants.
   final ParticipantLayoutMode layoutMode;
@@ -71,17 +75,18 @@ class RegularCallParticipantsContent extends StatelessWidget {
     };
 
     // Only these two layouts leave the local participant out of the
-    // arrangement, so only they can float a self-view. The grid and the four
-    // bar layouts give them a tile, where a self-view would show them twice,
-    // so every other case is false whatever enableLocalVideo says.
+    // arrangement, so only they can float a self-view. An explicitly
+    // requested grid and the four bar layouts give them a tile, where a
+    // self-view would show them twice, so every other case is false whatever
+    // enableFloatingSelfView says. auto's grid still floats one.
     //
     // speakerOneToOne floats on every platform: it shows nobody but the
     // speaker, so without the inset the local participant is absent from the
     // call entirely. auto's grid follows the platform instead.
     final floatsSelfView = switch (effective) {
-      ParticipantLayoutMode.speakerOneToOne => enableLocalVideo ?? true,
+      ParticipantLayoutMode.speakerOneToOne => enableFloatingSelfView ?? true,
       ParticipantLayoutMode.grid when isAuto =>
-        enableLocalVideo ?? !isDesktopDevice,
+        enableFloatingSelfView ?? !isDesktopDevice,
       _ => false,
     };
 
@@ -132,7 +137,7 @@ class RegularCallParticipantsContent extends StatelessWidget {
       child = StreamLocalVideo(
         call: call,
         participant: localParticipant,
-        participantBuilder: localVideoParticipantBuilder,
+        participantBuilder: floatingSelfViewBuilder,
         child: child,
       );
     }

--- a/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
@@ -23,7 +23,12 @@ class RegularCallParticipantsContent extends StatelessWidget {
   /// The list of participants to display.
   final Iterable<CallParticipantState> participants;
 
-  /// Enable local video view for the local participant.
+  /// Whether the local participant's self-view floats over the layout.
+  ///
+  /// Only [ParticipantLayoutMode.auto] and
+  /// [ParticipantLayoutMode.speakerOneToOne] read it, the layouts that leave
+  /// the local participant out of the arrangement. Defaults to true under
+  /// `speakerOneToOne`, and to false on desktop under `auto`.
   final bool? enableLocalVideo;
 
   /// Builder function used to build a participant grid item.
@@ -66,17 +71,13 @@ class RegularCallParticipantsContent extends StatelessWidget {
     };
 
     // Only these two layouts leave the local participant out of the
-    // arrangement, so only they can float a self-view over it. The grid and the
-    // four bar layouts give them a tile of their own, and a self-view on top of
-    // that would show them twice — which is why every other case is false here
-    // whatever [enableLocalVideo] says.
+    // arrangement, so only they can float a self-view. The grid and the four
+    // bar layouts give them a tile, where a self-view would show them twice,
+    // so every other case is false whatever enableLocalVideo says.
     //
-    // The two differ in what they default to. Under speakerOneToOne the inset
-    // is the layout rather than an addition to it: without it the layout is a
-    // lone spotlight, and the local participant, who gets no tile and no bar
-    // either, disappears from the call. Under auto's grid it follows the
-    // platform, since a phone has no room for a tile per person but a desktop
-    // does.
+    // speakerOneToOne floats on every platform: it shows nobody but the
+    // speaker, so without the inset the local participant is absent from the
+    // call entirely. auto's grid follows the platform instead.
     final floatsSelfView = switch (effective) {
       ParticipantLayoutMode.speakerOneToOne => enableLocalVideo ?? true,
       ParticipantLayoutMode.grid when isAuto =>
@@ -90,19 +91,21 @@ class RegularCallParticipantsContent extends StatelessWidget {
         remoteParticipants.isNotEmpty;
 
     Widget child;
-    if (effective.isSpeakerLayout) {
+    // A speaker layout has to have somebody to spotlight; with nobody in the
+    // call the grid renders its own empty state.
+    if (effective.isSpeakerLayout && participants.isNotEmpty) {
       var spotlight = participants.first;
 
-      // The frame belongs to somebody else whenever the local participant is
-      // already accounted for: floating over the layout, or — in a 1-on-1
-      // call — because spotlighting yourself is never what was meant.
+      // Somebody else takes the frame whenever the local participant is
+      // already accounted for: floating over the layout, or alone with one
+      // other person.
       if (remoteParticipants.isNotEmpty &&
           (floatLocalVideo || remoteParticipants.length == 1)) {
         spotlight = remoteParticipants.first;
       }
 
       // speakerOneToOne shows the speaker alone. The spotlight view hides an
-      // empty bar and gives the whole frame to the spotlight.
+      // empty bar and gives its space to the spotlight.
       final barParticipants = effective.barAlignment == null
           ? const <CallParticipantState>[]
           : ([...participants]..remove(spotlight));

--- a/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
@@ -32,7 +32,8 @@ class RegularCallParticipantsContent extends StatelessWidget {
   ///
   /// Defaults to true under `speakerOneToOne`, which `auto` resolves to in a
   /// one-on-one call. Under `auto` in a group call it defaults to true on
-  /// mobile and false on desktop.
+  /// mobile while at most two other people are in the call, and to false
+  /// otherwise.
   final bool? enableFloatingSelfView;
 
   /// Builder function used to build a participant grid item.
@@ -43,6 +44,13 @@ class RegularCallParticipantsContent extends StatelessWidget {
 
   /// The layout mode used to display the participants.
   final ParticipantLayoutMode layoutMode;
+
+  /// The most other participants [ParticipantLayoutMode.auto] floats a
+  /// self-view over on mobile.
+  ///
+  /// A grid past this many tiles is crowded enough on a phone that the inset
+  /// would cover one, so the local participant takes a tile of their own.
+  static const _maxRemotesBehindSelfView = 2;
 
   // The default participant builder.
   static Widget _defaultParticipantBuilder(
@@ -82,11 +90,14 @@ class RegularCallParticipantsContent extends StatelessWidget {
     //
     // speakerOneToOne floats on every platform: it shows nobody but the
     // speaker, so without the inset the local participant is absent from the
-    // call entirely. auto's grid follows the platform instead.
+    // call entirely. auto's grid follows the platform and the size of the
+    // call instead.
     final floatsSelfView = switch (effective) {
       ParticipantLayoutMode.speakerOneToOne => enableFloatingSelfView ?? true,
       ParticipantLayoutMode.grid when isAuto =>
-        enableFloatingSelfView ?? !isDesktopDevice,
+        enableFloatingSelfView ??
+            (!isDesktopDevice &&
+                remoteParticipants.length <= _maxRemotesBehindSelfView),
       _ => false,
     };
 

--- a/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
@@ -101,11 +101,12 @@ class RegularCallParticipantsContent extends StatelessWidget {
     if (effective.isSpeakerLayout && participants.isNotEmpty) {
       var spotlight = participants.first;
 
-      // Somebody else takes the frame whenever the local participant is
-      // already accounted for: floating over the layout, or alone with one
-      // other person.
+      // A layout with no bar shows nobody but the spotlight, so it goes to a
+      // remote whenever there is one. A bar layout can spotlight whoever the
+      // sort put first, the local participant included, since everybody else
+      // is still in the bar — unless there is only one other person.
       if (remoteParticipants.isNotEmpty &&
-          (floatLocalVideo || remoteParticipants.length == 1)) {
+          (effective.barAlignment == null || remoteParticipants.length == 1)) {
         spotlight = remoteParticipants.first;
       }
 

--- a/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../../stream_video_flutter.dart';
 import 'layout/call_participants_grid_view.dart';
-import 'layout/call_participants_spotlight_view.dart';
 
 /// A widget that represents the main area of the call when nobody is
 /// sharing their screen.
@@ -15,7 +14,7 @@ class RegularCallParticipantsContent extends StatelessWidget {
     this.callParticipantBuilder = _defaultParticipantBuilder,
     this.enableLocalVideo,
     this.localVideoParticipantBuilder,
-    this.layoutMode = ParticipantLayoutMode.grid,
+    this.layoutMode = ParticipantLayoutMode.auto,
   });
 
   /// Represents a call.
@@ -54,40 +53,71 @@ class RegularCallParticipantsContent extends StatelessWidget {
     final remoteParticipants = participants.where((e) => !e.isLocal);
     final localParticipant = participants.where((e) => e.isLocal).firstOrNull;
 
-    if (layoutMode == ParticipantLayoutMode.spotlight) {
+    // ParticipantLayoutMode.auto follows the call: one person on the other end
+    // is a conversation and gets their face full-frame, anything else is a
+    // group and gets a grid.
+    final requested = layoutMode.canonical;
+    final isAuto = requested == ParticipantLayoutMode.auto;
+    final effective = switch (isAuto) {
+      false => requested,
+      true when remoteParticipants.length == 1 =>
+        ParticipantLayoutMode.speakerOneToOne,
+      true => ParticipantLayoutMode.grid,
+    };
+
+    // By default we don't show local video on desktop devices — except under
+    // speakerOneToOne, where the floating self-view is the layout rather than
+    // an addition to it: without it the layout is a lone spotlight, and the
+    // local participant, who has no tile either, disappears from the call.
+    final showsSelfView = effective == ParticipantLayoutMode.speakerOneToOne;
+    final enableLocalVideo =
+        this.enableLocalVideo ?? (showsSelfView || !isDesktopDevice);
+    // Only the layouts that leave the local participant out of the arrangement
+    // float them over it. The grid and the four bar layouts already give them a
+    // tile, and a self-view on top of that would show them twice.
+    final floatLocalVideo =
+        enableLocalVideo &&
+        localParticipant != null &&
+        remoteParticipants.isNotEmpty &&
+        (isAuto || showsSelfView);
+
+    Widget child;
+    if (effective.isSpeakerLayout) {
       var spotlight = participants.first;
 
-      // In a 1-on-1 call we don't spotlight the local participant.
-      if (remoteParticipants.length == 1) {
+      // The frame belongs to somebody else whenever the local participant is
+      // already accounted for: floating over the layout, or — in a 1-on-1
+      // call — because spotlighting yourself is never what was meant.
+      if (remoteParticipants.isNotEmpty &&
+          (floatLocalVideo || remoteParticipants.length == 1)) {
         spotlight = remoteParticipants.first;
       }
 
-      final barParticipants = [...participants]..remove(spotlight);
+      // speakerOneToOne shows the speaker alone. The spotlight view hides an
+      // empty bar and gives the whole frame to the spotlight.
+      final barParticipants = effective.barAlignment == null
+          ? const <CallParticipantState>[]
+          : ([...participants]..remove(spotlight));
 
-      return CallParticipantsSpotlightView(
+      child = CallParticipantsSpotlightView(
         call: call,
         spotlight: spotlight,
         participants: barParticipants,
         participantBuilder: callParticipantBuilder,
+        barAlignment: effective.barAlignment ?? ParticipantsBarAlignment.bottom,
+      );
+    } else {
+      final gridParticipants = [...participants];
+      if (floatLocalVideo) gridParticipants.remove(localParticipant);
+
+      child = CallParticipantsGridView(
+        call: call,
+        participants: gridParticipants,
+        itemBuilder: callParticipantBuilder,
       );
     }
 
-    // By default we don't show local video on desktop devices.
-    final enableLocalVideo = this.enableLocalVideo ?? !isDesktopDevice;
-    final showLocalVideo = enableLocalVideo && remoteParticipants.isNotEmpty;
-
-    final gridParticipants = [...participants];
-    if (showLocalVideo && localParticipant != null) {
-      gridParticipants.remove(localParticipant);
-    }
-
-    Widget child = CallParticipantsGridView(
-      call: call,
-      participants: gridParticipants,
-      itemBuilder: callParticipantBuilder,
-    );
-
-    if (showLocalVideo && localParticipant != null) {
+    if (floatLocalVideo) {
       child = StreamLocalVideo(
         call: call,
         participant: localParticipant,

--- a/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/regular_call_participants_content.dart
@@ -65,21 +65,29 @@ class RegularCallParticipantsContent extends StatelessWidget {
       true => ParticipantLayoutMode.grid,
     };
 
-    // By default we don't show local video on desktop devices — except under
-    // speakerOneToOne, where the floating self-view is the layout rather than
-    // an addition to it: without it the layout is a lone spotlight, and the
-    // local participant, who has no tile either, disappears from the call.
-    final showsSelfView = effective == ParticipantLayoutMode.speakerOneToOne;
-    final enableLocalVideo =
-        this.enableLocalVideo ?? (showsSelfView || !isDesktopDevice);
-    // Only the layouts that leave the local participant out of the arrangement
-    // float them over it. The grid and the four bar layouts already give them a
-    // tile, and a self-view on top of that would show them twice.
+    // Only these two layouts leave the local participant out of the
+    // arrangement, so only they can float a self-view over it. The grid and the
+    // four bar layouts give them a tile of their own, and a self-view on top of
+    // that would show them twice — which is why every other case is false here
+    // whatever [enableLocalVideo] says.
+    //
+    // The two differ in what they default to. Under speakerOneToOne the inset
+    // is the layout rather than an addition to it: without it the layout is a
+    // lone spotlight, and the local participant, who gets no tile and no bar
+    // either, disappears from the call. Under auto's grid it follows the
+    // platform, since a phone has no room for a tile per person but a desktop
+    // does.
+    final floatsSelfView = switch (effective) {
+      ParticipantLayoutMode.speakerOneToOne => enableLocalVideo ?? true,
+      ParticipantLayoutMode.grid when isAuto =>
+        enableLocalVideo ?? !isDesktopDevice,
+      _ => false,
+    };
+
     final floatLocalVideo =
-        enableLocalVideo &&
+        floatsSelfView &&
         localParticipant != null &&
-        remoteParticipants.isNotEmpty &&
-        (isAuto || showsSelfView);
+        remoteParticipants.isNotEmpty;
 
     Widget child;
     if (effective.isSpeakerLayout) {

--- a/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_participants/screen_share_call_participants_content.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../stream_video_flutter.dart';
-import 'layout/call_participants_spotlight_view.dart';
 
 /// A widget that represents the main area of the call when somebody is
 /// sharing their screen.

--- a/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
+++ b/packages/stream_video_flutter/lib/src/call_screen/call_content/call_content.dart
@@ -51,7 +51,7 @@ class StreamCallContent extends StatefulWidget {
     this.callControlsWidgetBuilder,
     this.callNotConnectedBuilder,
     this.callFastReconnectingOverlayBuilder,
-    this.layoutMode = ParticipantLayoutMode.grid,
+    this.layoutMode = ParticipantLayoutMode.auto,
     this.extendBody = false,
     this.pictureInPictureConfiguration = const PictureInPictureConfiguration(),
   });

--- a/packages/stream_video_flutter/lib/src/l10n/arb/stream_video_flutter_en.arb
+++ b/packages/stream_video_flutter/lib/src/l10n/arb/stream_video_flutter_en.arb
@@ -19,6 +19,42 @@
   "@desktopScreenShareWindow": {
     "description": "Tab to select a single window to share"
   },
+  "layoutMenuTitle": "Layout",
+  "@layoutMenuTitle": {
+    "description": "Title of the sheet that picks how participants are laid out"
+  },
+  "layoutSelectTooltip": "Change layout",
+  "@layoutSelectTooltip": {
+    "description": "Tooltip of the call control that picks a participant layout"
+  },
+  "layoutDefault": "Default",
+  "@layoutDefault": {
+    "description": "The participant layout that follows the call instead of being fixed"
+  },
+  "layoutGrid": "Grid",
+  "@layoutGrid": {
+    "description": "The participant layout giving everybody an equal tile"
+  },
+  "layoutSpeakerTop": "Speaker (Top)",
+  "@layoutSpeakerTop": {
+    "description": "The participant layout with the speaker below the other participants"
+  },
+  "layoutSpeakerBottom": "Speaker (Bottom)",
+  "@layoutSpeakerBottom": {
+    "description": "The participant layout with the speaker above the other participants"
+  },
+  "layoutSpeakerLeft": "Speaker (Left)",
+  "@layoutSpeakerLeft": {
+    "description": "The participant layout with the speaker right of the other participants"
+  },
+  "layoutSpeakerRight": "Speaker (Right)",
+  "@layoutSpeakerRight": {
+    "description": "The participant layout with the speaker left of the other participants"
+  },
+  "layoutSpeakerOneToOne": "Speaker 1:1",
+  "@layoutSpeakerOneToOne": {
+    "description": "The participant layout showing only the speaker and the local participant"
+  },
   "livestreamBackstageStartingSoon": "Livestream will start soon",
   "@livestreamBackstageStartingSoon": {
     "description": "Label for livestream backstage when live stream will soon start"

--- a/packages/stream_video_flutter/lib/src/l10n/arb/stream_video_flutter_en.arb
+++ b/packages/stream_video_flutter/lib/src/l10n/arb/stream_video_flutter_en.arb
@@ -37,19 +37,19 @@
   },
   "layoutSpeakerTop": "Speaker (Top)",
   "@layoutSpeakerTop": {
-    "description": "The participant layout with the speaker below the other participants"
+    "description": "The participant layout with the speaker above the other participants"
   },
   "layoutSpeakerBottom": "Speaker (Bottom)",
   "@layoutSpeakerBottom": {
-    "description": "The participant layout with the speaker above the other participants"
+    "description": "The participant layout with the speaker below the other participants"
   },
   "layoutSpeakerLeft": "Speaker (Left)",
   "@layoutSpeakerLeft": {
-    "description": "The participant layout with the speaker right of the other participants"
+    "description": "The participant layout with the speaker left of the other participants"
   },
   "layoutSpeakerRight": "Speaker (Right)",
   "@layoutSpeakerRight": {
-    "description": "The participant layout with the speaker left of the other participants"
+    "description": "The participant layout with the speaker right of the other participants"
   },
   "layoutSpeakerOneToOne": "Speaker 1:1",
   "@layoutSpeakerOneToOne": {

--- a/packages/stream_video_flutter/lib/src/l10n/arb/stream_video_flutter_nl.arb
+++ b/packages/stream_video_flutter/lib/src/l10n/arb/stream_video_flutter_nl.arb
@@ -5,41 +5,14 @@
   "desktopScreenShareEntireScreen": "Volledig scherm",
   "desktopScreenShareWindow": "Venster",
   "layoutMenuTitle": "Indeling",
-  "@layoutMenuTitle": {
-    "description": "Title of the sheet that picks how participants are laid out"
-  },
   "layoutSelectTooltip": "Indeling wijzigen",
-  "@layoutSelectTooltip": {
-    "description": "Tooltip of the call control that picks a participant layout"
-  },
   "layoutDefault": "Standaard",
-  "@layoutDefault": {
-    "description": "The participant layout that follows the call instead of being fixed"
-  },
   "layoutGrid": "Raster",
-  "@layoutGrid": {
-    "description": "The participant layout giving everybody an equal tile"
-  },
   "layoutSpeakerTop": "Spreker (boven)",
-  "@layoutSpeakerTop": {
-    "description": "The participant layout with the speaker below the other participants"
-  },
   "layoutSpeakerBottom": "Spreker (onder)",
-  "@layoutSpeakerBottom": {
-    "description": "The participant layout with the speaker above the other participants"
-  },
   "layoutSpeakerLeft": "Spreker (links)",
-  "@layoutSpeakerLeft": {
-    "description": "The participant layout with the speaker right of the other participants"
-  },
   "layoutSpeakerRight": "Spreker (rechts)",
-  "@layoutSpeakerRight": {
-    "description": "The participant layout with the speaker left of the other participants"
-  },
   "layoutSpeakerOneToOne": "Spreker 1:1",
-  "@layoutSpeakerOneToOne": {
-    "description": "The participant layout showing only the speaker and the local participant"
-  },
   "livestreamBackstageStartingSoon": "Livestream begint binnenkort",
   "livestreamBackstageStartingIn": "Livestream begint over:",
   "livestreamBackstageParticipants": "{count, plural, zero{Nog geen deelnemers  zijn} one{Eén deelnemer is} other{{count} deelnemers zijn}} vroeg aanwezig",

--- a/packages/stream_video_flutter/lib/src/l10n/arb/stream_video_flutter_nl.arb
+++ b/packages/stream_video_flutter/lib/src/l10n/arb/stream_video_flutter_nl.arb
@@ -4,6 +4,42 @@
   "desktopScreenShareChooseDialogCancel": "Annuleren",
   "desktopScreenShareEntireScreen": "Volledig scherm",
   "desktopScreenShareWindow": "Venster",
+  "layoutMenuTitle": "Indeling",
+  "@layoutMenuTitle": {
+    "description": "Title of the sheet that picks how participants are laid out"
+  },
+  "layoutSelectTooltip": "Indeling wijzigen",
+  "@layoutSelectTooltip": {
+    "description": "Tooltip of the call control that picks a participant layout"
+  },
+  "layoutDefault": "Standaard",
+  "@layoutDefault": {
+    "description": "The participant layout that follows the call instead of being fixed"
+  },
+  "layoutGrid": "Raster",
+  "@layoutGrid": {
+    "description": "The participant layout giving everybody an equal tile"
+  },
+  "layoutSpeakerTop": "Spreker (boven)",
+  "@layoutSpeakerTop": {
+    "description": "The participant layout with the speaker below the other participants"
+  },
+  "layoutSpeakerBottom": "Spreker (onder)",
+  "@layoutSpeakerBottom": {
+    "description": "The participant layout with the speaker above the other participants"
+  },
+  "layoutSpeakerLeft": "Spreker (links)",
+  "@layoutSpeakerLeft": {
+    "description": "The participant layout with the speaker right of the other participants"
+  },
+  "layoutSpeakerRight": "Spreker (rechts)",
+  "@layoutSpeakerRight": {
+    "description": "The participant layout with the speaker left of the other participants"
+  },
+  "layoutSpeakerOneToOne": "Spreker 1:1",
+  "@layoutSpeakerOneToOne": {
+    "description": "The participant layout showing only the speaker and the local participant"
+  },
   "livestreamBackstageStartingSoon": "Livestream begint binnenkort",
   "livestreamBackstageStartingIn": "Livestream begint over:",
   "livestreamBackstageParticipants": "{count, plural, zero{Nog geen deelnemers  zijn} one{Eén deelnemer is} other{{count} deelnemers zijn}} vroeg aanwezig",

--- a/packages/stream_video_flutter/lib/src/l10n/localizations/stream_video_flutter_localizations.dart
+++ b/packages/stream_video_flutter/lib/src/l10n/localizations/stream_video_flutter_localizations.dart
@@ -131,6 +131,60 @@ abstract class StreamVideoFlutterLocalizations {
   /// **'Window'**
   String get desktopScreenShareWindow;
 
+  /// Title of the sheet that picks how participants are laid out
+  ///
+  /// In en, this message translates to:
+  /// **'Layout'**
+  String get layoutMenuTitle;
+
+  /// Tooltip of the call control that picks a participant layout
+  ///
+  /// In en, this message translates to:
+  /// **'Change layout'**
+  String get layoutSelectTooltip;
+
+  /// The participant layout that follows the call instead of being fixed
+  ///
+  /// In en, this message translates to:
+  /// **'Default'**
+  String get layoutDefault;
+
+  /// The participant layout giving everybody an equal tile
+  ///
+  /// In en, this message translates to:
+  /// **'Grid'**
+  String get layoutGrid;
+
+  /// The participant layout with the speaker below the other participants
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker (Top)'**
+  String get layoutSpeakerTop;
+
+  /// The participant layout with the speaker above the other participants
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker (Bottom)'**
+  String get layoutSpeakerBottom;
+
+  /// The participant layout with the speaker right of the other participants
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker (Left)'**
+  String get layoutSpeakerLeft;
+
+  /// The participant layout with the speaker left of the other participants
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker (Right)'**
+  String get layoutSpeakerRight;
+
+  /// The participant layout showing only the speaker and the local participant
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker 1:1'**
+  String get layoutSpeakerOneToOne;
+
   /// Label for livestream backstage when live stream will soon start
   ///
   /// In en, this message translates to:

--- a/packages/stream_video_flutter/lib/src/l10n/localizations/stream_video_flutter_localizations.dart
+++ b/packages/stream_video_flutter/lib/src/l10n/localizations/stream_video_flutter_localizations.dart
@@ -155,25 +155,25 @@ abstract class StreamVideoFlutterLocalizations {
   /// **'Grid'**
   String get layoutGrid;
 
-  /// The participant layout with the speaker below the other participants
+  /// The participant layout with the speaker above the other participants
   ///
   /// In en, this message translates to:
   /// **'Speaker (Top)'**
   String get layoutSpeakerTop;
 
-  /// The participant layout with the speaker above the other participants
+  /// The participant layout with the speaker below the other participants
   ///
   /// In en, this message translates to:
   /// **'Speaker (Bottom)'**
   String get layoutSpeakerBottom;
 
-  /// The participant layout with the speaker right of the other participants
+  /// The participant layout with the speaker left of the other participants
   ///
   /// In en, this message translates to:
   /// **'Speaker (Left)'**
   String get layoutSpeakerLeft;
 
-  /// The participant layout with the speaker left of the other participants
+  /// The participant layout with the speaker right of the other participants
   ///
   /// In en, this message translates to:
   /// **'Speaker (Right)'**

--- a/packages/stream_video_flutter/lib/src/l10n/localizations/stream_video_flutter_localizations_en.dart
+++ b/packages/stream_video_flutter/lib/src/l10n/localizations/stream_video_flutter_localizations_en.dart
@@ -25,6 +25,33 @@ class StreamVideoFlutterLocalizationsEn
   String get desktopScreenShareWindow => 'Window';
 
   @override
+  String get layoutMenuTitle => 'Layout';
+
+  @override
+  String get layoutSelectTooltip => 'Change layout';
+
+  @override
+  String get layoutDefault => 'Default';
+
+  @override
+  String get layoutGrid => 'Grid';
+
+  @override
+  String get layoutSpeakerTop => 'Speaker (Top)';
+
+  @override
+  String get layoutSpeakerBottom => 'Speaker (Bottom)';
+
+  @override
+  String get layoutSpeakerLeft => 'Speaker (Left)';
+
+  @override
+  String get layoutSpeakerRight => 'Speaker (Right)';
+
+  @override
+  String get layoutSpeakerOneToOne => 'Speaker 1:1';
+
+  @override
   String get livestreamBackstageStartingSoon => 'Livestream will start soon';
 
   @override

--- a/packages/stream_video_flutter/lib/src/l10n/localizations/stream_video_flutter_localizations_nl.dart
+++ b/packages/stream_video_flutter/lib/src/l10n/localizations/stream_video_flutter_localizations_nl.dart
@@ -25,6 +25,33 @@ class StreamVideoFlutterLocalizationsNl
   String get desktopScreenShareWindow => 'Venster';
 
   @override
+  String get layoutMenuTitle => 'Indeling';
+
+  @override
+  String get layoutSelectTooltip => 'Indeling wijzigen';
+
+  @override
+  String get layoutDefault => 'Standaard';
+
+  @override
+  String get layoutGrid => 'Raster';
+
+  @override
+  String get layoutSpeakerTop => 'Spreker (boven)';
+
+  @override
+  String get layoutSpeakerBottom => 'Spreker (onder)';
+
+  @override
+  String get layoutSpeakerLeft => 'Spreker (links)';
+
+  @override
+  String get layoutSpeakerRight => 'Spreker (rechts)';
+
+  @override
+  String get layoutSpeakerOneToOne => 'Spreker 1:1';
+
+  @override
   String get livestreamBackstageStartingSoon => 'Livestream begint binnenkort';
 
   @override

--- a/packages/stream_video_flutter/lib/src/livestream/livestream_content.dart
+++ b/packages/stream_video_flutter/lib/src/livestream/livestream_content.dart
@@ -229,7 +229,7 @@ class _LivestreamContentState extends State<LivestreamContent> {
         call: properties.call,
         layoutMode: widget.showMultipleHosts
             ? widget.layoutMode
-            : ParticipantLayoutMode.speakerBottom,
+            : ParticipantLayoutMode.speakerTop,
         screenShareMode: widget.screenShareMode,
         hosts: widget.showMultipleHosts
             ? properties.hosts

--- a/packages/stream_video_flutter/lib/src/livestream/livestream_content.dart
+++ b/packages/stream_video_flutter/lib/src/livestream/livestream_content.dart
@@ -229,7 +229,7 @@ class _LivestreamContentState extends State<LivestreamContent> {
         call: properties.call,
         layoutMode: widget.showMultipleHosts
             ? widget.layoutMode
-            : ParticipantLayoutMode.spotlight,
+            : ParticipantLayoutMode.speakerBottom,
         screenShareMode: widget.screenShareMode,
         hosts: widget.showMultipleHosts
             ? properties.hosts

--- a/packages/stream_video_flutter/lib/src/widgets/design_system_candidates/stream_adaptive_menu_anchor.dart
+++ b/packages/stream_video_flutter/lib/src/widgets/design_system_candidates/stream_adaptive_menu_anchor.dart
@@ -315,6 +315,41 @@ class _StreamAdaptiveMenuAnchorState extends State<StreamAdaptiveMenuAnchor>
     );
   }
 
+  /// Fills the row of the option currently in effect, as the sheet's
+  /// [StreamListTile] does for its own selected row.
+  ///
+  /// [StreamContextMenuAction] has no selected state, and the radio indicator
+  /// that would otherwise mark the choice is suppressed by an explicit
+  /// [StreamMenuOption.leading] — so without this a menu of icons shows nothing
+  /// at all for the option in effect.
+  ///
+  /// The style has to be built up from [StreamContextMenuAnchor.defaultActionStyle]
+  /// rather than layered over it: [StreamContextMenuActionTheme.of] reads the
+  /// nearest theme only, so a bare override here would drop the design's row
+  /// metrics and leave the selected row taller and wider than its siblings.
+  Widget _selectedBackground(
+    BuildContext context, {
+    required bool selected,
+    required Widget child,
+  }) {
+    if (!selected) return child;
+
+    return StreamContextMenuActionTheme(
+      data: StreamContextMenuActionThemeData(
+        style: StreamContextMenuAnchor.defaultActionStyle(context)
+            .merge(widget.menuItemStyle)
+            .merge(
+              StreamContextMenuActionStyle(
+                backgroundColor: WidgetStatePropertyAll(
+                  context.streamColorScheme.backgroundSelected,
+                ),
+              ),
+            ),
+      ),
+      child: child,
+    );
+  }
+
   Widget _anchored(BuildContext context, {double? width}) {
     return StreamContextMenuAnchor(
       controller: _menuController,
@@ -350,21 +385,25 @@ class _StreamAdaptiveMenuAnchorState extends State<StreamAdaptiveMenuAnchor>
                 if (section.heading case final heading?)
                   StreamContextMenuHeading(label: Text(heading)),
               for (final option in section.options)
-                StreamContextMenuAction<void>(
-                  onTap: option.onSelected == null
-                      ? null
-                      : () => _select(option),
-                  // Deliberately left enabled for a row with nothing to
-                  // press. `enabled: false` is the design system's
-                  // *unavailable* look — it paints the label in
-                  // `textDisabled` — and a list that only shows something,
-                  // like the people already in a call, would render every
-                  // name as though that person were unavailable.
-                  leading: _leadingOf(option),
-                  label: Text(
-                    option.label,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
+                _selectedBackground(
+                  context,
+                  selected: option.selected ?? false,
+                  child: StreamContextMenuAction<void>(
+                    onTap: option.onSelected == null
+                        ? null
+                        : () => _select(option),
+                    // Deliberately left enabled for a row with nothing to
+                    // press. `enabled: false` is the design system's
+                    // *unavailable* look — it paints the label in
+                    // `textDisabled` — and a list that only shows something,
+                    // like the people already in a call, would render every
+                    // name as though that person were unavailable.
+                    leading: _leadingOf(option),
+                    label: Text(
+                      option.label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ),
                 ),
             ],

--- a/packages/stream_video_flutter/lib/src/widgets/design_system_candidates/stream_adaptive_menu_anchor.dart
+++ b/packages/stream_video_flutter/lib/src/widgets/design_system_candidates/stream_adaptive_menu_anchor.dart
@@ -323,8 +323,9 @@ class _StreamAdaptiveMenuAnchorState extends State<StreamAdaptiveMenuAnchor>
   /// [StreamMenuOption.leading] — so without this a menu of icons shows nothing
   /// at all for the option in effect.
   ///
-  /// The style has to be built up from [StreamContextMenuAnchor.defaultActionStyle]
-  /// rather than layered over it: [StreamContextMenuActionTheme.of] reads the
+  /// The style has to be built up from
+  /// [StreamContextMenuAnchor.defaultActionStyle] rather than layered over it:
+  /// [StreamContextMenuActionTheme.of] reads the
   /// nearest theme only, so a bare override here would drop the design's row
   /// metrics and leave the selected row taller and wider than its siblings.
   Widget _selectedBackground(

--- a/packages/stream_video_flutter/lib/src/widgets/design_system_candidates/stream_context_menu_anchor.dart
+++ b/packages/stream_video_flutter/lib/src/widgets/design_system_candidates/stream_context_menu_anchor.dart
@@ -94,11 +94,32 @@ class StreamContextMenuAnchor extends StatelessWidget {
   /// Called when the menu closes.
   final VoidCallback? onClose;
 
+  /// The design's `Web / Menu Item`, which every row in the menu is styled to.
+  ///
+  /// It is a 32px tall row with a 200px minimum width, a caption/emphasis label
+  /// and 16px icons. The stream_core_flutter defaults are a 40px tall row with
+  /// a 242px minimum width, a body/emphasis label and 20px icons.
+  ///
+  /// The row is inset by 8px on top of the 4px the menu panel already pads
+  /// with, which puts the content 12px from the panel edge and leaves the row's
+  /// rounded highlight 4px inside it, as designed.
+  ///
+  /// Public because [StreamContextMenuActionTheme.of] reads only the nearest
+  /// theme: anything varying one row has to re-merge this, or that row falls
+  /// back to the core defaults while its siblings keep the design's metrics.
+  static StreamContextMenuActionStyle defaultActionStyle(
+    BuildContext context,
+  ) => StreamContextMenuActionStyle(
+    textStyle: WidgetStatePropertyAll(context.streamTextTheme.captionEmphasis),
+    iconSize: const WidgetStatePropertyAll(16),
+    minimumSize: const WidgetStatePropertyAll(Size(200, 32)),
+    padding: WidgetStatePropertyAll(
+      EdgeInsets.symmetric(horizontal: context.streamSpacing.xs),
+    ),
+  );
+
   @override
   Widget build(BuildContext context) {
-    final spacing = context.streamSpacing;
-    final textTheme = context.streamTextTheme;
-
     return MenuAnchor(
       controller: controller,
       alignmentOffset: alignmentOffset,
@@ -120,24 +141,9 @@ class StreamContextMenuAnchor extends StatelessWidget {
         PrimaryScrollController.none(
           child: ConstrainedBox(
             constraints: constraints,
-            // The design's `Web / Menu Item` is a 32px tall row with a 200px
-            // minimum width, a caption/emphasis label and 16px icons. The
-            // stream_core_flutter defaults are a 40px tall row with a 242px
-            // minimum width, a body/emphasis label and 20px icons.
-            //
-            // The row is inset by 8px on top of the 4px the menu panel already
-            // pads with, which puts the content 12px from the panel edge and
-            // leaves the row's rounded highlight 4px inside it, as designed.
             child: StreamContextMenuActionTheme(
               data: StreamContextMenuActionThemeData(
-                style: StreamContextMenuActionStyle(
-                  textStyle: WidgetStatePropertyAll(textTheme.captionEmphasis),
-                  iconSize: const WidgetStatePropertyAll(16),
-                  minimumSize: const WidgetStatePropertyAll(Size(200, 32)),
-                  padding: WidgetStatePropertyAll(
-                    EdgeInsets.symmetric(horizontal: spacing.xs),
-                  ),
-                ).merge(actionStyle),
+                style: defaultActionStyle(context).merge(actionStyle),
               ),
               child: StreamContextMenu(
                 elevation: elevation,

--- a/packages/stream_video_flutter/lib/src/widgets/design_system_candidates/stream_context_menu_anchor.dart
+++ b/packages/stream_video_flutter/lib/src/widgets/design_system_candidates/stream_context_menu_anchor.dart
@@ -100,9 +100,9 @@ class StreamContextMenuAnchor extends StatelessWidget {
   /// and 16px icons. The stream_core_flutter defaults are a 40px tall row with
   /// a 242px minimum width, a body/emphasis label and 20px icons.
   ///
-  /// The row is inset by 8px on top of the 4px the menu panel already pads
-  /// with, which puts the content 12px from the panel edge and leaves the row's
-  /// rounded highlight 4px inside it, as designed.
+  /// The row is inset horizontally by 8px on top of the 4px the menu panel
+  /// already pads with, which puts the content 12px from the panel edge and
+  /// leaves the row's rounded highlight 4px inside it, as designed.
   ///
   /// Public because [StreamContextMenuActionTheme.of] reads only the nearest
   /// theme: anything varying one row has to re-merge this, or that row falls

--- a/packages/stream_video_flutter/lib/stream_video_flutter.dart
+++ b/packages/stream_video_flutter/lib/stream_video_flutter.dart
@@ -37,6 +37,7 @@ export 'src/call_participants/call_participants_sorting_mixin.dart';
 export 'src/call_participants/floating_participant_tile.dart';
 export 'src/call_participants/indicators/audio_indicator.dart';
 export 'src/call_participants/indicators/connection_quality_indicator.dart';
+export 'src/call_participants/layout/call_participants_spotlight_view.dart';
 export 'src/call_participants/layout/participant_layout_mode.dart';
 export 'src/call_participants/livestream_hosts.dart';
 export 'src/call_participants/local_video.dart';

--- a/packages/stream_video_flutter/test/src/call_controls/controls/stream_layout_button_test.dart
+++ b/packages/stream_video_flutter/test/src/call_controls/controls/stream_layout_button_test.dart
@@ -95,6 +95,32 @@ void main() {
       }
     });
 
+    testWidgets('menuDirection decides which way the menu opens', (
+      tester,
+    ) async {
+      for (final (direction, offset) in <(StreamMenuDirection, Offset)>[
+        (StreamMenuDirection.up, const Offset(0, -8)),
+        (StreamMenuDirection.down, const Offset(0, 8)),
+      ]) {
+        await tester.pumpWidget(
+          TestWrapper(
+            platform: .macOS,
+            child: StreamLayoutButton(
+              layouts: ParticipantLayoutModeX.selectable,
+              menuDirection: direction,
+              onLayoutModeChanged: (_) {},
+            ),
+          ),
+        );
+
+        expect(
+          tester.widget<MenuAnchor>(find.byType(MenuAnchor)).alignmentOffset,
+          offset,
+          reason: '$direction',
+        );
+      }
+    });
+
     testWidgets('opens a sheet headed "Layout" on Android', (tester) async {
       await tester.pumpWidget(
         TestWrapper(

--- a/packages/stream_video_flutter/test/src/call_controls/controls/stream_layout_button_test.dart
+++ b/packages/stream_video_flutter/test/src/call_controls/controls/stream_layout_button_test.dart
@@ -1,0 +1,337 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_video_flutter/stream_video_flutter.dart';
+
+import '../../../test_utils/test_wrapper.dart';
+
+// The menu lives above the page — anchored in an Overlay, or in a sheet route —
+// and the capture Alchemist uses for the committed CI goldens drops overlay
+// content, so an open menu snapshots blank rather than failing. Everything
+// about the open menu is asserted here instead of snapshotted.
+void main() {
+  // The icons the widget resolves off `context.streamIcons`; the defaults are
+  // what TestWrapper's theme installs.
+  const icons = StreamIcons();
+
+  group('StreamLayoutButton', () {
+    testWidgets('draws the icon of the layout in effect', (tester) async {
+      for (final (mode, icon) in <(ParticipantLayoutMode, IconData)>[
+        (.auto, icons.gridDefaultFill),
+        (.grid, icons.gridFill),
+        (.speakerTop, icons.speakerTopFill),
+        (.speakerBottom, icons.speakerBottomFill),
+        (.speakerLeft, icons.speakerLeftFill),
+        (.speakerRight, icons.speakerRightFill),
+        (.speakerOneToOne, icons.pipFill),
+      ]) {
+        await tester.pumpWidget(
+          TestWrapper(
+            child: StreamLayoutButton(
+              layout: mode,
+              onLayoutModeChanged: (_) {},
+            ),
+          ),
+        );
+
+        expect(
+          find.byIcon(icon),
+          findsOneWidget,
+          reason: '$mode should draw its own icon',
+        );
+      }
+    });
+
+    testWidgets('draws the deprecated aliases as their replacement', (
+      tester,
+    ) async {
+      for (final (mode, icon) in <(ParticipantLayoutMode, IconData)>[
+        // ignore: deprecated_member_use
+        (ParticipantLayoutMode.spotlight, icons.speakerBottomFill),
+        // ignore: deprecated_member_use
+        (ParticipantLayoutMode.pictureInPicture, icons.pipFill),
+      ]) {
+        await tester.pumpWidget(
+          TestWrapper(
+            child: StreamLayoutButton(
+              layout: mode,
+              onLayoutModeChanged: (_) {},
+            ),
+          ),
+        );
+
+        expect(find.byIcon(icon), findsOneWidget, reason: '$mode');
+      }
+    });
+
+    testWidgets('opens an anchored menu of every layout on macOS', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        TestWrapper(
+          platform: .macOS,
+          child: StreamLayoutButton(
+            layouts: ParticipantLayoutModeX.selectable,
+            onLayoutModeChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(find.byType(StreamContextMenuAction<void>), findsNothing);
+
+      await tester.tap(find.byIcon(icons.gridDefaultFill));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StreamContextMenuAction<void>), findsNWidgets(7));
+      for (final label in const [
+        'Default',
+        'Grid',
+        'Speaker (Top)',
+        'Speaker (Bottom)',
+        'Speaker (Left)',
+        'Speaker (Right)',
+        'Speaker 1:1',
+      ]) {
+        expect(find.text(label), findsOneWidget, reason: label);
+      }
+    });
+
+    testWidgets('opens a sheet headed "Layout" on Android', (tester) async {
+      await tester.pumpWidget(
+        TestWrapper(
+          child: StreamLayoutButton(
+            layouts: ParticipantLayoutModeX.selectable,
+            onLayoutModeChanged: (_) {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(icons.gridDefaultFill));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StreamSheetHeader), findsOneWidget);
+      expect(find.text('Layout'), findsOneWidget);
+      expect(find.byType(StreamListTile), findsNWidgets(7));
+    });
+
+    testWidgets('marks the row of the layout in effect on the sheet', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        TestWrapper(
+          child: StreamLayoutButton(
+            layout: .speakerLeft,
+            layouts: ParticipantLayoutModeX.selectable,
+            onLayoutModeChanged: (_) {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(icons.speakerLeftFill).first);
+      await tester.pumpAndSettle();
+
+      final selected = tester
+          .widgetList<StreamListTile>(find.byType(StreamListTile))
+          .where((tile) => tile.props.selected)
+          .toList();
+
+      expect(selected, hasLength(1));
+      expect(
+        find.descendant(
+          of: find.byWidget(selected.single),
+          matching: find.text('Speaker (Left)'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('fills the row of the layout in effect in the anchored menu', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        TestWrapper(
+          platform: .macOS,
+          child: StreamLayoutButton(
+            layout: .grid,
+            layouts: ParticipantLayoutModeX.selectable,
+            onLayoutModeChanged: (_) {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(icons.gridFill).first);
+      await tester.pumpAndSettle();
+
+      final backgroundSelected = tester
+          .element(find.byType(StreamLayoutButton))
+          .streamColorScheme
+          .backgroundSelected;
+
+      final filled = tester
+          .widgetList<TextButton>(
+            find.descendant(
+              of: find.byType(StreamContextMenuAction<void>),
+              matching: find.byType(TextButton),
+            ),
+          )
+          .where(
+            (button) =>
+                button.style?.backgroundColor?.resolve(const {}) ==
+                backgroundSelected,
+          );
+
+      expect(filled, hasLength(1));
+
+      // The fill must not cost the row the design's metrics: the selected row
+      // re-themes the action, and a theme that dropped the anchor's own would
+      // leave it taller and wider than its siblings.
+      expect(
+        filled.single.style?.minimumSize?.resolve(const {}),
+        const Size(200, 32),
+      );
+    });
+
+    testWidgets('reports the picked layout and closes', (tester) async {
+      final picked = <ParticipantLayoutMode>[];
+
+      await tester.pumpWidget(
+        TestWrapper(
+          platform: .macOS,
+          child: StreamLayoutButton(
+            layouts: ParticipantLayoutModeX.selectable,
+            onLayoutModeChanged: picked.add,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(icons.gridDefaultFill));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Speaker (Right)'));
+      await tester.pumpAndSettle();
+
+      expect(picked, [ParticipantLayoutMode.speakerRight]);
+      expect(find.byType(StreamContextMenuAction<void>), findsNothing);
+    });
+
+    testWidgets('offers only the layouts it was given', (tester) async {
+      await tester.pumpWidget(
+        TestWrapper(
+          platform: .macOS,
+          child: StreamLayoutButton(
+            layouts: const [.grid, .speakerOneToOne, .auto],
+            onLayoutModeChanged: (_) {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(icons.gridDefaultFill));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StreamContextMenuAction<void>), findsNWidgets(3));
+      expect(find.text('Grid'), findsOneWidget);
+      expect(find.text('Speaker (Top)'), findsNothing);
+    });
+
+    group('with two layouts', () {
+      testWidgets('toggles instead of opening a menu', (tester) async {
+        final picked = <ParticipantLayoutMode>[];
+
+        await tester.pumpWidget(
+          TestWrapper(
+            platform: .macOS,
+            child: StreamLayoutButton(onLayoutModeChanged: picked.add),
+          ),
+        );
+
+        // The default pair, and the default layout is the first of them.
+        expect(find.byIcon(icons.gridDefaultFill), findsOneWidget);
+
+        await tester.tap(find.byIcon(icons.gridDefaultFill));
+        await tester.pumpAndSettle();
+
+        expect(picked, [ParticipantLayoutMode.speakerBottom]);
+        expect(find.byType(StreamContextMenuAction<void>), findsNothing);
+        expect(find.byType(StreamListTile), findsNothing);
+      });
+
+      testWidgets('toggles back from the second layout', (tester) async {
+        final picked = <ParticipantLayoutMode>[];
+
+        await tester.pumpWidget(
+          TestWrapper(
+            child: StreamLayoutButton(
+              layout: .speakerBottom,
+              onLayoutModeChanged: picked.add,
+            ),
+          ),
+        );
+
+        await tester.tap(find.byIcon(icons.speakerBottomFill));
+        await tester.pumpAndSettle();
+
+        expect(picked, [ParticipantLayoutMode.auto]);
+      });
+
+      testWidgets('moves to the first entry from a layout outside the pair', (
+        tester,
+      ) async {
+        final picked = <ParticipantLayoutMode>[];
+
+        await tester.pumpWidget(
+          TestWrapper(
+            child: StreamLayoutButton(
+              layout: .speakerLeft,
+              onLayoutModeChanged: picked.add,
+            ),
+          ),
+        );
+
+        // Still draws what is actually in effect, not something from the pair.
+        expect(find.byIcon(icons.speakerLeftFill), findsOneWidget);
+
+        await tester.tap(find.byIcon(icons.speakerLeftFill));
+        await tester.pumpAndSettle();
+
+        expect(picked, [ParticipantLayoutMode.auto]);
+      });
+
+      testWidgets('is disabled when its one layout is already in effect', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          TestWrapper(
+            child: StreamLayoutButton(
+              layout: .grid,
+              layouts: const [.grid],
+              onLayoutModeChanged: (_) {},
+            ),
+          ),
+        );
+
+        expect(
+          tester
+              .widget<CallControlButton>(find.byType(CallControlButton))
+              .onPressed,
+          isNull,
+        );
+      });
+    });
+
+    testWidgets('is disabled when it has no layouts to offer', (tester) async {
+      await tester.pumpWidget(
+        TestWrapper(
+          child: StreamLayoutButton(
+            layouts: const [],
+            onLayoutModeChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(
+        tester.widget<CallControlButton>(find.byType(CallControlButton))
+            .onPressed,
+        isNull,
+      );
+    });
+  });
+}

--- a/packages/stream_video_flutter/test/src/call_controls/controls/stream_layout_button_test.dart
+++ b/packages/stream_video_flutter/test/src/call_controls/controls/stream_layout_button_test.dart
@@ -46,7 +46,7 @@ void main() {
     ) async {
       for (final (mode, icon) in <(ParticipantLayoutMode, IconData)>[
         // ignore: deprecated_member_use
-        (ParticipantLayoutMode.spotlight, icons.speakerBottomFill),
+        (ParticipantLayoutMode.spotlight, icons.speakerTopFill),
         // ignore: deprecated_member_use
         (ParticipantLayoutMode.pictureInPicture, icons.pipFill),
       ]) {

--- a/packages/stream_video_flutter/test/src/call_controls/controls/stream_layout_button_test.dart
+++ b/packages/stream_video_flutter/test/src/call_controls/controls/stream_layout_button_test.dart
@@ -328,7 +328,8 @@ void main() {
       );
 
       expect(
-        tester.widget<CallControlButton>(find.byType(CallControlButton))
+        tester
+            .widget<CallControlButton>(find.byType(CallControlButton))
             .onPressed,
         isNull,
       );

--- a/packages/stream_video_flutter/test/src/call_participants/call_participants_sort_test.dart
+++ b/packages/stream_video_flutter/test/src/call_participants/call_participants_sort_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_video_flutter/stream_video_flutter.dart';
+
+import '../../test_utils/test_wrapper.dart';
+import '../mocks.dart';
+
+// Both participants report themselves visible, which is what separates the
+// two presets: `regular` only consults the dominant speaker for a participant
+// scrolled out of the viewport, `speaker` always does.
+MockCallParticipantState _participant(
+  String id, {
+  bool isDominantSpeaker = false,
+}) {
+  final participant = MockCallParticipantState();
+  when(() => participant.name).thenReturn(id);
+  when(() => participant.userId).thenReturn(id);
+  when(() => participant.sessionId).thenReturn(id);
+  when(() => participant.uniqueParticipantKey).thenReturn(id);
+  when(() => participant.isLocal).thenReturn(false);
+  when(() => participant.isDominantSpeaker).thenReturn(isDominantSpeaker);
+  when(() => participant.isPinned).thenReturn(false);
+  when(() => participant.isSpeaking).thenReturn(false);
+  when(() => participant.isScreenShareEnabled).thenReturn(false);
+  when(() => participant.screenShareTrack).thenReturn(null);
+  when(
+    () => participant.viewportVisibility,
+  ).thenReturn(ViewportVisibility.visible);
+  return participant;
+}
+
+Widget _box(BuildContext _, Call __, CallParticipantState participant) =>
+    SizedBox.expand(key: ValueKey('tile-${participant.sessionId}'));
+
+void main() {
+  testWidgets('picking a speaker layout re-sorts with the speaker preset', (
+    tester,
+  ) async {
+    final participants = [
+      _participant('first-to-join'),
+      _participant('speaker', isDominantSpeaker: true),
+    ];
+
+    Future<void> pumpWith(ParticipantLayoutMode layoutMode) =>
+        tester.pumpWidget(
+          TestWrapper(
+            child: SizedBox(
+              width: 800,
+              height: 600,
+              child: StreamCallParticipants(
+                call: MockCall(),
+                participants: participants,
+                layoutMode: layoutMode,
+                callParticipantBuilder: _box,
+                floatingSelfViewBuilder: _box,
+              ),
+            ),
+          ),
+        );
+
+    // The grid's own preset leaves a visible dominant speaker where they are.
+    await pumpWith(ParticipantLayoutMode.grid);
+
+    // Nothing about the participants changes — only the layout, and with it
+    // the preset the list is ordered by.
+    await pumpWith(ParticipantLayoutMode.speakerTop);
+    await tester.pumpAndSettle();
+
+    final view = tester.widget<CallParticipantsSpotlightView>(
+      find.byType(CallParticipantsSpotlightView),
+    );
+    expect(view.spotlight.sessionId, 'speaker');
+  });
+}

--- a/packages/stream_video_flutter/test/src/call_participants/call_participants_sort_test.dart
+++ b/packages/stream_video_flutter/test/src/call_participants/call_participants_sort_test.dart
@@ -34,6 +34,47 @@ Widget _box(BuildContext _, Call __, CallParticipantState participant) =>
     SizedBox.expand(key: ValueKey('tile-${participant.sessionId}'));
 
 void main() {
+  testWidgets('a sort the caller passes inline does not re-sort every build', (
+    tester,
+  ) async {
+    final participants = [
+      _participant('first-to-join'),
+      _participant('speaker', isDominantSpeaker: true),
+    ];
+    var comparisons = 0;
+
+    // A fresh closure on every build, the way a call site written inline
+    // hands one over. Comparing these would be function identity, so every
+    // rebuild would look like a new sort.
+    Future<void> pumpAgain() => tester.pumpWidget(
+      TestWrapper(
+        child: SizedBox(
+          width: 800,
+          height: 600,
+          child: StreamCallParticipants(
+            call: MockCall(),
+            participants: participants,
+            sort: (a, b) {
+              comparisons++;
+              return a.sessionId.compareTo(b.sessionId);
+            },
+            callParticipantBuilder: _box,
+            floatingSelfViewBuilder: _box,
+          ),
+        ),
+      ),
+    );
+
+    await pumpAgain();
+    expect(comparisons, greaterThan(0), reason: 'sorted once on the way in');
+
+    final afterFirstBuild = comparisons;
+    await pumpAgain();
+    await pumpAgain();
+
+    expect(comparisons, afterFirstBuild);
+  });
+
   testWidgets('picking a speaker layout re-sorts with the speaker preset', (
     tester,
   ) async {

--- a/packages/stream_video_flutter/test/src/call_participants/layout/participant_layout_mode_test.dart
+++ b/packages/stream_video_flutter/test/src/call_participants/layout/participant_layout_mode_test.dart
@@ -1,0 +1,128 @@
+// The deprecated aliases are part of what these pin.
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_video_flutter/stream_video_flutter.dart';
+
+void main() {
+  group('canonical', () {
+    test('maps the deprecated aliases onto their replacement', () {
+      expect(
+        ParticipantLayoutMode.spotlight.canonical,
+        ParticipantLayoutMode.speakerTop,
+      );
+      expect(
+        ParticipantLayoutMode.pictureInPicture.canonical,
+        ParticipantLayoutMode.speakerOneToOne,
+      );
+    });
+
+    test('leaves every selectable layout alone', () {
+      for (final mode in ParticipantLayoutModeX.selectable) {
+        expect(mode.canonical, mode, reason: '$mode');
+      }
+    });
+  });
+
+  group('selectable', () {
+    test('is every layout except the deprecated aliases', () {
+      expect(
+        ParticipantLayoutModeX.selectable,
+        ParticipantLayoutMode.values
+            .where((mode) => mode.canonical == mode)
+            .toList(),
+      );
+    });
+  });
+
+  group('barAlignment', () {
+    // The bar takes the edge opposite the speaker, so the name of the layout
+    // is where the *speaker* sits — which is what the menu's icons draw.
+    test('puts the bar opposite the speaker', () {
+      expect(
+        ParticipantLayoutMode.speakerTop.barAlignment,
+        ParticipantsBarAlignment.bottom,
+      );
+      expect(
+        ParticipantLayoutMode.speakerBottom.barAlignment,
+        ParticipantsBarAlignment.top,
+      );
+      expect(
+        ParticipantLayoutMode.speakerLeft.barAlignment,
+        ParticipantsBarAlignment.right,
+      );
+      expect(
+        ParticipantLayoutMode.speakerRight.barAlignment,
+        ParticipantsBarAlignment.left,
+      );
+    });
+
+    test('is null for the layouts with no bar', () {
+      for (final mode in [
+        ParticipantLayoutMode.auto,
+        ParticipantLayoutMode.grid,
+        ParticipantLayoutMode.speakerOneToOne,
+        ParticipantLayoutMode.pictureInPicture,
+      ]) {
+        expect(mode.barAlignment, isNull, reason: '$mode');
+      }
+    });
+
+    test('agrees with the layout each alias stands for', () {
+      for (final mode in [
+        ParticipantLayoutMode.spotlight,
+        ParticipantLayoutMode.pictureInPicture,
+      ]) {
+        expect(mode.barAlignment, mode.canonical.barAlignment, reason: '$mode');
+      }
+    });
+  });
+
+  group('isSpeakerLayout', () {
+    test('is true for the five speaker layouts and both aliases', () {
+      for (final mode in [
+        ParticipantLayoutMode.speakerTop,
+        ParticipantLayoutMode.speakerBottom,
+        ParticipantLayoutMode.speakerLeft,
+        ParticipantLayoutMode.speakerRight,
+        ParticipantLayoutMode.speakerOneToOne,
+        ParticipantLayoutMode.spotlight,
+        ParticipantLayoutMode.pictureInPicture,
+      ]) {
+        expect(mode.isSpeakerLayout, isTrue, reason: '$mode');
+      }
+    });
+
+    test('is false for auto and grid', () {
+      expect(ParticipantLayoutMode.auto.isSpeakerLayout, isFalse);
+      expect(ParticipantLayoutMode.grid.isSpeakerLayout, isFalse);
+    });
+  });
+
+  group('sorting', () {
+    test('sorts by speaker for every layout that spotlights one', () {
+      for (final mode in ParticipantLayoutMode.values.where(
+        (mode) => mode.isSpeakerLayout,
+      )) {
+        expect(
+          mode.sorting,
+          CallParticipantSortingPresets.speaker,
+          reason: '$mode',
+        );
+      }
+    });
+
+    test('sorts regularly for auto and grid', () {
+      for (final mode in [
+        ParticipantLayoutMode.auto,
+        ParticipantLayoutMode.grid,
+      ]) {
+        expect(
+          mode.sorting,
+          CallParticipantSortingPresets.regular,
+          reason: '$mode',
+        );
+      }
+    });
+  });
+}

--- a/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
+++ b/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -343,6 +344,96 @@ void main() {
 
       expect(find.byType(StreamLocalVideo), findsNothing);
       expect(gridSessionsOf(tester), ['remote-1', 'remote-2', 'local']);
+    });
+
+    // These pass enableFloatingSelfView: null to exercise the default itself.
+    // `isDesktopDevice` reads defaultTargetPlatform, which flutter_test
+    // reports as android, so the unoverridden cases take the mobile path.
+    testWidgets('floats the self-view on mobile with two others', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .auto,
+        enableFloatingSelfView: null,
+        participants: [
+          _participant('remote-1'),
+          _participant('remote-2'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(find.byType(StreamLocalVideo), findsOneWidget);
+      expect(gridSessionsOf(tester), ['remote-1', 'remote-2']);
+    });
+
+    testWidgets('gives the local participant a tile on mobile once a third '
+        'person joins', (tester) async {
+      await pump(
+        tester,
+        layoutMode: .auto,
+        enableFloatingSelfView: null,
+        participants: [
+          _participant('remote-1'),
+          _participant('remote-2'),
+          _participant('remote-3'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(find.byType(StreamLocalVideo), findsNothing);
+      expect(gridSessionsOf(tester), [
+        'remote-1',
+        'remote-2',
+        'remote-3',
+        'local',
+      ]);
+    });
+
+    testWidgets('still floats a self-view a crowded grid asked for', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .auto,
+        // Matching the helper's default, but stated because opting in over a
+        // crowded grid is what this pins.
+        // ignore: avoid_redundant_argument_values
+        enableFloatingSelfView: true,
+        participants: [
+          _participant('remote-1'),
+          _participant('remote-2'),
+          _participant('remote-3'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(find.byType(StreamLocalVideo), findsOneWidget);
+    });
+
+    testWidgets('gives the local participant a tile on desktop', (
+      tester,
+    ) async {
+      // Reset inside the body: the framework checks the foundation debug
+      // variables before tearDowns run.
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        await pump(
+          tester,
+          layoutMode: .auto,
+          enableFloatingSelfView: null,
+          participants: [
+            _participant('remote-1'),
+            _participant('remote-2'),
+            _participant('local', isLocal: true),
+          ],
+        );
+
+        expect(find.byType(StreamLocalVideo), findsNothing);
+        expect(gridSessionsOf(tester), ['remote-1', 'remote-2', 'local']);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
 
     testWidgets('draws a grid while nobody else has joined', (tester) async {

--- a/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
+++ b/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
@@ -227,6 +227,28 @@ void main() {
       expect(find.byType(StreamLocalVideo), findsOneWidget);
     });
 
+    testWidgets('spotlights a remote with the self-view off and the local '
+        'one sorting first', (tester) async {
+      // With no bar and no floating self-view, spotlighting the local
+      // participant would leave every remote off the screen entirely.
+      await pump(
+        tester,
+        layoutMode: .speakerOneToOne,
+        enableFloatingSelfView: false,
+        participants: [
+          _participant('local', isLocal: true),
+          _participant('remote-1'),
+          _participant('remote-2'),
+        ],
+      );
+
+      final view = tester.widget<CallParticipantsSpotlightView>(
+        find.byType(CallParticipantsSpotlightView),
+      );
+      expect(view.spotlight.sessionId, 'remote-1');
+      expect(find.byType(StreamLocalVideo), findsNothing);
+    });
+
     testWidgets('spotlights the local participant when alone in the call', (
       tester,
     ) async {

--- a/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
+++ b/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
@@ -29,9 +29,9 @@ Widget _box(BuildContext _, Call __, CallParticipantState participant) =>
     );
 
 void main() {
-  // `enableLocalVideo` is passed explicitly throughout: its default reads a
-  // platform detector with no test override, so leaving it off would make
-  // these depend on the host OS.
+  // The helper defaults `enableLocalVideo` to true: under `auto` the flag
+  // falls back to a platform detector with no test override, which would make
+  // those cases depend on the host OS.
   Future<void> pump(
     WidgetTester tester, {
     required ParticipantLayoutMode layoutMode,
@@ -70,10 +70,10 @@ void main() {
   group('the four bar layouts', () {
     for (final (mode, alignment)
         in <(ParticipantLayoutMode, ParticipantsBarAlignment)>[
-          (.speakerTop, .top),
-          (.speakerBottom, .bottom),
-          (.speakerLeft, .left),
-          (.speakerRight, .right),
+          (.speakerTop, .bottom),
+          (.speakerBottom, .top),
+          (.speakerLeft, .right),
+          (.speakerRight, .left),
         ]) {
       testWidgets('$mode spotlights with the bar $alignment', (tester) async {
         await pump(
@@ -98,6 +98,32 @@ void main() {
         expect(find.byType(StreamLocalVideo), findsNothing);
       });
     }
+
+    testWidgets('spotlights a remote when only one other person is in the '
+        'call', (tester) async {
+      await pump(
+        tester,
+        layoutMode: .speakerBottom,
+        participants: [
+          _participant('local', isLocal: true),
+          _participant('remote-1'),
+        ],
+      );
+
+      final view = tester.widget<CallParticipantsSpotlightView>(
+        find.byType(CallParticipantsSpotlightView),
+      );
+      expect(view.spotlight.sessionId, 'remote-1');
+      expect(view.participants.map((e) => e.sessionId), ['local']);
+    });
+
+    testWidgets('grid takes over when nobody is in the call', (tester) async {
+      await pump(tester, layoutMode: .speakerBottom, participants: const []);
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CallParticipantsSpotlightView), findsNothing);
+      expect(find.byType(CallParticipantsGridView), findsOneWidget);
+    });
 
     testWidgets('spotlight is still the bottom bar', (tester) async {
       await pump(
@@ -136,12 +162,20 @@ void main() {
       expect(find.byType(StreamLocalVideo), findsOneWidget);
     });
 
+    testWidgets('grid takes over when nobody is in the call', (tester) async {
+      await pump(tester, layoutMode: .speakerOneToOne, participants: const []);
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CallParticipantsSpotlightView), findsNothing);
+      expect(find.byType(CallParticipantsGridView), findsOneWidget);
+    });
+
     testWidgets('floats the self-view even where the default is off', (
       tester,
     ) async {
-      // `enableLocalVideo` defaults to off on desktop, which under this layout
-      // used to drop the local participant altogether: the bar is empty, so
-      // without the self-view they were nowhere on screen.
+      // This layout defaults the flag to true on every platform: the bar is
+      // empty, so without the self-view the local participant is nowhere on
+      // screen.
       await pump(
         tester,
         layoutMode: .speakerOneToOne,

--- a/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
+++ b/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+// Neither the content widget nor the grid is exported from the barrel — both
+// are internal to the default call content — so they are reached directly.
+// ignore: implementation_imports
+import 'package:stream_video_flutter/src/call_participants/layout/call_participants_grid_view.dart';
+// ignore: implementation_imports
+import 'package:stream_video_flutter/src/call_participants/regular_call_participants_content.dart';
+import 'package:stream_video_flutter/stream_video_flutter.dart';
+
+import '../../test_utils/test_wrapper.dart';
+import '../mocks.dart';
+
+MockCallParticipantState _participant(String id, {bool isLocal = false}) {
+  final participant = MockCallParticipantState();
+  when(() => participant.name).thenReturn(id);
+  when(() => participant.userId).thenReturn(id);
+  when(() => participant.sessionId).thenReturn(id);
+  when(() => participant.uniqueParticipantKey).thenReturn(id);
+  when(() => participant.isLocal).thenReturn(isLocal);
+  return participant;
+}
+
+Widget _box(BuildContext _, Call __, CallParticipantState participant) =>
+    SizedBox.expand(
+      key: ValueKey('tile-${participant.sessionId}'),
+      child: const ColoredBox(color: Color(0xFF6E7A8A)),
+    );
+
+void main() {
+  // `enableLocalVideo` is passed explicitly throughout: its default reads a
+  // platform detector with no test override, so leaving it off would make
+  // these depend on the host OS.
+  Future<void> pump(
+    WidgetTester tester, {
+    required ParticipantLayoutMode layoutMode,
+    required List<CallParticipantState> participants,
+    bool? enableLocalVideo = true,
+  }) => tester.pumpWidget(
+    TestWrapper(
+      child: SizedBox(
+        width: 800,
+        height: 600,
+        child: RegularCallParticipantsContent(
+          call: MockCall(),
+          participants: participants,
+          layoutMode: layoutMode,
+          enableLocalVideo: enableLocalVideo,
+          callParticipantBuilder: _box,
+          // The self-view otherwise falls back to the real participant tile,
+          // which asks the mock far more than a layout test cares to stub.
+          localVideoParticipantBuilder: _box,
+        ),
+      ),
+    ),
+  );
+
+  Iterable<String> gridSessionsOf(WidgetTester tester) => tester
+      .widget<CallParticipantsGridView>(find.byType(CallParticipantsGridView))
+      .participants
+      .map((participant) => participant.sessionId);
+
+  ParticipantsBarAlignment barAlignmentOf(WidgetTester tester) => tester
+      .widget<CallParticipantsSpotlightView>(
+        find.byType(CallParticipantsSpotlightView),
+      )
+      .barAlignment;
+
+  group('the four bar layouts', () {
+    for (final (mode, alignment)
+        in <(ParticipantLayoutMode, ParticipantsBarAlignment)>[
+          (.speakerTop, .top),
+          (.speakerBottom, .bottom),
+          (.speakerLeft, .left),
+          (.speakerRight, .right),
+        ]) {
+      testWidgets('$mode spotlights with the bar $alignment', (tester) async {
+        await pump(
+          tester,
+          layoutMode: mode,
+          participants: [
+            _participant('remote-1'),
+            _participant('remote-2'),
+            _participant('local', isLocal: true),
+          ],
+        );
+
+        expect(find.byType(CallParticipantsSpotlightView), findsOneWidget);
+        expect(barAlignmentOf(tester), alignment);
+
+        // Everybody but the spotlight is in the bar, the local participant
+        // included: these layouts give them a tile rather than floating them.
+        final view = tester.widget<CallParticipantsSpotlightView>(
+          find.byType(CallParticipantsSpotlightView),
+        );
+        expect(view.participants, hasLength(2));
+        expect(find.byType(StreamLocalVideo), findsNothing);
+      });
+    }
+
+    testWidgets('spotlight is still the bottom bar', (tester) async {
+      await pump(
+        tester,
+        // ignore: deprecated_member_use
+        layoutMode: ParticipantLayoutMode.spotlight,
+        participants: [
+          _participant('remote-1'),
+          _participant('remote-2'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(barAlignmentOf(tester), ParticipantsBarAlignment.bottom);
+    });
+  });
+
+  group('speakerOneToOne', () {
+    testWidgets('shows the speaker alone with the self-view floating', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .speakerOneToOne,
+        participants: [
+          _participant('remote-1'),
+          _participant('remote-2'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      final view = tester.widget<CallParticipantsSpotlightView>(
+        find.byType(CallParticipantsSpotlightView),
+      );
+      expect(view.participants, isEmpty);
+      expect(find.byType(StreamLocalVideo), findsOneWidget);
+    });
+
+    testWidgets('floats the self-view even where the default is off', (
+      tester,
+    ) async {
+      // `enableLocalVideo` defaults to off on desktop, which under this layout
+      // used to drop the local participant altogether: the bar is empty, so
+      // without the self-view they were nowhere on screen.
+      await pump(
+        tester,
+        layoutMode: .speakerOneToOne,
+        enableLocalVideo: null,
+        participants: [
+          _participant('remote-1'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(find.byType(StreamLocalVideo), findsOneWidget);
+    });
+
+    testWidgets('still obeys an explicit enableLocalVideo: false', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .speakerOneToOne,
+        enableLocalVideo: false,
+        participants: [
+          _participant('remote-1'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(find.byType(StreamLocalVideo), findsNothing);
+    });
+
+    testWidgets('spotlights a remote even when the local one sorts first', (
+      tester,
+    ) async {
+      // The speaker sorting can put the local participant first. Spotlighting
+      // them would show them twice: full frame and floating.
+      await pump(
+        tester,
+        layoutMode: .speakerOneToOne,
+        participants: [
+          _participant('local', isLocal: true),
+          _participant('remote-1'),
+          _participant('remote-2'),
+        ],
+      );
+
+      final view = tester.widget<CallParticipantsSpotlightView>(
+        find.byType(CallParticipantsSpotlightView),
+      );
+      expect(view.spotlight.sessionId, 'remote-1');
+      expect(find.byType(StreamLocalVideo), findsOneWidget);
+    });
+
+    testWidgets('spotlights the local participant when alone in the call', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .speakerOneToOne,
+        participants: [_participant('local', isLocal: true)],
+      );
+
+      final view = tester.widget<CallParticipantsSpotlightView>(
+        find.byType(CallParticipantsSpotlightView),
+      );
+      expect(view.spotlight.sessionId, 'local');
+      expect(find.byType(StreamLocalVideo), findsNothing);
+    });
+  });
+
+  group('grid', () {
+    testWidgets('gives the local participant a tile of its own', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .grid,
+        participants: [
+          _participant('remote-1'),
+          _participant('remote-2'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(find.byType(CallParticipantsSpotlightView), findsNothing);
+      // No self-view on top: it would show the local participant twice.
+      expect(find.byType(StreamLocalVideo), findsNothing);
+      expect(gridSessionsOf(tester), ['remote-1', 'remote-2', 'local']);
+    });
+  });
+
+  group('auto', () {
+    testWidgets('spotlights the other person in a one-on-one call', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .auto,
+        participants: [
+          _participant('remote-1'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      final view = tester.widget<CallParticipantsSpotlightView>(
+        find.byType(CallParticipantsSpotlightView),
+      );
+      expect(view.spotlight.sessionId, 'remote-1');
+      expect(view.participants, isEmpty);
+      expect(find.byType(StreamLocalVideo), findsOneWidget);
+    });
+
+    testWidgets('falls back to a grid with a floating self-view in a group', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .auto,
+        participants: [
+          _participant('remote-1'),
+          _participant('remote-2'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(find.byType(CallParticipantsSpotlightView), findsNothing);
+      expect(find.byType(StreamLocalVideo), findsOneWidget);
+      // The local participant floats instead of taking a cell in the grid.
+      expect(gridSessionsOf(tester), ['remote-1', 'remote-2']);
+    });
+
+    testWidgets('keeps everybody in the grid when the self-view is off', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        layoutMode: .auto,
+        enableLocalVideo: false,
+        participants: [
+          _participant('remote-1'),
+          _participant('remote-2'),
+          _participant('local', isLocal: true),
+        ],
+      );
+
+      expect(find.byType(StreamLocalVideo), findsNothing);
+      expect(gridSessionsOf(tester), ['remote-1', 'remote-2', 'local']);
+    });
+
+    testWidgets('draws a grid while nobody else has joined', (tester) async {
+      await pump(
+        tester,
+        layoutMode: .auto,
+        participants: [_participant('local', isLocal: true)],
+      );
+
+      expect(find.byType(CallParticipantsSpotlightView), findsNothing);
+      expect(find.byType(StreamLocalVideo), findsNothing);
+      expect(gridSessionsOf(tester), ['local']);
+    });
+  });
+}

--- a/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
+++ b/packages/stream_video_flutter/test/src/call_participants/regular_call_participants_content_test.dart
@@ -29,14 +29,14 @@ Widget _box(BuildContext _, Call __, CallParticipantState participant) =>
     );
 
 void main() {
-  // The helper defaults `enableLocalVideo` to true: under `auto` the flag
+  // The helper defaults `enableFloatingSelfView` to true: under `auto` the flag
   // falls back to a platform detector with no test override, which would make
   // those cases depend on the host OS.
   Future<void> pump(
     WidgetTester tester, {
     required ParticipantLayoutMode layoutMode,
     required List<CallParticipantState> participants,
-    bool? enableLocalVideo = true,
+    bool? enableFloatingSelfView = true,
   }) => tester.pumpWidget(
     TestWrapper(
       child: SizedBox(
@@ -46,11 +46,11 @@ void main() {
           call: MockCall(),
           participants: participants,
           layoutMode: layoutMode,
-          enableLocalVideo: enableLocalVideo,
+          enableFloatingSelfView: enableFloatingSelfView,
           callParticipantBuilder: _box,
           // The self-view otherwise falls back to the real participant tile,
           // which asks the mock far more than a layout test cares to stub.
-          localVideoParticipantBuilder: _box,
+          floatingSelfViewBuilder: _box,
         ),
       ),
     ),
@@ -179,7 +179,7 @@ void main() {
       await pump(
         tester,
         layoutMode: .speakerOneToOne,
-        enableLocalVideo: null,
+        enableFloatingSelfView: null,
         participants: [
           _participant('remote-1'),
           _participant('local', isLocal: true),
@@ -189,13 +189,13 @@ void main() {
       expect(find.byType(StreamLocalVideo), findsOneWidget);
     });
 
-    testWidgets('still obeys an explicit enableLocalVideo: false', (
+    testWidgets('still obeys an explicit enableFloatingSelfView: false', (
       tester,
     ) async {
       await pump(
         tester,
         layoutMode: .speakerOneToOne,
-        enableLocalVideo: false,
+        enableFloatingSelfView: false,
         participants: [
           _participant('remote-1'),
           _participant('local', isLocal: true),
@@ -311,7 +311,7 @@ void main() {
       await pump(
         tester,
         layoutMode: .auto,
-        enableLocalVideo: false,
+        enableFloatingSelfView: false,
         participants: [
           _participant('remote-1'),
           _participant('remote-2'),


### PR DESCRIPTION
`StreamLayoutButton` flipped between two layouts and drew one of two icons. It now draws the layout in effect and offers the rest through a `StreamAdaptiveMenuAnchor`: a context menu on a desktop platform, a bottom sheet on Android and iOS. Given two layouts it toggles instead of opening a menu, which is what its default pair does.

Design: [menu](https://www.figma.com/design/W7pOBtNINkAh14XdCJQKuB/Video-SDK-Design?node-id=782-71821), [sheet](https://www.figma.com/design/W7pOBtNINkAh14XdCJQKuB/Video-SDK-Design?node-id=777-29351).

## The seven layouts

| Mode | Label | Renders |
|---|---|---|
| `auto` | Default | Speaker full-frame in a one-on-one call, a grid otherwise. The self-view floats over the speaker, and over the grid on mobile while at most two other people are in the call. |
| `grid` | Grid | Even grid, local participant as an ordinary tile. |
| `speakerTop` / `speakerBottom` / `speakerLeft` / `speakerRight` | Speaker (…) | Spotlight on that edge, with the participants bar along the opposite one. |
| `speakerOneToOne` | Speaker 1:1 | Spotlight alone, local participant floating over it. |

**A layout is named after where the speaker sits, not the bar** — that is what the design's icons draw, so `speakerTop` sets `ParticipantsBarAlignment.bottom`. The four map onto the alignment `CallParticipantsSpotlightView` already had and `RegularCallParticipantsContent` never set. Screen share is untouched: `StreamCallParticipants.build` returns `ScreenShareCallParticipantsContent` before `layoutMode` is read, and that widget picks its own alignment from the window aspect ratio.

## Notes for review

- **`auto` is the new default** for `StreamCallContent`, `StreamCallParticipants` and `RegularCallParticipantsContent`. `grid` now gives the local participant a tile instead of floating them. The livestream widgets still default to `grid`, and are otherwise untouched — the new layouts there are for a later PR with designs of their own.
- **`spotlight` → `speakerTop`, `pictureInPicture` → `speakerOneToOne`**, both deprecated with `fix_data.yaml` transforms. `spotlight` took the spotlight view's default bottom bar, which is `speakerTop` under the naming above. `dart fix --apply` migrates call sites; verified end to end on a probe file.
- **`enableLocalVideo` is `enableFloatingSelfView` now**, and `localVideoParticipantBuilder` is `floatingSelfViewBuilder`. The flag decides whether the self-view *floats over* the layout or the local participant takes a tile like anybody else — the old name read as "show my video at all", which the grid and the four bar layouts ignore because those give them a tile either way. `dart fix --apply` renames both.
- **Only `auto` and `speakerOneToOne` read it**, the two layouts that leave the local participant out of the arrangement. Under `speakerOneToOne` it defaults to on; under `auto` in a group call, to on for mobile with at most two other people and off beyond that. That threshold matches the other SDKs: Android gates on `callParticipants.size in 2..3`, React Native on `remoteParticipants.length < 3`, Swift on `participants.count <= 3`.
- **`speakerOneToOne` floats the self-view on desktop too**, where the flag otherwise defaults to off. The inset *is* that layout — without it the local participant, who gets no tile and no bar either, disappears from the call. An explicit `false` still wins.
- **A speaker layout needs somebody to spotlight.** `participants.first` threw `StateError` on an empty list; five layouts reach that branch now and each is one tap away, so it falls through to the grid instead.
- **A layout with no bar always spotlights a remote.** With the self-view off, the speaker sort could put the local participant first and spotlight them, and since that layout draws no bar, every remote fell off the screen.
- **Changing the layout re-sorts.** `StreamCallParticipants` derives its sort from `layoutMode` but recalculated only when the participants or the call changed, so picking a speaker layout swapped the preset without reordering and spotlighted whoever the previous preset had first. On a quiet call nothing arrived to correct it. Pre-existing, but a seven-entry menu makes it reachable.
- **`StreamContextMenuAnchor.defaultActionStyle` is new** and is the interesting bit. The design fills the selected row, which the sheet did via `StreamListTile(selected:)` but the anchored menu could not — `StreamContextMenuAction` has no selected state, and the radio indicator that would otherwise mark it is suppressed by a per-row `leading` icon. Nesting a second `StreamContextMenuActionTheme` does *not* work: `.of` uses `dependOnInheritedWidgetOfExactType`, so it shadows rather than layers, and the selected row would drop to core's 40px/242px/20px defaults while its siblings keep the design's 32px/200px/16px. Hoisting the row style makes it re-mergeable. A test pins the metrics alongside the fill.
- **`menuDirection`, not `direction`**, matching the device split buttons, and defaulting to `down` alongside them so every call control with a menu defaults the same way.
- The sample offers every layout, minus `speakerLeft`/`speakerRight` below 768px, where a column of participants beside the speaker leaves the speaker too narrow.

## Testing

`flutter analyze` clean for `stream_video_flutter` and the sample. 399 tests pass locally; the 38 golden tests need CI to generate their baselines.

Four test files cover the menu, the toggle, `menuDirection`, what each layout renders, the self-view rules including the mobile threshold and the desktop default, the re-sort on a layout change, and the enum's own derivations — `canonical`, `selectable`, `barAlignment`, `isSpeakerLayout` and `sorting`. The two fixes above each have a test that fails without the change. The menu is asserted rather than snapshotted — the CI golden capture drops anything painted into an `Overlay`.

Checked by eye on macOS and iOS against the Figma: seven rows on the menu, five on the sheet at phone width, per-row icons, active row filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
