### PR TITLE
fix(llc): mute camera in background on devices without multitasking camera access

### DIFF
--- a/packages/stream_video/CHANGELOG.md
+++ b/packages/stream_video/CHANGELOG.md
@@ -71,6 +71,7 @@
 - A coordinator WebSocket error frame that says nothing about the credentials — a rate limit, or an error about a single request — no longer closes an otherwise healthy connection. Only an expired or rejected token, or a rejected API key, closes the socket now; the rest are logged.
 - Fixed the participant sort reordering tiles that are visible on screen. One participant whose tile was not visible was enough to move the dominant speaker to the first tile.
 - A viewport visibility is now recorded whether or not the session accepts it. A dropped report left a participant recorded as something they were not for the rest of the call, since a viewport only ever reports what changed.
+- On iOS devices without multitasking camera access, the camera track is now muted while the app is in the background, so other participants see camera-off instead of a frozen frame.
 
 ## 1.6.0
 

--- a/packages/stream_video/lib/src/internal/_background_mute_policy.dart
+++ b/packages/stream_video/lib/src/internal/_background_mute_policy.dart
@@ -2,17 +2,21 @@ import 'package:stream_core/stream_core.dart';
 
 /// Whether the camera track should be muted while the app is in the background.
 ///
-/// iOS suspends camera capture in the background unless the device supports
-/// multitasking camera access, which leaves the other participants looking at a
-/// frozen frame. Muting the track shows them camera-off instead.
+/// iOS suspends camera capture in the background unless the capture session
+/// supports multitasking camera access, which leaves the other participants
+/// looking at a frozen frame. Muting the track shows them camera-off instead.
+///
+/// [multitaskingCameraAccessSupported] is `null` when it could not be read, in
+/// which case the track is muted rather than risking the frozen frame.
 bool shouldMuteCameraInBackground({
   required bool isVideoEnabled,
   required bool muteVideoWhenInBackground,
-  required bool multitaskingCameraAccessEnabled,
+  required bool? multitaskingCameraAccessSupported,
   required PlatformType platform,
 }) {
   if (!isVideoEnabled) return false;
   if (muteVideoWhenInBackground) return true;
+  if (platform != PlatformType.ios) return false;
 
-  return platform == PlatformType.ios && !multitaskingCameraAccessEnabled;
+  return multitaskingCameraAccessSupported != true;
 }

--- a/packages/stream_video/lib/src/internal/_background_mute_policy.dart
+++ b/packages/stream_video/lib/src/internal/_background_mute_policy.dart
@@ -1,0 +1,18 @@
+import 'package:stream_core/stream_core.dart';
+
+/// Whether the camera track should be muted while the app is in the background.
+///
+/// iOS suspends camera capture in the background unless the device supports
+/// multitasking camera access, which leaves the other participants looking at a
+/// frozen frame. Muting the track shows them camera-off instead.
+bool shouldMuteCameraInBackground({
+  required bool isVideoEnabled,
+  required bool muteVideoWhenInBackground,
+  required bool multitaskingCameraAccessEnabled,
+  required PlatformType platform,
+}) {
+  if (!isVideoEnabled) return false;
+  if (muteVideoWhenInBackground) return true;
+
+  return platform == PlatformType.ios && !multitaskingCameraAccessEnabled;
+}

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -25,6 +25,7 @@ import 'core/connection_state.dart';
 import 'core/internet_connection_network_state_provider.dart';
 import 'errors/stream_video_exception.dart';
 import 'errors/stream_video_exception_composer.dart';
+import 'internal/_background_mute_policy.dart';
 import 'internal/_instance_holder.dart';
 import 'latency/latency_service.dart';
 import 'latency/latency_settings.dart';
@@ -618,7 +619,13 @@ class StreamVideo extends Disposable {
             final isAudioEnabled =
                 callState.localParticipant?.isAudioEnabled ?? false;
 
-            if (_options.muteVideoWhenInBackground && isVideoEnabled) {
+            if (shouldMuteCameraInBackground(
+              isVideoEnabled: isVideoEnabled,
+              muteVideoWhenInBackground: _options.muteVideoWhenInBackground,
+              multitaskingCameraAccessEnabled:
+                  callState.iOSMultitaskingCameraAccessEnabled,
+              platform: CurrentPlatform.type,
+            )) {
               await activeCall.setCameraEnabled(enabled: false);
               _mutedCameraByStateChange[activeCall.callCid.value] = true;
               _logger.v(() => 'Muted camera track since app was paused.');
@@ -1611,6 +1618,10 @@ class StreamVideoOptions {
 
   final AudioProcessor? audioProcessor;
 
+  /// Mutes the camera track while the app is in the background.
+  ///
+  /// On iOS devices without multitasking camera access the camera track is
+  /// muted in the background regardless of this option.
   final bool muteVideoWhenInBackground;
   final bool muteAudioWhenInBackground;
   final bool autoConnect;

--- a/packages/stream_video/lib/src/stream_video.dart
+++ b/packages/stream_video/lib/src/stream_video.dart
@@ -594,6 +594,19 @@ class StreamVideo extends Disposable {
     );
   }
 
+  /// Whether the capture session in use supports camera access while
+  /// multitasking, or `null` when it could not be read.
+  Future<bool?> _multitaskingCameraAccessSupported() async {
+    if (!CurrentPlatform.isIos) return null;
+
+    try {
+      return await rtc.Helper.isIOSMultitaskingCameraAccessSupported();
+    } catch (e) {
+      _logger.w(() => '[multitaskingCameraAccessSupported] failed: $e');
+      return null;
+    }
+  }
+
   Future<void> _onAppState(LifecycleState state) async {
     _logger.d(() => '[onAppState] state: $state');
     try {
@@ -612,6 +625,9 @@ class StreamVideo extends Disposable {
           _subscriptions.cancel(_idEvents);
           await _client.closeConnection();
         } else if (activeCalls.isNotEmpty) {
+          final multitaskingCameraAccessSupported =
+              await _multitaskingCameraAccessSupported();
+
           for (final activeCall in activeCalls) {
             final callState = activeCall.state.value;
             final isVideoEnabled =
@@ -622,8 +638,8 @@ class StreamVideo extends Disposable {
             if (shouldMuteCameraInBackground(
               isVideoEnabled: isVideoEnabled,
               muteVideoWhenInBackground: _options.muteVideoWhenInBackground,
-              multitaskingCameraAccessEnabled:
-                  callState.iOSMultitaskingCameraAccessEnabled,
+              multitaskingCameraAccessSupported:
+                  multitaskingCameraAccessSupported,
               platform: CurrentPlatform.type,
             )) {
               await activeCall.setCameraEnabled(enabled: false);

--- a/packages/stream_video/test/src/internal/background_mute_policy_test.dart
+++ b/packages/stream_video/test/src/internal/background_mute_policy_test.dart
@@ -7,13 +7,13 @@ void main() {
     bool shouldMute({
       bool isVideoEnabled = true,
       bool muteVideoWhenInBackground = false,
-      bool multitaskingCameraAccessEnabled = false,
+      bool? multitaskingCameraAccessSupported = false,
       PlatformType platform = PlatformType.ios,
     }) {
       return shouldMuteCameraInBackground(
         isVideoEnabled: isVideoEnabled,
         muteVideoWhenInBackground: muteVideoWhenInBackground,
-        multitaskingCameraAccessEnabled: multitaskingCameraAccessEnabled,
+        multitaskingCameraAccessSupported: multitaskingCameraAccessSupported,
         platform: platform,
       );
     }
@@ -27,7 +27,11 @@ void main() {
     });
 
     test('does not mute on iOS with multitasking camera access', () {
-      expect(shouldMute(multitaskingCameraAccessEnabled: true), isFalse);
+      expect(shouldMute(multitaskingCameraAccessSupported: true), isFalse);
+    });
+
+    test('mutes on iOS when support could not be read', () {
+      expect(shouldMute(multitaskingCameraAccessSupported: null), isTrue);
     });
 
     test('does not mute on other platforms', () {
@@ -57,7 +61,7 @@ void main() {
       expect(
         shouldMute(
           muteVideoWhenInBackground: true,
-          multitaskingCameraAccessEnabled: true,
+          multitaskingCameraAccessSupported: true,
         ),
         isTrue,
       );

--- a/packages/stream_video/test/src/internal/background_mute_policy_test.dart
+++ b/packages/stream_video/test/src/internal/background_mute_policy_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core/stream_core.dart';
+import 'package:stream_video/src/internal/_background_mute_policy.dart';
+
+void main() {
+  group('shouldMuteCameraInBackground', () {
+    bool shouldMute({
+      bool isVideoEnabled = true,
+      bool muteVideoWhenInBackground = false,
+      bool multitaskingCameraAccessEnabled = false,
+      PlatformType platform = PlatformType.ios,
+    }) {
+      return shouldMuteCameraInBackground(
+        isVideoEnabled: isVideoEnabled,
+        muteVideoWhenInBackground: muteVideoWhenInBackground,
+        multitaskingCameraAccessEnabled: multitaskingCameraAccessEnabled,
+        platform: platform,
+      );
+    }
+
+    test('does not mute a camera that is already off', () {
+      expect(shouldMute(isVideoEnabled: false), isFalse);
+    });
+
+    test('mutes on iOS without multitasking camera access', () {
+      expect(shouldMute(), isTrue);
+    });
+
+    test('does not mute on iOS with multitasking camera access', () {
+      expect(shouldMute(multitaskingCameraAccessEnabled: true), isFalse);
+    });
+
+    test('does not mute on other platforms', () {
+      for (final platform in [
+        PlatformType.android,
+        PlatformType.web,
+        PlatformType.macOS,
+        PlatformType.windows,
+        PlatformType.linux,
+      ]) {
+        expect(
+          shouldMute(platform: platform),
+          isFalse,
+          reason: 'should not mute on $platform',
+        );
+      }
+    });
+
+    test('mutes on any platform when the option is set', () {
+      expect(
+        shouldMute(
+          muteVideoWhenInBackground: true,
+          platform: PlatformType.android,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldMute(
+          muteVideoWhenInBackground: true,
+          multitaskingCameraAccessEnabled: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('the option does not mute a camera that is off', () {
+      expect(
+        shouldMute(isVideoEnabled: false, muteVideoWhenInBackground: true),
+        isFalse,
+      );
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1989,12 +1989,13 @@ packages:
     source: hosted
     version: "2.1.1"
   stream_webrtc_flutter:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: stream_webrtc_flutter
-      sha256: "6938c87d6054e7ddcd5114641f7173e84f000f14aedfc57651c1115726dcf356"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "3bb87874d59bb9276969daef356f5fefa01639c5"
+      resolved-ref: "3bb87874d59bb9276969daef356f5fefa01639c5"
+      url: "https://github.com/GetStream/webrtc-flutter.git"
+    source: git
     version: "3.2.0"
   string_scanner:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,12 @@ dev_dependencies:
 dependency_overrides:
   cli_util: ^0.5.1
   file_picker: ^12.0.0-beta.5
+  # TODO: drop once a release with the multitasking camera access fix is out.
+  # https://github.com/GetStream/webrtc-flutter/pull/88
+  stream_webrtc_flutter:
+    git:
+      url: https://github.com/GetStream/webrtc-flutter.git
+      ref: 3bb87874d59bb9276969daef356f5fefa01639c5
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git


### PR DESCRIPTION
### 🎯 Goal

On iOS, the OS suspends camera capture as soon as the app goes to the background unless the device supports [multitasking camera access](https://developer.apple.com/documentation/avfoundation/avcapturesession/ismultitaskingcameraaccesssupported) (effectively M1 iPads and later). On every other device — older iPads, and any device on iOS 15 — the outgoing video track stays "on" while no frames are produced, so the other participants are left staring at a frozen frame for as long as the app is backgrounded. This is easy to hit with Picture-in-Picture, where backgrounding the app is the whole point.

The Swift SDK fixed this in [1.15.0](https://github.com/GetStream/stream-video-swift/pull/633) with `ApplicationLifecycleVideoMuteAdapter`: on devices where `isMultitaskingCameraAccessSupported` is `false`, it mutes the video track on background and unmutes on foreground, so remote participants see a clear camera-off state instead of a stuck image. This ports that behaviour to Flutter.

### 🛠 Implementation details

The decision lives in a new pure function, `shouldMuteCameraInBackground` in `packages/stream_video/lib/src/internal/_background_mute_policy.dart`:

```dart
if (!isVideoEnabled) return false;
if (muteVideoWhenInBackground) return true;

if (platform != PlatformType.ios) return false;

return multitaskingCameraAccessSupported != true;
```

`StreamVideo._onAppState` calls it in place of the previous `_options.muteVideoWhenInBackground && isVideoEnabled` check, passing `CurrentPlatform.type` and the device's multitasking camera access support, read once per background transition. The resume path is unchanged — `_mutedCameraByStateChange` already restores the camera and does not care why it was muted.

`muteVideoWhenInBackground` keeps its meaning as the explicit, all-platforms override and now has a doc comment noting that iOS may mute regardless. `internal/` is not exported from the barrel, so no public API is added.

Two deliberate departures from the Swift implementation:

1. Swift toggles only the SFU mute flag and leaves the capture session alone. This reuses `setCameraEnabled(enabled: false)`, which also tears down capture. On iOS that costs nothing extra — the OS has already suspended the session — and it keeps a single resume path rather than two.
2. Swift probes `isMultitaskingCameraAccessSupported` directly, and so does this now — through `Helper.isIOSMultitaskingCameraAccessSupported()`, added in [GetStream/webrtc-flutter#88](https://github.com/GetStream/webrtc-flutter/pull/88). `null` (support could not be read) is treated as "mute", so the frozen frame is never the fallback.

### ⚠️ Depends on a plugin change

This needs [GetStream/webrtc-flutter#88](https://github.com/GetStream/webrtc-flutter/pull/88), pinned here through a `dependency_overrides` entry on commit `3bb8787`. **The override must be dropped once a `stream_webrtc_flutter` release carries the fix.**

That PR also fixes the bug underneath this one: a capture session is created per `getUserMedia` call and starts without multitasking camera access, so toggling the camera off and on lost it — even on an M1 iPad. Without it, this PR would correctly decide not to mute on a capable device that had silently lost the capability, and the frozen frame would come back.

### 🎨 UI Changes

No UI changes in this repo. The visible effect is on the **remote** side: a backgrounded participant on an unsupported device now renders as camera-off (avatar) rather than a frozen frame.

### 🧪 Testing

- 7 new unit tests in `packages/stream_video/test/src/internal/background_mute_policy_test.dart` cover the platform gate, the multitasking-supported case, support that could not be read, the explicit option on every platform, and the camera-already-off cases.
- Full `stream_video` suite: 688 tests passing.
- `flutter build ios --simulator --debug` on `dogfooding` succeeds against the git-sourced plugin, so the override resolves end to end.

On-device behaviour is **not** verified. Reproducing it needs a pre-M1 iPad (or an iOS 15 device) in a call with a second participant watching: background the app and check whether the remote tile freezes or goes to camera-off. The device this was found on cannot currently run debug builds.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

