### PR TITLE
feat(samples): side panels for stats, participants and chat

### DIFF
--- a/dogfooding/lib/router/router.dart
+++ b/dogfooding/lib/router/router.dart
@@ -20,8 +20,6 @@ GoRouter initRouter(UserAuthController authNotifier) {
           $homeRoute,
           $lobbyRoute,
           $callRoute,
-          $callParticipantsRoute,
-          $callStatsRoute,
           $livestreamRoute,
         ],
         builder: (context, state, child) {

--- a/dogfooding/lib/router/routes.dart
+++ b/dogfooding/lib/router/routes.dart
@@ -3,9 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:stream_video_filters/video_effects_manager.dart';
 import 'package:stream_video_flutter/stream_video_flutter.dart';
 
-import '../screens/call_participants_list.dart';
 import '../screens/call_screen.dart';
-import '../screens/call_stats_screen.dart';
 import '../screens/home_screen.dart';
 import '../screens/join_call_screen.dart';
 import '../screens/livestream_demo_screen.dart';
@@ -122,34 +120,5 @@ class CallRoute extends GoRouteData with $CallRoute {
       videoEffectsManager: $extra.effectsManager,
       encryptionKey: $extra.encryptionKey,
     );
-  }
-}
-
-@immutable
-@TypedGoRoute<CallParticipantsRoute>(
-  path: '/call/participants',
-  name: 'participants',
-)
-class CallParticipantsRoute extends GoRouteData with $CallParticipantsRoute {
-  const CallParticipantsRoute({required this.$extra});
-
-  final Call $extra;
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) {
-    return CallParticipantsList(call: $extra);
-  }
-}
-
-@immutable
-@TypedGoRoute<CallStatsRoute>(path: '/call/stats', name: 'stats')
-class CallStatsRoute extends GoRouteData with $CallStatsRoute {
-  const CallStatsRoute({required this.$extra});
-
-  final Call $extra;
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) {
-    return CallStatsScreen(call: $extra);
   }
 }

--- a/dogfooding/lib/router/routes.g.dart
+++ b/dogfooding/lib/router/routes.g.dart
@@ -12,8 +12,6 @@ List<RouteBase> get $appRoutes => [
   $lobbyRoute,
   $livestreamRoute,
   $callRoute,
-  $callParticipantsRoute,
-  $callStatsRoute,
 ];
 
 RouteBase get $homeRoute => GoRouteData.$route(
@@ -185,68 +183,6 @@ mixin $CallRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/call');
-
-  @override
-  void go(BuildContext context) => context.go(location, extra: _self.$extra);
-
-  @override
-  Future<T?> push<T>(BuildContext context) =>
-      context.push<T>(location, extra: _self.$extra);
-
-  @override
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location, extra: _self.$extra);
-
-  @override
-  void replace(BuildContext context) =>
-      context.replace(location, extra: _self.$extra);
-}
-
-RouteBase get $callParticipantsRoute => GoRouteData.$route(
-  path: '/call/participants',
-  name: 'participants',
-  factory: $CallParticipantsRoute._fromState,
-);
-
-mixin $CallParticipantsRoute on GoRouteData {
-  static CallParticipantsRoute _fromState(GoRouterState state) =>
-      CallParticipantsRoute($extra: state.extra as Call);
-
-  CallParticipantsRoute get _self => this as CallParticipantsRoute;
-
-  @override
-  String get location => GoRouteData.$location('/call/participants');
-
-  @override
-  void go(BuildContext context) => context.go(location, extra: _self.$extra);
-
-  @override
-  Future<T?> push<T>(BuildContext context) =>
-      context.push<T>(location, extra: _self.$extra);
-
-  @override
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location, extra: _self.$extra);
-
-  @override
-  void replace(BuildContext context) =>
-      context.replace(location, extra: _self.$extra);
-}
-
-RouteBase get $callStatsRoute => GoRouteData.$route(
-  path: '/call/stats',
-  name: 'stats',
-  factory: $CallStatsRoute._fromState,
-);
-
-mixin $CallStatsRoute on GoRouteData {
-  static CallStatsRoute _fromState(GoRouterState state) =>
-      CallStatsRoute($extra: state.extra as Call);
-
-  CallStatsRoute get _self => this as CallStatsRoute;
-
-  @override
-  String get location => GoRouteData.$location('/call/stats');
 
   @override
   void go(BuildContext context) => context.go(location, extra: _self.$extra);

--- a/dogfooding/lib/screens/call_participants_list.dart
+++ b/dogfooding/lib/screens/call_participants_list.dart
@@ -66,9 +66,9 @@ class CallParticipantsPanelBody extends StatelessWidget {
             ),
             Padding(
               padding: const EdgeInsets.all(16),
+              // Full-width buttons, one per row: the panel is too narrow to
+              // fit both labels across it.
               child: Column(
-                // Stacked rather than side by side: two labelled buttons do
-                // not fit across a side panel, and 'Add member' wraps.
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   // Builder provides the button's own context so the share
@@ -165,9 +165,11 @@ class CallParticipantsPanelBody extends StatelessWidget {
               TextField(
                 controller: controller,
                 autofocus: true,
-                decoration: const InputDecoration(
+                decoration: InputDecoration(
                   hintText: 'User ID',
-                  hintStyle: TextStyle(color: Colors.white30),
+                  hintStyle: TextStyle(
+                    color: context.streamColorScheme.textTertiary,
+                  ),
                 ),
                 onSubmitted: (value) => Navigator.of(context).pop(value.trim()),
               ),
@@ -323,7 +325,9 @@ class _MemberTile extends StatelessWidget {
             ),
           ),
           TextButton.icon(
-            style: TextButton.styleFrom(foregroundColor: Colors.white),
+            style: TextButton.styleFrom(
+              foregroundColor: context.streamColorScheme.textPrimary,
+            ),
             icon: const Icon(Icons.notifications_active_outlined),
             label: const Text('Ring'),
             onPressed: onRing,

--- a/dogfooding/lib/screens/call_participants_list.dart
+++ b/dogfooding/lib/screens/call_participants_list.dart
@@ -5,16 +5,18 @@ import 'package:stream_video_flutter/stream_video_flutter.dart';
 import '../core/repos/app_preferences.dart';
 import '../di/injector.dart';
 
-class CallParticipantsList extends StatelessWidget {
-  const CallParticipantsList({super.key, required this.call});
+/// The call's participants and invited members, as the body of a side panel.
+class CallParticipantsPanelBody extends StatelessWidget {
+  /// Creates a participants body for [call].
+  const CallParticipantsPanelBody({super.key, required this.call});
 
+  /// The call whose participants and members are listed.
   final Call call;
 
   @override
   Widget build(BuildContext context) {
     final streamVideoTheme = StreamVideoTheme.of(context);
     final textTheme = streamVideoTheme.textTheme;
-    final colorScheme = StreamTheme.of(context).colorScheme;
 
     return StreamBuilder<CallState>(
       initialData: call.state.value,
@@ -28,91 +30,68 @@ class CallParticipantsList extends StatelessWidget {
             .where((member) => !participantIds.contains(member.userId))
             .toList();
 
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(
-              'Participants (${participants.length})',
-              style: textTheme.title3.apply(color: colorScheme.textPrimary),
-            ),
-            centerTitle: true,
-            foregroundColor: colorScheme.textPrimary,
-            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-            actions: [
-              IconButton(
-                icon: Icon(Icons.close, color: colorScheme.textPrimary),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-              ),
-            ],
-          ),
-          body: Column(
-            children: [
-              Expanded(
-                child: ListView(
-                  padding: const EdgeInsets.only(bottom: 16),
-                  children: [
-                    for (final participant in participants)
-                      _ParticipantTile(
-                        participant: participant,
+        return Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.only(bottom: 16),
+                children: [
+                  for (final participant in participants)
+                    _ParticipantTile(
+                      participant: participant,
+                      theme: streamVideoTheme,
+                    ),
+                  if (membersNotInCall.isNotEmpty) ...[
+                    const Divider(height: 32),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 8,
+                      ),
+                      child: Text(
+                        'Members not in call (${membersNotInCall.length})',
+                        style: textTheme.title3,
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    for (final member in membersNotInCall)
+                      _MemberTile(
+                        member: member,
                         theme: streamVideoTheme,
+                        onRing: () => _ringMember(context, member),
                       ),
-                    if (membersNotInCall.isNotEmpty) ...[
-                      const Divider(height: 32),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 8,
-                        ),
-                        child: Text(
-                          'Members not in call (${membersNotInCall.length})',
-                          style: textTheme.title3,
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-                      for (final member in membersNotInCall)
-                        _MemberTile(
-                          member: member,
-                          theme: streamVideoTheme,
-                          onRing: () => _ringMember(context, member),
-                        ),
-                    ],
                   ],
-                ),
+                ],
               ),
-              SafeArea(
-                top: false,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        // Builder provides the button's own context so the
-                        // share sheet can be anchored to the button.
-                        child: Builder(
-                          builder: (buttonContext) => StreamButton(
-                            style: StreamButtonStyle.secondary,
-                            type: StreamButtonType.outline,
-                            iconLeft: const Icon(Icons.link),
-                            onPressed: () => _shareLink(buttonContext),
-                            child: const Text('Share link'),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: StreamButton(
-                          iconLeft: const Icon(Icons.person_add_alt_1),
-                          onPressed: () => _showAddMemberDialog(context),
-                          child: const Text('Add member'),
-                        ),
-                      ),
-                    ],
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                // Stacked rather than side by side: two labelled buttons do
+                // not fit across a side panel, and 'Add member' wraps.
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Builder provides the button's own context so the share
+                  // sheet can be anchored to the button.
+                  Builder(
+                    builder: (buttonContext) => StreamButton(
+                      style: StreamButtonStyle.secondary,
+                      type: StreamButtonType.outline,
+                      iconLeft: const Icon(Icons.link),
+                      onPressed: () => _shareLink(buttonContext),
+                      child: const Text('Share link'),
+                    ),
                   ),
-                ),
+                  const SizedBox(height: 12),
+                  StreamButton(
+                    iconLeft: const Icon(Icons.person_add_alt_1),
+                    onPressed: () => _showAddMemberDialog(context),
+                    child: const Text('Add member'),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -17,7 +17,6 @@ import '../app/user_auth_controller.dart';
 import '../core/repos/app_preferences.dart';
 import '../core/repos/user_chat_repository.dart';
 import '../di/injector.dart';
-import '../router/routes.dart';
 import '../utils/feedback_dialog.dart';
 import '../widgets/badged_call_option.dart';
 import '../widgets/call_duration_title.dart';
@@ -25,6 +24,11 @@ import '../widgets/closed_captions_widget.dart';
 import '../widgets/e2ee_key_notification.dart';
 import '../widgets/settings_menu/settings_menu.dart';
 import '../widgets/share_call_card.dart';
+import '../widgets/side_panel/call_side_panel.dart';
+import '../widgets/side_panel/call_side_panel_layout.dart';
+import '../widgets/side_panel/chat_panel_body.dart';
+import 'call_participants_list.dart';
+import 'call_stats_screen.dart';
 
 const _useCustomDesktopScreenShareOption = false;
 
@@ -48,7 +52,8 @@ class CallScreen extends StatefulWidget {
   State<CallScreen> createState() => _CallScreenState();
 }
 
-class _CallScreenState extends State<CallScreen> {
+class _CallScreenState extends State<CallScreen>
+    with SingleTickerProviderStateMixin {
   late final _logger = taggedLogger(tag: 'SV:Dogfooding:CallScreen');
 
   late final _userChatRepo = locator.get<UserChatRepository>();
@@ -76,6 +81,29 @@ class _CallScreenState extends State<CallScreen> {
   StreamSubscription<Event>? _chatConnectionRecoverySubscription;
   ParticipantLayoutMode _currentLayoutMode = ParticipantLayoutMode.auto;
   bool _moreMenuVisible = false;
+
+  /// The panel the user asked for, or null once it starts closing.
+  CallSidePanel? _openPanel;
+
+  /// The panel whose content is in the tree. Outlives [_openPanel], so the
+  /// exit animation still has something to animate.
+  CallSidePanel? _mountedPanel;
+
+  late final _panelController = AnimationController(
+    duration: const Duration(milliseconds: 250),
+    vsync: this,
+  )..addStatusListener(_onPanelStatusChanged);
+
+  late final _panelAnimation = CurvedAnimation(
+    parent: _panelController,
+    curve: Curves.easeOutCubic,
+    reverseCurve: Curves.easeInCubic,
+  );
+
+  /// Carries the panel's own state across the breakpoint: the docked and the
+  /// full-screen layout hang it in different places, and without a global key
+  /// crossing 768px would remount it and lose the chat's scroll offset.
+  final _panelKey = GlobalKey();
 
   @override
   void initState() {
@@ -121,6 +149,8 @@ class _CallScreenState extends State<CallScreen> {
     _speakingWhileMuted.dispose();
     _chatConnectionRecoverySubscription?.cancel();
     _devices.dispose();
+    _panelAnimation.dispose();
+    _panelController.dispose();
     widget.call.leave();
     _userChatRepo.disconnectUser();
     _videoEffectsManager.dispose();
@@ -204,18 +234,73 @@ class _CallScreenState extends State<CallScreen> {
     setState(() {});
   }
 
-  void showParticipants(BuildContext context) {
-    CallParticipantsRoute($extra: widget.call).push<void>(context);
+  void _onPanelStatusChanged(AnimationStatus status) {
+    // Held until the exit finishes: unmounting the panel any earlier would
+    // take the app bar's height back while the panel is still on screen.
+    if (status == AnimationStatus.dismissed) {
+      setState(() => _mountedPanel = null);
+    }
   }
 
-  void showStats(BuildContext context) {
-    CallStatsRoute($extra: widget.call).push<void>(context);
+  /// Opens [panel], or closes it if it is already the open one.
+  void togglePanel(CallSidePanel panel) {
+    if (_openPanel == panel) return closePanel();
+
+    setState(() {
+      _openPanel = _mountedPanel = panel;
+      // The two never share the screen: both hang off the same control bar.
+      _moreMenuVisible = false;
+    });
+    _panelController.forward();
+  }
+
+  /// Closes whichever panel is open, animating it out.
+  void closePanel() {
+    if (_openPanel == null) return;
+
+    setState(() => _openPanel = null);
+    _panelController.reverse();
   }
 
   void toggleMoreMenu(BuildContext context) {
+    final visible = !_moreMenuVisible;
+    if (visible) closePanel();
+
     setState(() {
-      _moreMenuVisible = !_moreMenuVisible;
+      _moreMenuVisible = visible;
     });
+  }
+
+  /// The open panel's chrome and content, or null when nothing is open.
+  Widget? _panelContent(Call call, {required bool fullScreen}) {
+    final panel = _mountedPanel;
+    if (panel == null) return null;
+
+    return CallSidePanelSurface(
+      key: _panelKey,
+      showLeadingDivider: !fullScreen,
+      onClose: closePanel,
+      title: switch (panel) {
+        CallSidePanel.participants => PartialCallStateBuilder(
+          call: call,
+          selector: (state) => state.callParticipants.length,
+          builder: (context, count) => Text('Participants ($count)'),
+        ),
+        CallSidePanel.chat => const Text('Chat'),
+        CallSidePanel.stats => const Text('Stats'),
+      },
+      child: switch (panel) {
+        CallSidePanel.participants => CallParticipantsPanelBody(call: call),
+        CallSidePanel.chat => switch (_channel) {
+          final channel? => ChatPanelBody(channel: channel),
+          // The chat connects asynchronously and its control stays disabled
+          // until it does, but losing the channel must not take the panel
+          // down with it.
+          null => const Center(child: CircularProgressIndicator()),
+        },
+        CallSidePanel.stats => CallStatsPanelBody(call: call),
+      },
+    );
   }
 
   // The controls the two bar layouts have in common. Built per call rather
@@ -307,13 +392,21 @@ class _CallScreenState extends State<CallScreen> {
     onError: _reportDeviceFailure,
   );
 
-  // onTap, so the button opens this app's own participants screen rather than
-  // the SDK's list.
-  StreamParticipantsButton _participantsControl(Call call) =>
-      StreamParticipantsButton(
-        call: call,
-        onTap: _channel != null ? () => showParticipants(context) : null,
-      );
+  // Not StreamParticipantsButton: this app opens its own panel rather than
+  // the SDK's list, and only CallFeatureButton can show that the panel is up.
+  Widget _participantsControl(Call call) => PartialCallStateBuilder(
+    call: call,
+    selector: (state) => state.callParticipants.length,
+    builder: (context, count) => BadgedCallOption(
+      badgeCount: count == 0 ? null : count,
+      callControlOption: CallFeatureButton(
+        icon: Icon(context.streamIcons.usersFill),
+        tooltip: 'Participants',
+        selected: _openPanel == CallSidePanel.participants,
+        onPressed: () => togglePanel(CallSidePanel.participants),
+      ),
+    ),
+  );
 
   /// The call's control bar, laid out per screen size.
   CallControlBar _callControls(BuildContext context, Call call) {
@@ -325,7 +418,11 @@ class _CallScreenState extends State<CallScreen> {
 
     final panels = [
       _participantsControl(call),
-      _ShowChatButton(channel: _channel),
+      _ShowChatButton(
+        channel: _channel,
+        selected: _openPanel == CallSidePanel.chat,
+        onPressed: () => togglePanel(CallSidePanel.chat),
+      ),
     ];
 
     return CallControlBar(
@@ -375,7 +472,8 @@ class _CallScreenState extends State<CallScreen> {
         trailing: [
           CallFeatureButton(
             icon: Icon(context.streamIcons.statsFill),
-            onPressed: () => showStats(context),
+            selected: _openPanel == CallSidePanel.stats,
+            onPressed: () => togglePanel(CallSidePanel.stats),
           ),
           ...panels,
         ],
@@ -388,6 +486,11 @@ class _CallScreenState extends State<CallScreen> {
     // ignore: deprecated_member_use
     return WillPopScope(
       onWillPop: () async {
+        if (_openPanel != null) {
+          closePanel();
+          return false;
+        }
+
         return !Navigator.of(context).userGestureInProgress;
       },
       child: Scaffold(
@@ -418,81 +521,106 @@ class _CallScreenState extends State<CallScreen> {
                     enablePictureInPicture: true,
                   ),
               callParticipantsWidgetBuilder: (context, call) {
-                return Stack(
-                  children: [
-                    Column(
-                      children: [
-                        Expanded(
-                          child: StreamCallParticipants(
-                            call: call,
-                            layoutMode: _currentLayoutMode,
-                          ),
-                        ),
-                        ClosedCaptionsWidget(call: call),
-                      ],
-                    ),
-                    Align(
-                      alignment: Alignment.bottomCenter,
-                      child: E2eeKeyNotification(
-                        call: call,
-                        onKeyApplied: (key) =>
-                            setState(() => _encryptionKey = key),
-                      ),
-                    ),
-                    if (_moreMenuVisible) ...[
-                      GestureDetector(
-                        onTap: () => setState(() => _moreMenuVisible = false),
-                        child: Container(color: Colors.black12),
-                      ),
-                      Positioned(
-                        bottom: 0,
-                        left: 0,
-                        right: 0,
-                        child: Align(
-                          alignment: Alignment.bottomLeft,
-                          child: ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 500),
-                            child: SettingsMenu(
+                // A narrow window has no room beside the grid, so the panel
+                // covers it instead of docking next to it.
+                final fullScreen = context.streamScreenSize.isSmall;
+
+                return CallSidePanelLayout(
+                  animation: _panelAnimation,
+                  panel: _panelContent(call, fullScreen: fullScreen),
+                  fullScreen: fullScreen,
+                  // What the collapsed app bar gave up, handed back to the
+                  // grid so it neither moves nor re-tiles while a panel is up.
+                  coveredTopExtent: _mountedPanel != null ? kToolbarHeight : 0,
+                  child: Stack(
+                    children: [
+                      Column(
+                        children: [
+                          Expanded(
+                            child: StreamCallParticipants(
                               call: call,
-                              videoEffectsManager: _videoEffectsManager,
-                              onReactionSend: (_) =>
-                                  setState(() => _moreMenuVisible = false),
-                              onStatsPressed: () => setState(() {
-                                showStats(context);
-                                _moreMenuVisible = false;
-                              }),
-                              onAudioOutputChange: (_, {closeMenu = true}) {
-                                if (closeMenu) {
-                                  setState(() => _moreMenuVisible = false);
-                                }
-                              },
-                              onAudioInputChange: (_) =>
-                                  setState(() => _moreMenuVisible = false),
+                              layoutMode: _currentLayoutMode,
+                            ),
+                          ),
+                          ClosedCaptionsWidget(call: call),
+                        ],
+                      ),
+                      Align(
+                        alignment: Alignment.bottomCenter,
+                        child: E2eeKeyNotification(
+                          call: call,
+                          onKeyApplied: (key) =>
+                              setState(() => _encryptionKey = key),
+                        ),
+                      ),
+                      if (_moreMenuVisible) ...[
+                        GestureDetector(
+                          onTap: () => setState(() => _moreMenuVisible = false),
+                          child: Container(color: Colors.black12),
+                        ),
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          child: Align(
+                            alignment: Alignment.bottomLeft,
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(maxWidth: 500),
+                              child: SettingsMenu(
+                                call: call,
+                                videoEffectsManager: _videoEffectsManager,
+                                onReactionSend: (_) =>
+                                    setState(() => _moreMenuVisible = false),
+                                onStatsPressed: () =>
+                                    togglePanel(CallSidePanel.stats),
+                                onAudioOutputChange: (_, {closeMenu = true}) {
+                                  if (closeMenu) {
+                                    setState(() => _moreMenuVisible = false);
+                                  }
+                                },
+                                onAudioInputChange: (_) =>
+                                    setState(() => _moreMenuVisible = false),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
-                    if (!_moreMenuVisible)
-                      Positioned(
-                        bottom: 0,
-                        left: 0,
-                        right: 0,
-                        child: PartialCallStateBuilder(
-                          call: call,
-                          selector: (state) => state.otherParticipants.isEmpty,
-                          builder: (context, isEmpty) => isEmpty
-                              ? ShareCallWelcomeCard(
-                                  call: call,
-                                  encryptionKey: _encryptionKey,
-                                )
-                              : const SizedBox.shrink(),
+                      ],
+                      if (!_moreMenuVisible)
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          child: PartialCallStateBuilder(
+                            call: call,
+                            selector: (state) =>
+                                state.otherParticipants.isEmpty,
+                            builder: (context, isEmpty) => isEmpty
+                                ? ShareCallWelcomeCard(
+                                    call: call,
+                                    encryptionKey: _encryptionKey,
+                                  )
+                                : const SizedBox.shrink(),
+                          ),
                         ),
-                      ),
-                  ],
+                    ],
+                  ),
                 );
               },
               callAppBarWidgetBuilder: (context, call) {
+                // A narrow window gives the whole body to the panel, the app
+                // bar's row included. A zero-height bar rather than null,
+                // because null falls back to the SDK's own.
+                if (context.streamScreenSize.isSmall && _mountedPanel != null) {
+                  return PreferredSize(
+                    preferredSize: Size.zero,
+                    // Scaffold sizes this slot from the child rather than the
+                    // preferred size, and strips the top inset from the body's
+                    // MediaQuery either way — so the status bar's strip has to
+                    // be held open here or the panel runs under the notch.
+                    child: SizedBox(height: MediaQuery.paddingOf(context).top),
+                  );
+                }
+
                 // A wide window carries the layout toggle and leaving in the
                 // control bar, which is where the design puts them, so the app
                 // bar only holds them below that breakpoint. Otherwise both
@@ -533,8 +661,19 @@ class _CallScreenState extends State<CallScreen> {
 }
 
 class _ShowChatButton extends StatefulWidget {
-  const _ShowChatButton({required this.channel});
+  const _ShowChatButton({
+    required this.channel,
+    required this.selected,
+    required this.onPressed,
+  });
+
   final Channel? channel;
+
+  /// Whether the chat panel is the one currently open.
+  final bool selected;
+
+  /// Called to open or close the chat panel.
+  final VoidCallback onPressed;
 
   @override
   State<_ShowChatButton> createState() => __ShowChatButtonState();
@@ -574,52 +713,12 @@ class __ShowChatButtonState extends State<_ShowChatButton> {
   @override
   Widget build(BuildContext context) {
     return BadgedCallOption(
-      callControlOption: CallControlButton(
+      callControlOption: CallFeatureButton(
         icon: Icon(context.streamIcons.messageBubblesFill),
-        onPressed: widget.channel != null ? () => showChat(context) : null,
+        selected: widget.selected,
+        onPressed: widget.channel != null ? widget.onPressed : null,
       ),
       badgeCount: _unreadCount == 0 ? null : _unreadCount,
-    );
-  }
-
-  void showChat(BuildContext context) {
-    showModalBottomSheet<dynamic>(
-      context: context,
-      showDragHandle: true,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (_) {
-        final size = MediaQuery.sizeOf(context);
-        final viewInsets = MediaQuery.viewInsetsOf(context);
-
-        return AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
-          height: size.height * 0.6 + viewInsets.bottom,
-          padding: EdgeInsets.only(bottom: viewInsets.bottom),
-          child: ChatBottomSheet(channel: widget.channel!),
-        );
-      },
-    );
-  }
-}
-
-class ChatBottomSheet extends StatelessWidget {
-  const ChatBottomSheet({super.key, required this.channel});
-
-  final Channel channel;
-
-  @override
-  Widget build(BuildContext context) {
-    return StreamChannel(
-      channel: channel,
-      child: Column(
-        children: <Widget>[
-          const Expanded(child: StreamMessageListView()),
-          StreamMessageComposer(),
-        ],
-      ),
     );
   }
 }

--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -83,11 +83,20 @@ class _CallScreenState extends State<CallScreen>
   bool _moreMenuVisible = false;
 
   /// The panel the user asked for, or null once it starts closing.
+  ///
+  /// Drives the control bar's selected states, which let go as soon as the
+  /// panel starts leaving. Anything asking whether a panel is *on screen*
+  /// wants [_mountedPanel] instead.
   CallSidePanel? _openPanel;
 
-  /// The panel whose content is in the tree. Outlives [_openPanel], so the
-  /// exit animation still has something to animate.
+  /// The panel whose content is in the tree, or null when nothing is up.
+  ///
+  /// Outlives [_openPanel] by the length of the exit animation, so it is the
+  /// one to read for "is a panel on screen": what the back button dismisses,
+  /// and what the app bar makes room for.
   CallSidePanel? _mountedPanel;
+
+  StreamSubscription<CallStatus>? _callStatusSubscription;
 
   late final _panelController = AnimationController(
     duration: const Duration(milliseconds: 250),
@@ -102,7 +111,8 @@ class _CallScreenState extends State<CallScreen>
 
   /// Carries the panel's own state across the breakpoint: the docked and the
   /// full-screen layout hang it in different places, and without a global key
-  /// crossing 768px would remount it and lose the chat's scroll offset.
+  /// crossing the [StreamScreenSize.small] boundary would remount it and lose
+  /// the chat's scroll offset.
   final _panelKey = GlobalKey();
 
   @override
@@ -112,6 +122,32 @@ class _CallScreenState extends State<CallScreen>
     _speakingWhileMutedSubscription = _speakingWhileMuted.stream.listen(
       _onSpeakingWhileMutedChanged,
     );
+    _callStatusSubscription = widget.call
+        .partialState((state) => state.status)
+        .listen(_onCallStatusChanged);
+  }
+
+  /// Closes the panel when the call stops being connected.
+  ///
+  /// The SDK only builds the slot the panel lives in while the call is
+  /// connected, so a reconnect takes the panel off screen on its own. Without
+  /// this the state would still claim one is up, and on a phone the app bar
+  /// would stay collapsed around nothing — taking the only leave button with
+  /// it.
+  void _onCallStatusChanged(CallStatus status) {
+    if (!mounted || _mountedPanel == null) return;
+    if (status.isConnected || status.isFastReconnecting || status.isMigrating) {
+      return;
+    }
+
+    _logger.d(() => 'Closing the $_mountedPanel panel: call is $status');
+    setState(() {
+      _openPanel = null;
+      _mountedPanel = null;
+    });
+    // Straight to closed rather than reversed: the panel is already gone, so
+    // there is nothing left on screen to animate out.
+    _panelController.reset();
   }
 
   void _onSpeakingWhileMutedChanged(SpeakingWhileMutedState state) {
@@ -147,6 +183,7 @@ class _CallScreenState extends State<CallScreen>
     _speakingWhileMutedDebounce?.cancel();
     _speakingWhileMutedSubscription.cancel();
     _speakingWhileMuted.dispose();
+    _callStatusSubscription?.cancel();
     _chatConnectionRecoverySubscription?.cancel();
     _devices.dispose();
     _panelAnimation.dispose();
@@ -235,43 +272,46 @@ class _CallScreenState extends State<CallScreen>
   }
 
   void _onPanelStatusChanged(AnimationStatus status) {
-    // Held until the exit finishes: unmounting the panel any earlier would
-    // take the app bar's height back while the panel is still on screen.
+    // _mountedPanel is held until the exit finishes: unmounting the panel any
+    // earlier would take the app bar's height back while it is still on
+    // screen.
     if (status == AnimationStatus.dismissed) {
       setState(() => _mountedPanel = null);
     }
   }
 
   /// Opens [panel], or closes it if it is already the open one.
-  void togglePanel(CallSidePanel panel) {
-    if (_openPanel == panel) return closePanel();
+  void _togglePanel(CallSidePanel panel) {
+    if (_openPanel == panel) return _closePanel();
 
     setState(() {
       _openPanel = _mountedPanel = panel;
-      // The two never share the screen: both hang off the same control bar.
+      // A panel and the more menu never share the screen: both hang off the
+      // same control bar.
       _moreMenuVisible = false;
     });
     _panelController.forward();
   }
 
-  /// Closes whichever panel is open, animating it out.
-  void closePanel() {
-    if (_openPanel == null) return;
+  /// Closes whichever panel is up, animating it out.
+  void _closePanel() {
+    if (_mountedPanel == null) return;
 
     setState(() => _openPanel = null);
     _panelController.reverse();
   }
 
-  void toggleMoreMenu(BuildContext context) {
-    final visible = !_moreMenuVisible;
-    if (visible) closePanel();
+  void _toggleMoreMenu() {
+    if (_moreMenuVisible) return _closeMoreMenu();
 
-    setState(() {
-      _moreMenuVisible = visible;
-    });
+    // The mirror of the exclusion in [_togglePanel].
+    _closePanel();
+    setState(() => _moreMenuVisible = true);
   }
 
-  /// The open panel's chrome and content, or null when nothing is open.
+  void _closeMoreMenu() => setState(() => _moreMenuVisible = false);
+
+  /// The panel's chrome and content, or null when nothing is open or closing.
   Widget? _panelContent(Call call, {required bool fullScreen}) {
     final panel = _mountedPanel;
     if (panel == null) return null;
@@ -279,7 +319,7 @@ class _CallScreenState extends State<CallScreen>
     return CallSidePanelSurface(
       key: _panelKey,
       showLeadingDivider: !fullScreen,
-      onClose: closePanel,
+      onClose: _closePanel,
       title: switch (panel) {
         CallSidePanel.participants => PartialCallStateBuilder(
           call: call,
@@ -293,9 +333,9 @@ class _CallScreenState extends State<CallScreen>
         CallSidePanel.participants => CallParticipantsPanelBody(call: call),
         CallSidePanel.chat => switch (_channel) {
           final channel? => ChatPanelBody(channel: channel),
-          // The chat connects asynchronously and its control stays disabled
-          // until it does, but losing the channel must not take the panel
-          // down with it.
+          // Shown while the channel is still connecting. The control that
+          // opens this panel is disabled until it arrives, so this is only
+          // reached if the connection never lands.
           null => const Center(child: CircularProgressIndicator()),
         },
         CallSidePanel.stats => CallStatsPanelBody(call: call),
@@ -392,8 +432,8 @@ class _CallScreenState extends State<CallScreen>
     onError: _reportDeviceFailure,
   );
 
-  // Not StreamParticipantsButton: this app opens its own panel rather than
-  // the SDK's list, and only CallFeatureButton can show that the panel is up.
+  // CallFeatureButton rather than StreamParticipantsButton, which has no
+  // selected state to show that the panel is up.
   Widget _participantsControl(Call call) => PartialCallStateBuilder(
     call: call,
     selector: (state) => state.callParticipants.length,
@@ -403,7 +443,7 @@ class _CallScreenState extends State<CallScreen>
         icon: Icon(context.streamIcons.usersFill),
         tooltip: 'Participants',
         selected: _openPanel == CallSidePanel.participants,
-        onPressed: () => togglePanel(CallSidePanel.participants),
+        onPressed: () => _togglePanel(CallSidePanel.participants),
       ),
     ),
   );
@@ -413,7 +453,7 @@ class _CallScreenState extends State<CallScreen>
     final moreButton = CallFeatureButton(
       icon: Icon(context.streamIcons.moreVerticalFill),
       selected: _moreMenuVisible,
-      onPressed: () => toggleMoreMenu(context),
+      onPressed: _toggleMoreMenu,
     );
 
     final panels = [
@@ -421,7 +461,7 @@ class _CallScreenState extends State<CallScreen>
       _ShowChatButton(
         channel: _channel,
         selected: _openPanel == CallSidePanel.chat,
-        onPressed: () => togglePanel(CallSidePanel.chat),
+        onPressed: () => _togglePanel(CallSidePanel.chat),
       ),
     ];
 
@@ -456,7 +496,7 @@ class _CallScreenState extends State<CallScreen>
           CallFeatureButton(
             icon: Icon(context.streamIcons.settingsFill),
             selected: _moreMenuVisible,
-            onPressed: () => toggleMoreMenu(context),
+            onPressed: _toggleMoreMenu,
           ),
           _layoutToggle(),
         ],
@@ -473,7 +513,7 @@ class _CallScreenState extends State<CallScreen>
           CallFeatureButton(
             icon: Icon(context.streamIcons.statsFill),
             selected: _openPanel == CallSidePanel.stats,
-            onPressed: () => togglePanel(CallSidePanel.stats),
+            onPressed: () => _togglePanel(CallSidePanel.stats),
           ),
           ...panels,
         ],
@@ -486,8 +526,16 @@ class _CallScreenState extends State<CallScreen>
     // ignore: deprecated_member_use
     return WillPopScope(
       onWillPop: () async {
-        if (_openPanel != null) {
-          closePanel();
+        // Keyed to what is on screen, not to what was asked for: a panel is
+        // still visible while it animates out, and back should dismiss it
+        // rather than fall through and leave the call.
+        if (_mountedPanel != null) {
+          _closePanel();
+          return false;
+        }
+
+        if (_moreMenuVisible) {
+          _closeMoreMenu();
           return false;
         }
 
@@ -555,7 +603,7 @@ class _CallScreenState extends State<CallScreen>
                       ),
                       if (_moreMenuVisible) ...[
                         GestureDetector(
-                          onTap: () => setState(() => _moreMenuVisible = false),
+                          onTap: _closeMoreMenu,
                           child: Container(color: Colors.black12),
                         ),
                         Positioned(
@@ -569,17 +617,13 @@ class _CallScreenState extends State<CallScreen>
                               child: SettingsMenu(
                                 call: call,
                                 videoEffectsManager: _videoEffectsManager,
-                                onReactionSend: (_) =>
-                                    setState(() => _moreMenuVisible = false),
+                                onReactionSend: (_) => _closeMoreMenu(),
                                 onStatsPressed: () =>
-                                    togglePanel(CallSidePanel.stats),
+                                    _togglePanel(CallSidePanel.stats),
                                 onAudioOutputChange: (_, {closeMenu = true}) {
-                                  if (closeMenu) {
-                                    setState(() => _moreMenuVisible = false);
-                                  }
+                                  if (closeMenu) _closeMoreMenu();
                                 },
-                                onAudioInputChange: (_) =>
-                                    setState(() => _moreMenuVisible = false),
+                                onAudioInputChange: (_) => _closeMoreMenu(),
                               ),
                             ),
                           ),
@@ -667,6 +711,8 @@ class _ShowChatButton extends StatefulWidget {
     required this.onPressed,
   });
 
+  /// The call's chat channel, or null while it is still connecting — the
+  /// button is disabled until it arrives.
   final Channel? channel;
 
   /// Whether the chat panel is the one currently open.

--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -318,7 +318,7 @@ class _CallScreenState extends State<CallScreen>
 
     return CallSidePanelSurface(
       key: _panelKey,
-      showLeadingDivider: !fullScreen,
+      docked: !fullScreen,
       onClose: _closePanel,
       title: switch (panel) {
         CallSidePanel.participants => PartialCallStateBuilder(

--- a/dogfooding/lib/screens/call_screen.dart
+++ b/dogfooding/lib/screens/call_screen.dart
@@ -85,18 +85,16 @@ class _CallScreenState extends State<CallScreen>
   /// The panel the user asked for, or null once it starts closing.
   ///
   /// Drives the control bar's selected states, which let go as soon as the
-  /// panel starts leaving. Anything asking whether a panel is *on screen*
-  /// wants [_mountedPanel] instead.
+  /// panel starts leaving. What the screen is still *holding* open is
+  /// [_mountedPanel]; what is actually painted is [_panelOnScreen].
   CallSidePanel? _openPanel;
 
-  /// The panel whose content is in the tree, or null when nothing is up.
+  /// The panel the screen is holding open, or null when there is none.
   ///
-  /// Outlives [_openPanel] by the length of the exit animation, so it is the
-  /// one to read for "is a panel on screen": what the back button dismisses,
-  /// and what the app bar makes room for.
+  /// Outlives [_openPanel] by the length of the exit animation, and is what
+  /// the back button dismisses. It is not the same as being painted — see
+  /// [_panelOnScreen], which the app bar asks before making room.
   CallSidePanel? _mountedPanel;
-
-  StreamSubscription<CallStatus>? _callStatusSubscription;
 
   late final _panelController = AnimationController(
     duration: const Duration(milliseconds: 250),
@@ -122,32 +120,25 @@ class _CallScreenState extends State<CallScreen>
     _speakingWhileMutedSubscription = _speakingWhileMuted.stream.listen(
       _onSpeakingWhileMutedChanged,
     );
-    _callStatusSubscription = widget.call
-        .partialState((state) => state.status)
-        .listen(_onCallStatusChanged);
   }
 
-  /// Closes the panel when the call stops being connected.
+  /// Whether a panel is on screen, rather than merely asked for.
   ///
-  /// The SDK only builds the slot the panel lives in while the call is
-  /// connected, so a reconnect takes the panel off screen on its own. Without
-  /// this the state would still claim one is up, and on a phone the app bar
-  /// would stay collapsed around nothing — taking the only leave button with
-  /// it.
-  void _onCallStatusChanged(CallStatus status) {
-    if (!mounted || _mountedPanel == null) return;
-    if (status.isConnected || status.isFastReconnecting || status.isMigrating) {
-      return;
-    }
+  /// The SDK builds the slot the panel lives in only while the call is
+  /// connected, so through a reconnect the panel is gone while [_mountedPanel]
+  /// still names one. Anything that gives the panel room — the collapsed app
+  /// bar, and the height handed back to the grid — has to ask this instead, or
+  /// it makes room for a panel that is not there.
+  ///
+  /// Reading the status rather than listening to it is enough: the SDK rebuilds
+  /// its content, and with it these builders, whenever the status changes.
+  bool _panelOnScreen(Call call) {
+    if (_mountedPanel == null) return false;
 
-    _logger.d(() => 'Closing the $_mountedPanel panel: call is $status');
-    setState(() {
-      _openPanel = null;
-      _mountedPanel = null;
-    });
-    // Straight to closed rather than reversed: the panel is already gone, so
-    // there is nothing left on screen to animate out.
-    _panelController.reset();
+    final status = call.state.value.status;
+    return status.isConnected ||
+        status.isFastReconnecting ||
+        status.isMigrating;
   }
 
   void _onSpeakingWhileMutedChanged(SpeakingWhileMutedState state) {
@@ -183,7 +174,6 @@ class _CallScreenState extends State<CallScreen>
     _speakingWhileMutedDebounce?.cancel();
     _speakingWhileMutedSubscription.cancel();
     _speakingWhileMuted.dispose();
-    _callStatusSubscription?.cancel();
     _chatConnectionRecoverySubscription?.cancel();
     _devices.dispose();
     _panelAnimation.dispose();
@@ -526,9 +516,11 @@ class _CallScreenState extends State<CallScreen>
     // ignore: deprecated_member_use
     return WillPopScope(
       onWillPop: () async {
-        // Keyed to what is on screen, not to what was asked for: a panel is
-        // still visible while it animates out, and back should dismiss it
-        // rather than fall through and leave the call.
+        // Any panel the screen is holding, not just one being painted: a
+        // panel is still visible while it animates out, and through a
+        // reconnect it is off screen but still open. Either way back should
+        // dismiss it rather than fall through and leave the call — the one
+        // outcome no press of back should reach by accident.
         if (_mountedPanel != null) {
           _closePanel();
           return false;
@@ -579,7 +571,7 @@ class _CallScreenState extends State<CallScreen>
                   fullScreen: fullScreen,
                   // What the collapsed app bar gave up, handed back to the
                   // grid so it neither moves nor re-tiles while a panel is up.
-                  coveredTopExtent: _mountedPanel != null ? kToolbarHeight : 0,
+                  coveredTopExtent: _panelOnScreen(call) ? kToolbarHeight : 0,
                   child: Stack(
                     children: [
                       Column(
@@ -654,7 +646,7 @@ class _CallScreenState extends State<CallScreen>
                 // A narrow window gives the whole body to the panel, the app
                 // bar's row included. A zero-height bar rather than null,
                 // because null falls back to the SDK's own.
-                if (context.streamScreenSize.isSmall && _mountedPanel != null) {
+                if (context.streamScreenSize.isSmall && _panelOnScreen(call)) {
                   return PreferredSize(
                     preferredSize: Size.zero,
                     // Scaffold sizes this slot from the child rather than the

--- a/dogfooding/lib/screens/call_stats_screen.dart
+++ b/dogfooding/lib/screens/call_stats_screen.dart
@@ -10,19 +10,15 @@ import 'stats_thermal_chart.dart';
 /// The call's live statistics, as the body of a side panel.
 class CallStatsPanelBody extends StatelessWidget {
   /// Creates a stats body for [call].
-  CallStatsPanelBody({super.key, required this.call});
+  const CallStatsPanelBody({super.key, required this.call});
 
   /// The call whose statistics are reported.
   final Call call;
 
-  final _userAuthController = locator.get<UserAuthController>();
-
   @override
   Widget build(BuildContext context) {
-    final streamVideoTheme = StreamVideoTheme.of(context);
-    final textTheme = streamVideoTheme.textTheme;
     final colorScheme = context.streamColorScheme;
-    final currentUser = _userAuthController.currentUser;
+    final currentUser = locator.get<UserAuthController>().currentUser;
 
     return StreamBuilder<CallMetrics?>(
       stream: call.statsReporter?.stream,
@@ -49,7 +45,10 @@ class CallStatsPanelBody extends StatelessWidget {
           child: Column(
             children: [
               ListTile(
-                leading: StreamUserAvatar(user: currentUser!),
+                // No avatar rather than a crash if the session has gone.
+                leading: currentUser == null
+                    ? null
+                    : StreamUserAvatar(user: currentUser),
                 title: Text(
                   'Call ID',
                   style: TextStyle(color: colorScheme.textPrimary),
@@ -59,143 +58,47 @@ class CallStatsPanelBody extends StatelessWidget {
                   style: TextStyle(color: colorScheme.textPrimary),
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  children: [
-                    Icon(Icons.network_check, color: colorScheme.textPrimary),
-                    const SizedBox(width: 8),
-                    Text(
-                      'Call latency',
-                      style: textTheme.title3.apply(
-                        color: colorScheme.textPrimary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  'Very high latency values may reduce call quality, cause lag, and make the call less enjoyable.',
-                  style: TextStyle(color: colorScheme.textPrimary),
-                ),
+              _StatsSection(
+                icon: Icons.network_check,
+                title: 'Call latency',
+                description:
+                    'Very high latency values may reduce call quality, cause lag, and make the call less enjoyable.',
+                chart: StatsLatencyChart(latencyHistory: state.latencyHistory),
               ),
               const SizedBox(height: 16),
-              SizedBox(
-                height: 200,
-                child: StatsLatencyChart(
-                  latencyHistory: state.latencyHistory,
-                ),
-              ),
-              const SizedBox(
-                height: 16,
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  children: [
-                    Icon(Icons.whatshot, color: colorScheme.textPrimary),
-                    const SizedBox(width: 8),
-                    Text(
-                      'Thermal state',
-                      style: textTheme.title3.apply(
-                        color: colorScheme.textPrimary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  'Device thermal state history. Higher bars indicate more severe states.',
-                  style: TextStyle(color: colorScheme.textPrimary),
-                ),
-              ),
-              const SizedBox(height: 16),
-              SizedBox(
-                height: 200,
-                child: StatsThermalChart(
+              _StatsSection(
+                icon: Icons.whatshot,
+                title: 'Thermal state',
+                description:
+                    'Device thermal state history. Higher bars indicate more severe states.',
+                chart: StatsThermalChart(
                   thermalSeverityHistory: state.thermalStatusHistory,
                 ),
               ),
-              const SizedBox(
-                height: 16,
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  children: [
-                    Icon(
-                      Icons.battery_full,
-                      color: colorScheme.textPrimary,
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      'Battery level',
-                      style: textTheme.title3.apply(
-                        color: colorScheme.textPrimary,
-                      ),
-                    ),
-                  ],
+              const SizedBox(height: 16),
+              _StatsSection(
+                icon: Icons.battery_full,
+                title: 'Battery level',
+                description: 'Track device battery level throughout the call.',
+                chart: StatsBatteryChart(
+                  batteryLevelHistory: state.batteryLevelHistory,
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  'Track device battery level throughout the call.',
+                footer: Text(
+                  'Battery percentage consumed during call: ${batteryDrained != null ? "$batteryDrained%" : "N/A"}',
                   style: TextStyle(color: colorScheme.textPrimary),
                 ),
               ),
               const SizedBox(height: 16),
-              SizedBox(
-                height: 200,
-                child: StatsBatteryChart(
-                  batteryLevelHistory: state.batteryLevelHistory,
-                ),
+              const _StatsSection(
+                icon: Icons.bar_chart,
+                title: 'Call performance',
+                description:
+                    'Review the key data points below to assess call performance.',
               ),
-              Text(
-                'Battery percentage consumed during call: ${batteryDrained != null ? "$batteryDrained%" : "N/A"}',
-                style: TextStyle(color: colorScheme.textPrimary),
-              ),
-              const SizedBox(
-                height: 16,
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  children: [
-                    Icon(Icons.bar_chart, color: colorScheme.textPrimary),
-                    const SizedBox(width: 8),
-                    Text(
-                      'Call performance',
-                      style: textTheme.title3.apply(
-                        color: colorScheme.textPrimary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  'Review the key data points below to assess call performance.',
-                  style: TextStyle(color: colorScheme.textPrimary),
-                ),
-              ),
-              const SizedBox(
-                height: 16,
-              ),
-              Row(
-                children: [
-                  Expanded(
-                    child: LatencyOrJitterItem(
-                      title: 'Latency',
-                      value: state.publisher?.latency ?? 0,
-                    ),
-                  ),
-                ],
+              const SizedBox(height: 16),
+              LatencyOrJitterItem(
+                title: 'Latency',
+                value: state.publisher?.latency ?? 0,
               ),
               Row(
                 children: [
@@ -220,7 +123,7 @@ class CallStatsPanelBody extends StatelessWidget {
                       title: 'Publish bitrate',
                       value: publisherBitrate == null
                           ? '--'
-                          : '${state.publisher?.bitrateKbps} Kbps',
+                          : '$publisherBitrate Kbps',
                     ),
                   ),
                   Expanded(
@@ -228,7 +131,7 @@ class CallStatsPanelBody extends StatelessWidget {
                       title: 'Receive bitrate',
                       value: subscriberBitrate == null
                           ? '--'
-                          : '${state.subscriber?.bitrateKbps} Kbps',
+                          : '$subscriberBitrate Kbps',
                     ),
                   ),
                 ],
@@ -276,22 +179,17 @@ class LatencyOrJitterItem extends StatelessWidget {
     super.key,
     required this.value,
     required this.title,
-    this.okRange,
   });
 
   final String title;
   final int? value;
-  final List<int>? okRange;
 
   @override
   Widget build(BuildContext context) {
     return StatsItem(
       title: title,
       value: value == null ? '--' : '$value ms',
-      trailing: StatIndicator(
-        value: value,
-        okRange: okRange ?? [for (var i = 75; i <= 100; i++) i],
-      ),
+      trailing: StatIndicator(value: value),
     );
   }
 }
@@ -311,7 +209,7 @@ class StatsItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = StreamVideoTheme.of(context);
-    final colorScheme = StreamTheme.of(context).colorScheme;
+    final colorScheme = context.streamColorScheme;
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
@@ -337,7 +235,7 @@ class StatsItem extends StatelessWidget {
               ],
             ),
           ),
-          if (trailing != null) ...[trailing!],
+          if (trailing case final trailing?) trailing,
         ],
       ),
     );
@@ -345,22 +243,26 @@ class StatsItem extends StatelessWidget {
 }
 
 class StatIndicator extends StatelessWidget {
-  const StatIndicator({super.key, required this.value, required this.okRange});
+  const StatIndicator({
+    super.key,
+    required this.value,
+    this.okMin = 75,
+    this.okMax = 100,
+  });
 
   final int? value;
-  final List<int> okRange;
 
-  (Color color, String text)? getIndicatorData() {
-    if (value == null) {
-      return null;
-    } else if (okRange.contains(value)) {
-      return (const Color(0xFFFFD646), 'Ok');
-    } else if (okRange.first > value!) {
-      return (const Color(0xFF00E2A1), 'Good');
-    } else {
-      return (const Color(0xFFDC433B), 'Bad');
-    }
-  }
+  /// Below this the reading is good; above [okMax] it is bad. Between the two
+  /// it is merely acceptable.
+  final int okMin;
+  final int okMax;
+
+  (Color color, String text)? getIndicatorData() => switch (value) {
+    null => null,
+    final value when value < okMin => (const Color(0xFF00E2A1), 'Good'),
+    final value when value <= okMax => (const Color(0xFFFFD646), 'Ok'),
+    _ => (const Color(0xFFDC433B), 'Bad'),
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -382,6 +284,67 @@ class StatIndicator extends StatelessWidget {
         indicatorData.$2,
         style: theme.textTheme.footnote.apply(color: indicatorData.$1),
       ),
+    );
+  }
+}
+
+/// One titled block of the stats panel: a heading, a line about what it
+/// shows, and optionally a chart under it.
+class _StatsSection extends StatelessWidget {
+  const _StatsSection({
+    required this.icon,
+    required this.title,
+    required this.description,
+    this.chart,
+    this.footer,
+  });
+
+  final IconData icon;
+  final String title;
+
+  /// What the section is for, under the heading.
+  final String description;
+
+  /// Charted history, given a fixed height so every section's is the same.
+  final Widget? chart;
+
+  /// A closing line below [chart], for a section that summarises itself.
+  final Widget? footer;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+    final textTheme = StreamVideoTheme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Icon(icon, color: colorScheme.textPrimary),
+              const SizedBox(width: 8),
+              Text(
+                title,
+                style: textTheme.title3.apply(color: colorScheme.textPrimary),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            description,
+            style: TextStyle(color: colorScheme.textPrimary),
+          ),
+        ),
+        if (chart case final chart?) ...[
+          const SizedBox(height: 16),
+          SizedBox(height: 200, child: chart),
+        ],
+        if (footer case final footer?) footer,
+      ],
     );
   }
 }

--- a/dogfooding/lib/screens/call_stats_screen.dart
+++ b/dogfooding/lib/screens/call_stats_screen.dart
@@ -59,214 +59,210 @@ class CallStatsPanelBody extends StatelessWidget {
                   style: TextStyle(color: colorScheme.textPrimary),
                 ),
               ),
-              if (snapshot.hasData) ...[
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    children: [
-                      Icon(Icons.network_check, color: colorScheme.textPrimary),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Call latency',
-                        style: textTheme.title3.apply(
-                          color: colorScheme.textPrimary,
-                        ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(Icons.network_check, color: colorScheme.textPrimary),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Call latency',
+                      style: textTheme.title3.apply(
+                        color: colorScheme.textPrimary,
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: Text(
-                    'Very high latency values may reduce call quality, cause lag, and make the call less enjoyable.',
-                    style: TextStyle(color: colorScheme.textPrimary),
-                  ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'Very high latency values may reduce call quality, cause lag, and make the call less enjoyable.',
+                  style: TextStyle(color: colorScheme.textPrimary),
                 ),
-                const SizedBox(height: 16),
-                SizedBox(
-                  height: 200,
-                  child: StatsLatencyChart(
-                    latencyHistory: state.latencyHistory,
-                  ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                height: 200,
+                child: StatsLatencyChart(
+                  latencyHistory: state.latencyHistory,
                 ),
-                if (snapshot.hasData) ...[
-                  const SizedBox(
-                    height: 16,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Row(
-                      children: [
-                        Icon(Icons.whatshot, color: colorScheme.textPrimary),
-                        const SizedBox(width: 8),
-                        Text(
-                          'Thermal state',
-                          style: textTheme.title3.apply(
-                            color: colorScheme.textPrimary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      'Device thermal state history. Higher bars indicate more severe states.',
-                      style: TextStyle(color: colorScheme.textPrimary),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  SizedBox(
-                    height: 200,
-                    child: StatsThermalChart(
-                      thermalSeverityHistory: state.thermalStatusHistory,
-                    ),
-                  ),
-                  const SizedBox(
-                    height: 16,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Row(
-                      children: [
-                        Icon(
-                          Icons.battery_full,
-                          color: colorScheme.textPrimary,
-                        ),
-                        const SizedBox(width: 8),
-                        Text(
-                          'Battery level',
-                          style: textTheme.title3.apply(
-                            color: colorScheme.textPrimary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      'Track device battery level throughout the call.',
-                      style: TextStyle(color: colorScheme.textPrimary),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  SizedBox(
-                    height: 200,
-                    child: StatsBatteryChart(
-                      batteryLevelHistory: state.batteryLevelHistory,
-                    ),
-                  ),
-                  Text(
-                    'Battery percentage consumed during call: ${batteryDrained != null ? "$batteryDrained%" : "N/A"}',
-                    style: TextStyle(color: colorScheme.textPrimary),
-                  ),
-                  const SizedBox(
-                    height: 16,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Row(
-                      children: [
-                        Icon(Icons.bar_chart, color: colorScheme.textPrimary),
-                        const SizedBox(width: 8),
-                        Text(
-                          'Call performance',
-                          style: textTheme.title3.apply(
-                            color: colorScheme.textPrimary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      'Review the key data points below to assess call performance.',
-                      style: TextStyle(color: colorScheme.textPrimary),
-                    ),
-                  ),
-                  const SizedBox(
-                    height: 16,
-                  ),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: LatencyOrJitterItem(
-                          title: 'Latency',
-                          value: state.publisher?.latency ?? 0,
-                        ),
+              ),
+              const SizedBox(
+                height: 16,
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(Icons.whatshot, color: colorScheme.textPrimary),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Thermal state',
+                      style: textTheme.title3.apply(
+                        color: colorScheme.textPrimary,
                       ),
-                    ],
-                  ),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: LatencyOrJitterItem(
-                          title: 'Receive jitter',
-                          value: state.subscriber?.jitterInMs,
-                        ),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'Device thermal state history. Higher bars indicate more severe states.',
+                  style: TextStyle(color: colorScheme.textPrimary),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                height: 200,
+                child: StatsThermalChart(
+                  thermalSeverityHistory: state.thermalStatusHistory,
+                ),
+              ),
+              const SizedBox(
+                height: 16,
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.battery_full,
+                      color: colorScheme.textPrimary,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Battery level',
+                      style: textTheme.title3.apply(
+                        color: colorScheme.textPrimary,
                       ),
-                      Expanded(
-                        child: LatencyOrJitterItem(
-                          title: 'Publish jitter',
-                          value: state.publisher?.jitterInMs,
-                        ),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'Track device battery level throughout the call.',
+                  style: TextStyle(color: colorScheme.textPrimary),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                height: 200,
+                child: StatsBatteryChart(
+                  batteryLevelHistory: state.batteryLevelHistory,
+                ),
+              ),
+              Text(
+                'Battery percentage consumed during call: ${batteryDrained != null ? "$batteryDrained%" : "N/A"}',
+                style: TextStyle(color: colorScheme.textPrimary),
+              ),
+              const SizedBox(
+                height: 16,
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(Icons.bar_chart, color: colorScheme.textPrimary),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Call performance',
+                      style: textTheme.title3.apply(
+                        color: colorScheme.textPrimary,
                       ),
-                    ],
-                  ),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: StatsItem(
-                          title: 'Publish bitrate',
-                          value: publisherBitrate == null
-                              ? '--'
-                              : '${state.publisher?.bitrateKbps} Kbps',
-                        ),
-                      ),
-                      Expanded(
-                        child: StatsItem(
-                          title: 'Receive bitrate',
-                          value: subscriberBitrate == null
-                              ? '--'
-                              : '${state.subscriber?.bitrateKbps} Kbps',
-                        ),
-                      ),
-                    ],
-                  ),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: StatsItem(
-                          title: 'Publish resolution',
-                          value:
-                              "${state.publisher?.resolution} | ${state.publisher?.videoCodec?.join('+')}",
-                        ),
-                      ),
-                      Expanded(
-                        child: StatsItem(
-                          title: 'Receive resolution',
-                          value:
-                              "${state.subscriber?.resolution} | ${state.subscriber?.videoCodec?.join('+')}",
-                        ),
-                      ),
-                    ],
-                  ),
-                  StatsItem(
-                    title: 'Region',
-                    value: state.clientEnvironment.sfu,
-                  ),
-                  StatsItem(
-                    title: 'SDK Version',
-                    value: state.clientEnvironment.sdkVersion,
-                  ),
-                  StatsItem(
-                    title: 'WebRTC Version',
-                    value: state.clientEnvironment.webRtcVersion,
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'Review the key data points below to assess call performance.',
+                  style: TextStyle(color: colorScheme.textPrimary),
+                ),
+              ),
+              const SizedBox(
+                height: 16,
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: LatencyOrJitterItem(
+                      title: 'Latency',
+                      value: state.publisher?.latency ?? 0,
+                    ),
                   ),
                 ],
-              ],
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: LatencyOrJitterItem(
+                      title: 'Receive jitter',
+                      value: state.subscriber?.jitterInMs,
+                    ),
+                  ),
+                  Expanded(
+                    child: LatencyOrJitterItem(
+                      title: 'Publish jitter',
+                      value: state.publisher?.jitterInMs,
+                    ),
+                  ),
+                ],
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: StatsItem(
+                      title: 'Publish bitrate',
+                      value: publisherBitrate == null
+                          ? '--'
+                          : '${state.publisher?.bitrateKbps} Kbps',
+                    ),
+                  ),
+                  Expanded(
+                    child: StatsItem(
+                      title: 'Receive bitrate',
+                      value: subscriberBitrate == null
+                          ? '--'
+                          : '${state.subscriber?.bitrateKbps} Kbps',
+                    ),
+                  ),
+                ],
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: StatsItem(
+                      title: 'Publish resolution',
+                      value:
+                          "${state.publisher?.resolution} | ${state.publisher?.videoCodec?.join('+')}",
+                    ),
+                  ),
+                  Expanded(
+                    child: StatsItem(
+                      title: 'Receive resolution',
+                      value:
+                          "${state.subscriber?.resolution} | ${state.subscriber?.videoCodec?.join('+')}",
+                    ),
+                  ),
+                ],
+              ),
+              StatsItem(
+                title: 'Region',
+                value: state.clientEnvironment.sfu,
+              ),
+              StatsItem(
+                title: 'SDK Version',
+                value: state.clientEnvironment.sdkVersion,
+              ),
+              StatsItem(
+                title: 'WebRTC Version',
+                value: state.clientEnvironment.webRtcVersion,
+              ),
             ],
           ),
         );

--- a/dogfooding/lib/screens/call_stats_screen.dart
+++ b/dogfooding/lib/screens/call_stats_screen.dart
@@ -7,9 +7,12 @@ import 'stats_battery_chart.dart';
 import 'stats_latency_chart.dart';
 import 'stats_thermal_chart.dart';
 
-class CallStatsScreen extends StatelessWidget {
-  CallStatsScreen({super.key, required this.call});
+/// The call's live statistics, as the body of a side panel.
+class CallStatsPanelBody extends StatelessWidget {
+  /// Creates a stats body for [call].
+  CallStatsPanelBody({super.key, required this.call});
 
+  /// The call whose statistics are reported.
   final Call call;
 
   final _userAuthController = locator.get<UserAuthController>();
@@ -18,6 +21,7 @@ class CallStatsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final streamVideoTheme = StreamVideoTheme.of(context);
     final textTheme = streamVideoTheme.textTheme;
+    final colorScheme = context.streamColorScheme;
     final currentUser = _userAuthController.currentUser;
 
     return StreamBuilder<CallMetrics?>(
@@ -41,245 +45,229 @@ class CallStatsScreen extends StatelessWidget {
             ? state.initialBatteryLevel! - state.batteryLevelHistory.last
             : null;
 
-        return SafeArea(
-          top: false,
-          child: Scaffold(
-            appBar: AppBar(
-              title: Text(
-                'Stats',
-                style: textTheme.title3.apply(color: Colors.white),
-              ),
-              centerTitle: true,
-              backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-              actions: [
-                IconButton(
-                  icon: const Icon(Icons.close, color: Colors.white),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
+        return SingleChildScrollView(
+          child: Column(
+            children: [
+              ListTile(
+                leading: StreamUserAvatar(user: currentUser!),
+                title: Text(
+                  'Call ID',
+                  style: TextStyle(color: colorScheme.textPrimary),
                 ),
-              ],
-            ),
-            body: SingleChildScrollView(
-              child: Column(
-                children: [
-                  ListTile(
-                    leading: StreamUserAvatar(user: currentUser!),
-                    title: const Text(
-                      'Call ID',
-                      style: TextStyle(color: Colors.white),
-                    ),
-                    subtitle: Text(
-                      call.callCid.value,
-                      style: const TextStyle(color: Colors.white),
-                    ),
-                  ),
-                  if (snapshot.hasData) ...[
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Row(
-                        children: [
-                          const Icon(Icons.network_check, color: Colors.white),
-                          const SizedBox(width: 8),
-                          Text(
-                            'Call latency',
-                            style: textTheme.title3.apply(color: Colors.white),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 16),
-                      child: Text(
-                        'Very high latency values may reduce call quality, cause lag, and make the call less enjoyable.',
-                        style: TextStyle(color: Colors.white),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    SizedBox(
-                      height: 200,
-                      child: StatsLatencyChart(
-                        latencyHistory: state.latencyHistory,
-                      ),
-                    ),
-                    if (snapshot.hasData) ...[
-                      const SizedBox(
-                        height: 16,
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Row(
-                          children: [
-                            const Icon(Icons.whatshot, color: Colors.white),
-                            const SizedBox(width: 8),
-                            Text(
-                              'Thermal state',
-                              style: textTheme.title3.apply(
-                                color: Colors.white,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 16),
-                        child: Text(
-                          'Device thermal state history. Higher bars indicate more severe states.',
-                          style: TextStyle(color: Colors.white),
-                        ),
-                      ),
-                      const SizedBox(height: 16),
-                      SizedBox(
-                        height: 200,
-                        child: StatsThermalChart(
-                          thermalSeverityHistory: state.thermalStatusHistory,
-                        ),
-                      ),
-                      const SizedBox(
-                        height: 16,
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Row(
-                          children: [
-                            const Icon(Icons.battery_full, color: Colors.white),
-                            const SizedBox(width: 8),
-                            Text(
-                              'Battery level',
-                              style: textTheme.title3.apply(
-                                color: Colors.white,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 16),
-                        child: Text(
-                          'Track device battery level throughout the call.',
-                          style: TextStyle(color: Colors.white),
-                        ),
-                      ),
-                      const SizedBox(height: 16),
-                      SizedBox(
-                        height: 200,
-                        child: StatsBatteryChart(
-                          batteryLevelHistory: state.batteryLevelHistory,
-                        ),
-                      ),
+                subtitle: Text(
+                  call.callCid.value,
+                  style: TextStyle(color: colorScheme.textPrimary),
+                ),
+              ),
+              if (snapshot.hasData) ...[
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Icon(Icons.network_check, color: colorScheme.textPrimary),
+                      const SizedBox(width: 8),
                       Text(
-                        'Battery percentage consumed during call: ${batteryDrained != null ? "$batteryDrained%" : "N/A"}',
-                        style: const TextStyle(color: Colors.white),
-                      ),
-                      const SizedBox(
-                        height: 16,
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Row(
-                          children: [
-                            const Icon(Icons.bar_chart, color: Colors.white),
-                            const SizedBox(width: 8),
-                            Text(
-                              'Call performance',
-                              style: textTheme.title3.apply(
-                                color: Colors.white,
-                              ),
-                            ),
-                          ],
+                        'Call latency',
+                        style: textTheme.title3.apply(
+                          color: colorScheme.textPrimary,
                         ),
-                      ),
-                      const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 16),
-                        child: Text(
-                          'Review the key data points below to assess call performance.',
-                          style: TextStyle(color: Colors.white),
-                        ),
-                      ),
-                      const SizedBox(
-                        height: 16,
-                      ),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: LatencyOrJitterItem(
-                              title: 'Latency',
-                              value: state.publisher?.latency ?? 0,
-                            ),
-                          ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: LatencyOrJitterItem(
-                              title: 'Receive jitter',
-                              value: state.subscriber?.jitterInMs,
-                            ),
-                          ),
-                          Expanded(
-                            child: LatencyOrJitterItem(
-                              title: 'Publish jitter',
-                              value: state.publisher?.jitterInMs,
-                            ),
-                          ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: StatsItem(
-                              title: 'Publish bitrate',
-                              value: publisherBitrate == null
-                                  ? '--'
-                                  : '${state.publisher?.bitrateKbps} Kbps',
-                            ),
-                          ),
-                          Expanded(
-                            child: StatsItem(
-                              title: 'Receive bitrate',
-                              value: subscriberBitrate == null
-                                  ? '--'
-                                  : '${state.subscriber?.bitrateKbps} Kbps',
-                            ),
-                          ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: StatsItem(
-                              title: 'Publish resolution',
-                              value:
-                                  "${state.publisher?.resolution} | ${state.publisher?.videoCodec?.join('+')}",
-                            ),
-                          ),
-                          Expanded(
-                            child: StatsItem(
-                              title: 'Receive resolution',
-                              value:
-                                  "${state.subscriber?.resolution} | ${state.subscriber?.videoCodec?.join('+')}",
-                            ),
-                          ),
-                        ],
-                      ),
-                      StatsItem(
-                        title: 'Region',
-                        value: state.clientEnvironment.sfu,
-                      ),
-                      StatsItem(
-                        title: 'SDK Version',
-                        value: state.clientEnvironment.sdkVersion,
-                      ),
-                      StatsItem(
-                        title: 'WebRTC Version',
-                        value: state.clientEnvironment.webRtcVersion,
                       ),
                     ],
-                  ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text(
+                    'Very high latency values may reduce call quality, cause lag, and make the call less enjoyable.',
+                    style: TextStyle(color: colorScheme.textPrimary),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  height: 200,
+                  child: StatsLatencyChart(
+                    latencyHistory: state.latencyHistory,
+                  ),
+                ),
+                if (snapshot.hasData) ...[
+                  const SizedBox(
+                    height: 16,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        Icon(Icons.whatshot, color: colorScheme.textPrimary),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Thermal state',
+                          style: textTheme.title3.apply(
+                            color: colorScheme.textPrimary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'Device thermal state history. Higher bars indicate more severe states.',
+                      style: TextStyle(color: colorScheme.textPrimary),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    height: 200,
+                    child: StatsThermalChart(
+                      thermalSeverityHistory: state.thermalStatusHistory,
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 16,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.battery_full,
+                          color: colorScheme.textPrimary,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Battery level',
+                          style: textTheme.title3.apply(
+                            color: colorScheme.textPrimary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'Track device battery level throughout the call.',
+                      style: TextStyle(color: colorScheme.textPrimary),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    height: 200,
+                    child: StatsBatteryChart(
+                      batteryLevelHistory: state.batteryLevelHistory,
+                    ),
+                  ),
+                  Text(
+                    'Battery percentage consumed during call: ${batteryDrained != null ? "$batteryDrained%" : "N/A"}',
+                    style: TextStyle(color: colorScheme.textPrimary),
+                  ),
+                  const SizedBox(
+                    height: 16,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        Icon(Icons.bar_chart, color: colorScheme.textPrimary),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Call performance',
+                          style: textTheme.title3.apply(
+                            color: colorScheme.textPrimary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'Review the key data points below to assess call performance.',
+                      style: TextStyle(color: colorScheme.textPrimary),
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 16,
+                  ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: LatencyOrJitterItem(
+                          title: 'Latency',
+                          value: state.publisher?.latency ?? 0,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: LatencyOrJitterItem(
+                          title: 'Receive jitter',
+                          value: state.subscriber?.jitterInMs,
+                        ),
+                      ),
+                      Expanded(
+                        child: LatencyOrJitterItem(
+                          title: 'Publish jitter',
+                          value: state.publisher?.jitterInMs,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: StatsItem(
+                          title: 'Publish bitrate',
+                          value: publisherBitrate == null
+                              ? '--'
+                              : '${state.publisher?.bitrateKbps} Kbps',
+                        ),
+                      ),
+                      Expanded(
+                        child: StatsItem(
+                          title: 'Receive bitrate',
+                          value: subscriberBitrate == null
+                              ? '--'
+                              : '${state.subscriber?.bitrateKbps} Kbps',
+                        ),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: StatsItem(
+                          title: 'Publish resolution',
+                          value:
+                              "${state.publisher?.resolution} | ${state.publisher?.videoCodec?.join('+')}",
+                        ),
+                      ),
+                      Expanded(
+                        child: StatsItem(
+                          title: 'Receive resolution',
+                          value:
+                              "${state.subscriber?.resolution} | ${state.subscriber?.videoCodec?.join('+')}",
+                        ),
+                      ),
+                    ],
+                  ),
+                  StatsItem(
+                    title: 'Region',
+                    value: state.clientEnvironment.sfu,
+                  ),
+                  StatsItem(
+                    title: 'SDK Version',
+                    value: state.clientEnvironment.sdkVersion,
+                  ),
+                  StatsItem(
+                    title: 'WebRTC Version',
+                    value: state.clientEnvironment.webRtcVersion,
+                  ),
                 ],
-              ),
-            ),
+              ],
+            ],
           ),
         );
       },

--- a/dogfooding/lib/widgets/side_panel/call_side_panel.dart
+++ b/dogfooding/lib/widgets/side_panel/call_side_panel.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:stream_video_flutter/stream_video_flutter.dart';
+
+/// The panels the call screen can put beside — or over — the video grid.
+enum CallSidePanel {
+  /// The participants and members of the call.
+  participants,
+
+  /// The call's chat channel.
+  chat,
+
+  /// The call's live statistics.
+  stats,
+}
+
+/// The chrome shared by every [CallSidePanel]: a header with a title and a
+/// close button, over the panel's own content.
+///
+/// The panel is not a route, so closing it is the caller's business — pass
+/// [onClose].
+class CallSidePanelSurface extends StatelessWidget {
+  /// Creates the chrome for a side panel showing [child].
+  const CallSidePanelSurface({
+    super.key,
+    required this.title,
+    required this.onClose,
+    required this.child,
+    this.showLeadingDivider = true,
+  });
+
+  /// The panel's heading, centred in the header.
+  final Widget title;
+
+  /// Called when the header's close button is pressed.
+  final VoidCallback onClose;
+
+  /// Whether to draw the line between the panel and the video grid beside it.
+  ///
+  /// False for a panel covering the whole screen, which has nothing to divide
+  /// itself from.
+  final bool showLeadingDivider;
+
+  /// The panel's content, filling everything below the header.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.backgroundElevation1,
+        border: showLeadingDivider
+            ? BorderDirectional(
+                start: BorderSide(color: colorScheme.borderDefault),
+              )
+            : null,
+      ),
+      child: Column(
+        children: [
+          StreamSheetHeader(
+            // The panel lives on the call screen's own route, so an implied
+            // leading button would offer to pop the call, not the panel.
+            automaticallyImplyLeading: false,
+            title: title,
+            trailing: StreamButton.icon(
+              style: StreamButtonStyle.secondary,
+              type: StreamButtonType.outline,
+              icon: Icon(context.streamIcons.xmark),
+              onPressed: onClose,
+            ),
+          ),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}

--- a/dogfooding/lib/widgets/side_panel/call_side_panel.dart
+++ b/dogfooding/lib/widgets/side_panel/call_side_panel.dart
@@ -25,7 +25,7 @@ class CallSidePanelSurface extends StatelessWidget {
     required this.title,
     required this.onClose,
     required this.child,
-    this.showLeadingDivider = true,
+    this.docked = true,
   });
 
   /// The panel's heading, centred in the header.
@@ -34,28 +34,28 @@ class CallSidePanelSurface extends StatelessWidget {
   /// Called when the header's close button is pressed.
   final VoidCallback onClose;
 
-  /// Whether to draw the line between the panel and the video grid beside it.
+  /// Whether the panel stands beside the video grid rather than over it.
   ///
-  /// False for a panel covering the whole screen, which has nothing to divide
-  /// itself from.
-  final bool showLeadingDivider;
+  /// Docked, it reads as a card: rounded, and inset from the grid beside it
+  /// and the window behind it. Covering the whole screen it fills its space
+  /// square and flush, having no edges to sit inside.
+  final bool docked;
 
   /// The panel's content, filling everything below the header.
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = context.streamColorScheme;
-
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: colorScheme.backgroundElevation1,
-        border: showLeadingDivider
-            ? BorderDirectional(
-                start: BorderSide(color: colorScheme.borderDefault),
-              )
-            : null,
-      ),
+    // Lifted rather than outlined. Every light-theme elevation is the same
+    // white as the call behind it, so a docked card needs its shadow to read
+    // as separate at all; in the dark theme the fill already carries that and
+    // the shadow is barely there.
+    final surface = Material(
+      color: context.streamColorScheme.backgroundElevation1,
+      elevation: docked ? context.streamElevation.level2 : 0,
+      borderRadius: docked ? BorderRadius.all(context.streamRadius.xl) : null,
+      // The content scrolls, so clip it to the corners it is drawn inside.
+      clipBehavior: docked ? Clip.antiAlias : Clip.none,
       child: Column(
         children: [
           StreamSheetHeader(
@@ -73,6 +73,15 @@ class CallSidePanelSurface extends StatelessWidget {
           Expanded(child: child),
         ],
       ),
+    );
+
+    if (!docked) return surface;
+
+    // Inset from the grid and the window, but full height: the panel's top and
+    // bottom line up with the video beside it.
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: context.streamSpacing.sm),
+      child: surface,
     );
   }
 }

--- a/dogfooding/lib/widgets/side_panel/call_side_panel_layout.dart
+++ b/dogfooding/lib/widgets/side_panel/call_side_panel_layout.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+/// Lays a side panel out against the call's video grid.
+///
+/// Two shapes, chosen by [fullScreen]:
+///
+///  * Docked — the panel takes [width] from the trailing edge and [child]
+///    shrinks to fill what is left, so the grid re-tiles beside it.
+///  * Full screen — the panel covers [child] entirely, sliding in over it.
+///
+/// Both are driven by [animation], which runs 0 (closed) to 1 (open). The
+/// widget itself holds no state: the call screen owns the controller, so the
+/// same animation can also collapse the app bar.
+class CallSidePanelLayout extends StatelessWidget {
+  /// Creates a layout showing [panel] against [child].
+  const CallSidePanelLayout({
+    super.key,
+    required this.animation,
+    required this.panel,
+    required this.fullScreen,
+    required this.child,
+    this.width = 360,
+    this.coveredTopExtent = 0,
+  });
+
+  /// Drives the panel's entrance and exit: 0 is closed, 1 is fully open.
+  final Animation<double> animation;
+
+  /// The panel to show, or null when there is nothing open or closing.
+  final Widget? panel;
+
+  /// Whether the panel covers [child] instead of standing beside it.
+  final bool fullScreen;
+
+  /// The width a docked panel takes from [child].
+  final double width;
+
+  /// Height to re-add above [child] to replace chrome the panel has covered.
+  ///
+  /// A full-screen panel takes over the app bar's row as well, and without
+  /// this the grid would jump up by that much — and re-tile — the moment a
+  /// panel opened.
+  final double coveredTopExtent;
+
+  /// The call content the panel is shown against.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final panel = this.panel;
+
+    if (!fullScreen) {
+      return Row(
+        // Stretch, so the panel fills the available height rather than
+        // settling at its intrinsic one.
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(child: child),
+          if (panel != null)
+            SizeTransition(
+              sizeFactor: animation,
+              axis: Axis.horizontal,
+              // Start-aligned, so the panel's leading edge travels with the
+              // growing box and the content appears to slide in from the
+              // window's edge rather than being wiped into place. End-aligned
+              // would hold it still and merely uncover it.
+              alignment: AlignmentDirectional.topStart,
+              // A fixed width inside the transition: the panel is laid out at
+              // its final width throughout and only clipped, so a message
+              // list or a chart never reflows mid-animation.
+              child: SizedBox(width: width, child: panel),
+            ),
+        ],
+      );
+    }
+
+    return Stack(
+      children: [
+        Padding(
+          padding: EdgeInsets.only(top: coveredTopExtent),
+          child: child,
+        ),
+        if (panel != null)
+          Positioned.fill(
+            child: SlideTransition(
+              position: animation.drive(
+                Tween(begin: const Offset(1, 0), end: Offset.zero),
+              ),
+              child: panel,
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/dogfooding/lib/widgets/side_panel/call_side_panel_layout.dart
+++ b/dogfooding/lib/widgets/side_panel/call_side_panel_layout.dart
@@ -9,8 +9,8 @@ import 'package:flutter/material.dart';
 ///  * Full screen — the panel covers [child] entirely, sliding in over it.
 ///
 /// Both are driven by [animation], which runs 0 (closed) to 1 (open). The
-/// widget itself holds no state: the call screen owns the controller, so the
-/// same animation can also collapse the app bar.
+/// widget itself holds no state — the caller owns the controller, and so also
+/// owns when the panel is mounted and unmounted.
 class CallSidePanelLayout extends StatelessWidget {
   /// Creates a layout showing [panel] against [child].
   const CallSidePanelLayout({
@@ -33,13 +33,18 @@ class CallSidePanelLayout extends StatelessWidget {
   final bool fullScreen;
 
   /// The width a docked panel takes from [child].
+  ///
+  /// Ignored when [fullScreen], where the panel takes everything.
   final double width;
 
   /// Height to re-add above [child] to replace chrome the panel has covered.
   ///
-  /// A full-screen panel takes over the app bar's row as well, and without
-  /// this the grid would jump up by that much — and re-tile — the moment a
-  /// panel opened.
+  /// A caller that hides its own chrome to make room for a full-screen panel
+  /// hands back what it gave up, so [child] neither moves nor re-lays-out the
+  /// moment a panel opens.
+  ///
+  /// Ignored unless [fullScreen], and unless there is a [panel] to make room
+  /// for.
   final double coveredTopExtent;
 
   /// The call content the panel is shown against.
@@ -61,9 +66,7 @@ class CallSidePanelLayout extends StatelessWidget {
               sizeFactor: animation,
               axis: Axis.horizontal,
               // Start-aligned, so the panel's leading edge travels with the
-              // growing box and the content appears to slide in from the
-              // window's edge rather than being wiped into place. End-aligned
-              // would hold it still and merely uncover it.
+              // growing box and the content slides in from the window's edge.
               alignment: AlignmentDirectional.topStart,
               // A fixed width inside the transition: the panel is laid out at
               // its final width throughout and only clipped, so a message
@@ -77,7 +80,7 @@ class CallSidePanelLayout extends StatelessWidget {
     return Stack(
       children: [
         Padding(
-          padding: EdgeInsets.only(top: coveredTopExtent),
+          padding: EdgeInsets.only(top: panel != null ? coveredTopExtent : 0),
           child: child,
         ),
         if (panel != null)

--- a/dogfooding/lib/widgets/side_panel/chat_panel_body.dart
+++ b/dogfooding/lib/widgets/side_panel/chat_panel_body.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+/// The call's chat, as the body of a side panel.
+class ChatPanelBody extends StatelessWidget {
+  /// Creates a chat body for [channel].
+  const ChatPanelBody({super.key, required this.channel});
+
+  /// The channel to show the messages of.
+  final Channel channel;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamChannel(
+      channel: channel,
+      child: Column(
+        children: <Widget>[
+          const Expanded(child: StreamMessageListView()),
+          StreamMessageComposer(),
+        ],
+      ),
+    );
+  }
+}

--- a/dogfooding/test/call_side_panel_layout_test.dart
+++ b/dogfooding/test/call_side_panel_layout_test.dart
@@ -72,10 +72,32 @@ void main() {
 
       await tester.pumpWidget(wrap(animation: controller, fullScreen: false));
 
-      // Half the width is given up by the grid...
+      // Half the panel's width is given up by the grid...
       expect(tester.getSize(find.byKey(gridKey)).width, bodySize.width - 180);
       // ...but the panel itself never reflows, it is only clipped.
       expect(tester.getSize(find.byKey(panelKey)).width, 360);
+      // Its leading edge travels with the growing box, so the content slides
+      // in rather than being uncovered in place.
+      expect(
+        tester.getRect(find.byKey(panelKey)).left,
+        body(tester).right - 180,
+      );
+    });
+
+    testWidgets('the covered extent is ignored beside the grid', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(
+          animation: kAlwaysCompleteAnimation,
+          fullScreen: false,
+          coveredTopExtent: 56,
+        ),
+      );
+
+      // Nothing is covered when the panel is docked, so the grid keeps its
+      // full height.
+      expect(tester.getSize(find.byKey(gridKey)).height, bodySize.height);
     });
 
     testWidgets('no panel means no divided width', (tester) async {
@@ -126,6 +148,23 @@ void main() {
       expect(grid.top - body(tester).top, 56);
       // The grid keeps its full width — nothing is docked beside it.
       expect(grid.width, bodySize.width);
+    });
+
+    testWidgets('no panel means the covered chrome is not given back', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(
+          animation: kAlwaysDismissedAnimation,
+          fullScreen: true,
+          withPanel: false,
+          coveredTopExtent: 56,
+        ),
+      );
+
+      // There is no panel covering the chrome, so padding the grid down would
+      // leave a gap under a bar that is still on screen.
+      expect(tester.getRect(find.byKey(gridKey)), body(tester));
     });
   });
 }

--- a/dogfooding/test/call_side_panel_layout_test.dart
+++ b/dogfooding/test/call_side_panel_layout_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dogfooding/widgets/side_panel/call_side_panel_layout.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Smaller than the 800x600 test surface, so the body is never clamped.
+  const bodySize = Size(700, 500);
+
+  const gridKey = ValueKey('grid');
+  const panelKey = ValueKey('panel');
+
+  /// A stand-in that fills whatever it is given, so the assertions below
+  /// measure the layout rather than an intrinsic size.
+  Widget filler(Key key) => SizedBox.expand(
+    key: key,
+    child: const ColoredBox(color: Color(0xFF000000)),
+  );
+
+  Widget wrap({
+    required Animation<double> animation,
+    required bool fullScreen,
+    bool withPanel = true,
+    double coveredTopExtent = 0,
+  }) {
+    return MaterialApp(
+      home: Center(
+        child: SizedBox.fromSize(
+          size: bodySize,
+          child: CallSidePanelLayout(
+            animation: animation,
+            fullScreen: fullScreen,
+            coveredTopExtent: coveredTopExtent,
+            panel: withPanel ? filler(panelKey) : null,
+            child: filler(gridKey),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Rect body(WidgetTester tester) =>
+      tester.getRect(find.byType(CallSidePanelLayout));
+
+  group('docked', () {
+    testWidgets('an open panel takes its width from the grid', (tester) async {
+      await tester.pumpWidget(
+        wrap(animation: kAlwaysCompleteAnimation, fullScreen: false),
+      );
+
+      expect(tester.getSize(find.byKey(gridKey)).width, bodySize.width - 360);
+      expect(tester.getSize(find.byKey(panelKey)).width, 360);
+      // Stretched, not settled at an intrinsic height.
+      expect(tester.getSize(find.byKey(panelKey)).height, bodySize.height);
+    });
+
+    testWidgets('a closed panel leaves the grid its full width', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(animation: kAlwaysDismissedAnimation, fullScreen: false),
+      );
+
+      expect(tester.getSize(find.byKey(gridKey)).width, bodySize.width);
+    });
+
+    testWidgets('the panel keeps its full width while clipped', (tester) async {
+      final controller = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 250),
+      )..value = 0.5;
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(wrap(animation: controller, fullScreen: false));
+
+      // Half the width is given up by the grid...
+      expect(tester.getSize(find.byKey(gridKey)).width, bodySize.width - 180);
+      // ...but the panel itself never reflows, it is only clipped.
+      expect(tester.getSize(find.byKey(panelKey)).width, 360);
+    });
+
+    testWidgets('no panel means no divided width', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          animation: kAlwaysCompleteAnimation,
+          fullScreen: false,
+          withPanel: false,
+        ),
+      );
+
+      expect(tester.getSize(find.byKey(gridKey)).width, bodySize.width);
+      expect(find.byKey(panelKey), findsNothing);
+    });
+  });
+
+  group('full screen', () {
+    testWidgets('an open panel covers the whole body', (tester) async {
+      await tester.pumpWidget(
+        wrap(animation: kAlwaysCompleteAnimation, fullScreen: true),
+      );
+
+      expect(tester.getRect(find.byKey(panelKey)), body(tester));
+    });
+
+    testWidgets('a closed panel waits off the trailing edge', (tester) async {
+      await tester.pumpWidget(
+        wrap(animation: kAlwaysDismissedAnimation, fullScreen: true),
+      );
+
+      expect(tester.getRect(find.byKey(panelKey)).left, body(tester).right);
+    });
+
+    testWidgets('the grid keeps the height the covered chrome gave up', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(
+          animation: kAlwaysCompleteAnimation,
+          fullScreen: true,
+          coveredTopExtent: 56,
+        ),
+      );
+
+      final grid = tester.getRect(find.byKey(gridKey));
+
+      expect(grid.height, bodySize.height - 56);
+      expect(grid.top - body(tester).top, 56);
+      // The grid keeps its full width — nothing is docked beside it.
+      expect(grid.width, bodySize.width);
+    });
+  });
+}

--- a/dogfooding/test/call_side_panel_layout_test.dart
+++ b/dogfooding/test/call_side_panel_layout_test.dart
@@ -167,4 +167,59 @@ void main() {
       expect(tester.getRect(find.byKey(gridKey)), body(tester));
     });
   });
+
+  testWidgets('a panel behind a global key survives crossing the breakpoint', (
+    tester,
+  ) async {
+    // The two layouts hang the panel in different places — a Row in one, a
+    // Stack in the other — so without the key the chat would remount and lose
+    // its scroll offset when the window crossed the breakpoint.
+    _ScrollProbeState.mounts = 0;
+    final key = GlobalKey<_ScrollProbeState>();
+
+    Widget at({required bool fullScreen}) => MaterialApp(
+      home: CallSidePanelLayout(
+        animation: kAlwaysCompleteAnimation,
+        fullScreen: fullScreen,
+        panel: _ScrollProbe(key: key),
+        child: filler(gridKey),
+      ),
+    );
+
+    await tester.pumpWidget(at(fullScreen: false));
+    expect(_ScrollProbeState.mounts, 1);
+    key.currentState!.offset = 120;
+
+    await tester.pumpWidget(at(fullScreen: true));
+    expect(_ScrollProbeState.mounts, 1, reason: 'the panel was remounted');
+    expect(key.currentState!.offset, 120, reason: 'panel state was lost');
+
+    await tester.pumpWidget(at(fullScreen: false));
+    expect(_ScrollProbeState.mounts, 1, reason: 'the panel was remounted back');
+    expect(key.currentState!.offset, 120);
+  });
+}
+
+/// Stands in for the chat, whose scroll offset is what the key protects.
+class _ScrollProbe extends StatefulWidget {
+  const _ScrollProbe({super.key});
+
+  @override
+  State<_ScrollProbe> createState() => _ScrollProbeState();
+}
+
+class _ScrollProbeState extends State<_ScrollProbe> {
+  /// How many times any probe has been built from scratch.
+  static int mounts = 0;
+
+  double offset = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    mounts++;
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.expand();
 }


### PR DESCRIPTION
The three in-call surfaces opened three different ways: participants and stats as full-screen `go_router` pushes, chat as a modal bottom sheet sized to 60% of the window. On a desktop window you lost sight of the call to read the stats. They are now one side panel.

- **Wide (≥768px)** — a card docked on the trailing edge, inset from the grid and the window, its top and bottom in line with the video. The grid shrinks and re-tiles beside it.
- **Narrow (<768px)** — full screen, covering the grid *and* the app bar, with the control bar still visible.

One panel at a time, its control shows a selected state, tapping it again closes it. Back closes the panel rather than leaving the call, and closes the more menu too. Opening the more menu closes the panel and vice versa. A reconnect leaves the panel open: the SDK stops building the slot it lives in while the call is not connected, so anything making room for the panel asks whether it is actually painted first, rather than trusting that one was asked for.

Dogfooding only — nothing under `packages/` changes, so no changelog entry.

## How it works

`StreamCallContent`'s `callParticipantsWidgetBuilder` slot *is* the Scaffold body, i.e. exactly the region between the app bar and the control bar, so the docked layout is a `Row` there and needs no SDK change. The narrow case collapses the app bar to a zero-height `PreferredSize` (holding the status-bar strip open), which frees the whole body while `bottomNavigationBar` keeps the controls.

One `Animation` drives a horizontal `SizeTransition`: the box measures `t × 360`, so `Expanded` hands the grid the remainder — shrink and slide stay in sync by construction, and the panel content is laid out at its final width throughout and only clipped, so charts and message lists never reflow mid-animation.

Three things to keep apart. `_openPanel` is what the user asked for and drives the controls' selected state. `_mountedPanel` outlives it by the length of the exit animation, and is what back dismisses — painted or not, since falling through to leaving the call is the one outcome back should never reach by accident. `_panelOnScreen` adds the call's status, and is what the collapsed app bar and the height handed back to the grid ask before making room.

The docked card is lifted rather than outlined. In the light theme `backgroundApp` and every `backgroundElevation` are the same white, so a `level2` elevation is the only thing separating it there; against the dark theme's black the fill carries that and the shadow is imperceptible.

`CallSidePanelLayout` is deliberately `Call`-free so it can be unit-tested without mocking; 10 tests cover both layouts, the mid-animation geometry, and the `GlobalKey` that carries panel state across the breakpoint.

## Also in here

- Three pre-existing defects the panel surfaced: "Add member" wrapped at panel width (footer buttons now stack), and both the stats screen and the participants list hardcoded `Colors.white` — 15 places and 2 — which was invisible in a light theme (now `colorScheme.textPrimary`).
- The stats panel's four sections — latency, thermal, battery, performance — each spelled out the same five nodes, and are one `_StatsSection` now. `StatIndicator` took a 26-element `okRange` list, rebuilt every frame for every item and searched with `contains()`; it takes two bounds. `CallStatsPanelBody` is `const`, and shows no avatar instead of crashing on `currentUser!`. Two always-true `snapshot.hasData` guards are gone.
- `StreamParticipantsButton` → `CallFeatureButton`, because only the latter has a selected state to show that the panel is up. This also drops an unrelated gate that disabled the participants button until the *chat* channel connected.
- `CallParticipantsRoute` and `CallStatsRoute` are removed; their screens became panel bodies.

## Verified by running it

Docked on macOS at 800px (all three panels, grid shrink and re-tile, selected states, panel/more-menu exclusion, both themes) and full screen on an iPhone simulator (panel covers the app bar, control bar stays, header clears the notch, keyboard lifts the composer with no manual `viewInsets` handling — `StreamCallContent` nests its own Scaffold, which resizes by default).

Crossing 768px with a panel open is covered by a test rather than by hand: the panel's `State` survives the crossing in both directions, since the move happens within a single build.

## Follow-ups, not in scope

`StreamCallContent` has no side-panel slot and exposes neither `extendBodyBehindAppBar` nor `resizeToAvoidBottomInset`; the zero-height app bar is a workaround a `callSidePanelWidgetBuilder` slot would remove. Worth doing if this pattern proves out — which is what dogfooding is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| Before | Small | Large | 
| --- | --- | --- |
| <img width="1423" height="1055" alt="image" src="https://github.com/user-attachments/assets/bbd6c3f4-0546-4bfd-9928-0f0df0193328" /> | <img width="702" height="1161" alt="image" src="https://github.com/user-attachments/assets/7cd58f9e-a2aa-42d5-b4f2-535c3ef6251e" /> | <img width="1833" height="1161" alt="image" src="https://github.com/user-attachments/assets/574144ae-e6f2-45dc-925a-f2d10359802f" /> |
| <img width="1423" height="1055" alt="image" src="https://github.com/user-attachments/assets/b587af23-9fa4-43ec-b14c-84e74113603c" /> | <img width="702" height="1161" alt="image" src="https://github.com/user-attachments/assets/1c559b98-1e73-43ae-b48f-0db3ab8346ad" /> | <img width="1833" height="1161" alt="image" src="https://github.com/user-attachments/assets/b739c48d-4809-456e-9930-d64950c70a45" /> |
| <img width="1423" height="1055" alt="image" src="https://github.com/user-attachments/assets/d5753c10-ec60-496a-bd1c-d68d5deaf089" /> | <img width="702" height="1161" alt="image" src="https://github.com/user-attachments/assets/c7fbc2ed-368f-4056-9394-d237473c5f1e" /> | <img width="1833" height="1161" alt="image" src="https://github.com/user-attachments/assets/705a4627-5037-42ca-ab02-13c1c950da17" /> |

