### PR TITLE
fix(samples): match the share call accordion to design

### DIFF
--- a/dogfooding/lib/app/app_content.dart
+++ b/dogfooding/lib/app/app_content.dart
@@ -208,7 +208,9 @@ class _StreamDogFoodingAppContentState
       builder: (context, child) {
         return StreamComponentFactory(
           builders: _componentBuilders,
-          child: child!,
+          // Above the router, so a snackbar shown from any route has a
+          // messenger to reach and outlives the screen that showed it.
+          child: StreamSnackbarScope(child: child!),
         );
       },
     );

--- a/dogfooding/lib/widgets/share_call_card.dart
+++ b/dogfooding/lib/widgets/share_call_card.dart
@@ -29,48 +29,84 @@ class _ShareCallWelcomeCardState extends State<ShareCallWelcomeCard> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = StreamVideoTheme.of(context);
-    final colorScheme = StreamTheme.of(context).colorScheme;
+    final colorScheme = context.streamColorScheme;
+    final spacing = context.streamSpacing;
+    final borderRadius = BorderRadius.all(context.streamRadius.lg);
+
+    // The design puts the card's edges on the participant label's. The label
+    // sits spacing.xs inside the tile, and the tile sits the grid's own
+    // padding inside the call, so the card clears both.
+    final gridPadding =
+        StreamCallParticipantsGridTheme.of(context).padding?.resolve(
+          Directionality.maybeOf(context),
+        ) ??
+        EdgeInsets.all(spacing.xs);
 
     return Align(
       alignment: Alignment.bottomCenter,
       child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Container(
-          decoration: BoxDecoration(
+        padding: gridPadding + EdgeInsets.all(spacing.xs),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            // A phone gives the card the full width between those insets; a
+            // wider window keeps it at the width the web design draws.
+            maxWidth: context.streamScreenSize.isSmall ? double.infinity : 360,
+          ),
+          child: Material(
+            // Elevation rather than a painted shadow, so the card lifts off the
+            // call the same way every other raised Stream surface does.
+            elevation: context.streamElevation.level3,
             color: colorScheme.backgroundElevation1,
-            borderRadius: BorderRadius.circular(16),
-          ),
-          foregroundDecoration: BoxDecoration(
-            border: Border.all(color: colorScheme.borderDefault),
-            borderRadius: BorderRadius.circular(16),
-          ),
-          clipBehavior: .antiAlias,
-          constraints: const BoxConstraints(maxWidth: 600),
-          child: ExpansionTile(
-            title: Padding(
-              padding: const EdgeInsets.all(8),
-              child: Text(
-                'Your meeting is live!',
-                style: theme.textTheme.title3,
+            shape: RoundedRectangleBorder(borderRadius: borderRadius),
+            clipBehavior: Clip.antiAlias,
+            child: DecoratedBox(
+              // Drawn over the children, which the Material clips to its own
+              // shape — an outward-aligned border would be eaten otherwise.
+              position: DecorationPosition.foreground,
+              decoration: BoxDecoration(
+                borderRadius: borderRadius,
+                border: Border.all(color: colorScheme.borderDefault),
+              ),
+              child: ExpansionTile(
+                title: Text(
+                  'Your Meeting is Live!',
+                  style: context.streamTextTheme.headingSm.copyWith(
+                    color: colorScheme.textPrimary,
+                  ),
+                ),
+                shape: const Border(
+                  top: BorderSide(color: Colors.transparent),
+                  bottom: BorderSide(color: Colors.transparent),
+                ),
+                trailing: Icon(
+                  _isExpanded
+                      ? context.streamIcons.chevronUp
+                      : context.streamIcons.chevronDown,
+                  size: spacing.lg,
+                  color: colorScheme.textPrimary,
+                ),
+                // minTileHeight sizes the row inside tilePadding, so the
+                // 16 above and below the title comes from centring it in 52.
+                tilePadding: EdgeInsets.symmetric(horizontal: spacing.md),
+                minTileHeight: 52,
+                childrenPadding: EdgeInsets.fromLTRB(
+                  spacing.md,
+                  0,
+                  spacing.md,
+                  spacing.md,
+                ),
+                // The content sizes itself to the card, not to its widest row.
+                expandedCrossAxisAlignment: CrossAxisAlignment.stretch,
+                onExpansionChanged: (value) =>
+                    setState(() => _isExpanded = value),
+                children: [
+                  _ShareCardContent(
+                    call: widget.call,
+                    encryptionKey: widget.encryptionKey,
+                  ),
+                ],
               ),
             ),
-            shape: const Border(
-              top: BorderSide(color: Colors.transparent),
-              bottom: BorderSide(color: Colors.transparent),
-            ),
-            trailing: Icon(
-              _isExpanded ? Icons.expand_more : Icons.expand_less,
-              color: colorScheme.textPrimary,
-            ),
-            childrenPadding: const EdgeInsets.all(16),
-            onExpansionChanged: (value) => setState(() => _isExpanded = value),
-            children: [
-              _ShareCardContent(
-                call: widget.call,
-                encryptionKey: widget.encryptionKey,
-              ),
-            ],
           ),
         ),
       ),
@@ -96,7 +132,7 @@ class ShareCallParticipantsCard extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(24),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Text('Share the link', style: theme.textTheme.title1),
           const SizedBox(height: 16),
@@ -115,8 +151,8 @@ class _ShareCardContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = StreamVideoTheme.of(context);
-    final colorScheme = StreamTheme.of(context).colorScheme;
+    final colorScheme = context.streamColorScheme;
+    final spacing = context.streamSpacing;
     final callId = call.id;
 
     // An encrypted call cannot be joined without the key, so an invite to one
@@ -129,29 +165,33 @@ class _ShareCardContent extends StatelessWidget {
     );
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         if (callUrl != null) ...[
           StreamButton(
-            iconLeft: const Icon(Icons.person_add_alt_1),
+            iconLeft: Icon(context.streamIcons.userAddFill),
+            // The default padded tap target grows each 40px pill to 48 and so
+            // doubles the gap the design puts between the two; a full-width
+            // button keeps a large tap area without it.
+            themeStyle: const StreamButtonThemeStyle(
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
             onPressed: () async {
               await SharePlus.instance.share(
                 ShareParams(uri: Uri.parse(callUrl)),
               );
             },
-            child: const Text('Share link with others'),
+            child: const Text('Add Others'),
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: spacing.xs),
         ],
-        Text(
-          'Share this call ID with others you want in the meeting.',
-          style: theme.textTheme.body,
-        ),
-        const SizedBox(height: 8),
         StreamButton(
           style: StreamButtonStyle.secondary,
           type: StreamButtonType.outline,
-          iconLeft: const Icon(Icons.copy_all),
+          iconLeft: Icon(context.streamIcons.copyFill),
+          themeStyle: const StreamButtonThemeStyle(
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
           onPressed: () async {
             await Clipboard.setData(ClipboardData(text: callId));
 
@@ -159,52 +199,50 @@ class _ShareCardContent extends StatelessWidget {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Row(
+                    spacing: spacing.xs,
                     children: [
-                      Icon(Icons.check, color: colorScheme.accentSuccess),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Call ID copied to clipboard',
-                        style: theme.textTheme.body.copyWith(
-                          color: theme.colorTheme.textHighEmphasis,
-                        ),
+                      Icon(
+                        context.streamIcons.checkmark,
+                        color: colorScheme.accentSuccess,
                       ),
+                      // Unstyled, so the text keeps the light-on-dark colour
+                      // the SnackBar theme gives its content.
+                      const Text('Call ID copied to clipboard'),
                     ],
                   ),
                 ),
               );
             }
           },
-          child: Text('Call id: $callId'),
+          child: const Text('Copy Call ID'),
         ),
         if (callUrl != null) ...[
-          Padding(
-            padding: const EdgeInsets.only(top: 16, bottom: 8),
-            child: Text(
-              'Or scan the QR code to join from another device',
-              style: theme.textTheme.body,
-            ),
-          ),
+          SizedBox(height: spacing.md),
           Container(
-            width: double.infinity,
+            height: 160,
             alignment: Alignment.center,
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(16),
-              color: Theme.of(context).scaffoldBackgroundColor,
+              borderRadius: BorderRadius.all(context.streamRadius.lg),
+              color: colorScheme.backgroundSurface,
             ),
-            padding: const EdgeInsets.all(16),
-            child: Container(
+            padding: EdgeInsets.all(spacing.md),
+            child: DecoratedBox(
               decoration: BoxDecoration(
                 color: Colors.white,
-                borderRadius: BorderRadius.circular(16),
+                borderRadius: BorderRadius.all(context.streamRadius.xl),
               ),
-              constraints: const BoxConstraints(maxHeight: 150),
               child: AspectRatio(
                 aspectRatio: 1,
-                child: QrImageView(
-                  data: callUrl,
-                  size: 200,
-                ),
+                child: QrImageView(data: callUrl, size: 200),
               ),
+            ),
+          ),
+          SizedBox(height: spacing.sm),
+          Text(
+            'Scan the QR code to join from another device.',
+            textAlign: TextAlign.center,
+            style: context.streamTextTheme.metadataDefault.copyWith(
+              color: colorScheme.textSecondary,
             ),
           ),
         ],

--- a/dogfooding/lib/widgets/share_call_card.dart
+++ b/dogfooding/lib/widgets/share_call_card.dart
@@ -196,20 +196,10 @@ class _ShareCardContent extends StatelessWidget {
             await Clipboard.setData(ClipboardData(text: callId));
 
             if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Row(
-                    spacing: spacing.xs,
-                    children: [
-                      Icon(
-                        context.streamIcons.checkmark,
-                        color: colorScheme.accentSuccess,
-                      ),
-                      // Unstyled, so the text keeps the light-on-dark colour
-                      // the SnackBar theme gives its content.
-                      const Text('Call ID copied to clipboard'),
-                    ],
-                  ),
+              StreamSnackbarMessenger.of(context).show(
+                StreamSnackbar(
+                  message: const Text('Call ID copied to clipboard'),
+                  variant: StreamSnackbarVariant.success,
                 ),
               );
             }


### PR DESCRIPTION
Brings the "Your Meeting is Live!" card in the sample app in line with [Video / iOS / Share Call Accordion](https://www.figma.com/design/W7pOBtNINkAh14XdCJQKuB/Video-SDK-Design?node-id=375-45607&m=dev) ([mobile frame](https://www.figma.com/design/W7pOBtNINkAh14XdCJQKuB/Video-SDK-Design?node-id=373-45309&m=dev), [web frame](https://www.figma.com/design/W7pOBtNINkAh14XdCJQKuB/Video-SDK-Design?node-id=391-22599&m=dev)).

## Spacing

In the design the card sits **8 inside the participant tile** on every side — the same 8 the participant label pill sits at — so their edges line up. We used a flat `EdgeInsets.all(24)`, so nothing did.

The inset is now derived rather than hardcoded: the grid's own padding, read from `StreamCallParticipantsGridTheme`, plus `spacing.xs`. That matters because the sample app overrides the grid padding to 4, so a fixed 16 would have missed the label by 4.

Measured on device against the design:

| | Design | Measured |
|---|---|---|
| Inset inside the tile | 8 left/right/bottom | 8 |
| Collapsed height | 52 | 52 |
| Buttons | 40 + 8 gap + 40 | 40 + 8 + 40 |
| Buttons → QR panel | 16 | 16 |
| QR panel | 160 | 160 |
| Panel → caption | 12 | 12 |
| Caption → card bottom | 16 | 16 |
| Expanded total | 360 | 360 |

## Contents

- Two full-width buttons, **Add Others** and **Copy Call ID**, 8 apart. They pass `tapTargetSize: shrinkWrap` — the default padded target grows each 40 pill to 48 and would double the designed gap; a full-width button keeps a large tap area without it.
- The QR moves onto a `backgroundSurface` panel with its caption underneath instead of above, and the explanatory sentence and the raw call id in the button label are gone.
- Icons come from `context.streamIcons` (`userAddFill`, `copyFill`, `chevronUp`/`chevronDown`, `checkmark`) rather than Material's.
- The card gets the design's drop shadow, through `Material` at `streamElevation.level3` with the border in a foreground `DecoratedBox`.
- A phone gives the card the full width between the insets; a window in the `medium`/`large` bucket centres it at 360, as the web frame draws it.

The "Call ID copied to clipboard" confirmation moves from a Material `SnackBar` to the design system's `StreamSnackbar`, whose `success` variant already carries the checkmark the old one hand-assembled. A `StreamSnackbarScope` sits above the router in `MaterialApp.router`'s builder so any route can reach a messenger. The old bar also rendered its text black on black, from a hardcoded colour that is now gone.

## Verification

Run on the iPhone 18 Pro and iPad (A16) simulators; widget bounds read out of the running app and cross-checked against the Figma geometry — the table above. Copy verified through `simctl pbpaste`. No golden tests cover this widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| Before | After | 
| --- | --- |
| <img width="1206" height="2622" alt="before-collapsed" src="https://github.com/user-attachments/assets/480fd4df-46ee-4f29-ab30-2fc76819555c" /> | <img width="1206" height="2622" alt="after-collapsed" src="https://github.com/user-attachments/assets/e9199ab5-e50c-47e8-a81b-59e0c31be539" /> |
| <img width="1206" height="2622" alt="before-expanded" src="https://github.com/user-attachments/assets/7d329460-c73b-41b4-a8bd-68da7928869f" /> | <img width="1206" height="2622" alt="after-expanded" src="https://github.com/user-attachments/assets/d095b756-87d0-4125-bd7d-d2a68c2e8d4e" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Snackbars shown from any route now remain available and visible while navigating between screens.

- **Style**
  - Updated the Share Call card with refreshed Stream design styling, spacing, colors, borders, and elevation.
  - Improved responsive sizing and layout for the card and participant content.
  - Refined the QR code section with updated sizing, styling, and centered metadata.

- **Usability**
  - Renamed sharing actions to “Add Others” and “Copy Call ID.”
  - Added clearer success feedback when copying a call ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->